### PR TITLE
Added save model functionality for shapelets

### DIFF
--- a/tslearn/shapelets.py
+++ b/tslearn/shapelets.py
@@ -187,7 +187,9 @@ def load_model(filename):
     filename: name of the file with trained model.
 
     """
-    return keras.models.load_model(filename)
+    return keras.models.load_model(filename,
+                                   custom_objects={'GlobalMinPooling1D': GlobalMinPooling1D,
+                                                   'LocalSquaredDistanceLayer': LocalSquaredDistanceLayer})
 
 
 class ShapeletModel(BaseEstimator, ClassifierMixin):


### PR DESCRIPTION
Added get_config in LocalSquaredDistanceLayer class and a couple wrappers to keras' save/load_model functionalities.

```python
"""Train shapelet model, save, load and predict."""

import pickle
from tslearn import shapelets

# Create mock model.
shp_clf = shapelets.ShapeletModel({10:5}, max_iter=1)
shp_clf.fit(X_train, y_train)

# Save it using custom method.
shp_clf.save('shapelet_model.h5')
# You probably also want to save/pickle the label_binarizer.
with open('label_binarizer.pkl', 'wb') as f:
    pickle.dump(shp_clf.label_binarizer, f)

# Delete trained model and load it from file.
del shp_clf
new_shp_clf = shapelets.load_model('shapelet_model.h5')

# Predict class probabilities.
X = new_data
y_probs = new_shp_clf.predict(X) 

# Load the label_binarizer to get the predicted label.
with open('label_binarizer.pkl', 'rb', f):
    label_binarizer = pickle.load(f)

y_pred =  label_binarizer.inverse_transform(y_probs)  # predicted labels for input data X
```