### PR TITLE
Use scipy to load arff data

### DIFF
--- a/tslearn/datasets.py
+++ b/tslearn/datasets.py
@@ -230,6 +230,9 @@ class UCR_UEA_datasets(object):
         >>> X_train, y_train, X_test, y_test = UCR_UEA_datasets().load_dataset("CinCECGTorso")
         >>> print(X_train.shape)
         (40, 1639, 1)
+        >>> X_train, y_train, X_test, y_test = UCR_UEA_datasets().load_dataset("PenDigits")
+        >>> print(X_train.shape)
+        (7494, 8, 2)
         >>> X_train, y_train, X_test, y_test = UCR_UEA_datasets().load_dataset("DatasetThatDoesNotExist")
         >>> print(X_train)
         None

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -517,7 +517,7 @@ def load_arff(dataset_path):
 
     # firstly get y_train
     y_ = data[names[-1]]  # data["class"]
-    y = numpy.array(y_).astype("str").reshape(-1, 1)
+    y = numpy.array(y_).astype("str")
 
     # get x_train
     if len(names) == 2:  # len=2 => multi-variate


### PR DESCRIPTION
Hi Romain,

I made an implementation to load the arff file from UEA / UCR dataset with SciPy.

SciPy is not capable to load the arff file for the SpokenArabicDigits, because there's an extra `\n` for each train/test example in the arff file. So for compatibility, I still kept the `remake_files` function to transfer `arff` to `csv`.

Cheers,
Yichang