### PR TITLE
[MRG] Better shape checks at test time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ consistent clustering runs (helps avoid empty cluster situations)
 * Calculate pairwise distance matrix between SAX representations
 * PiecewiseAggregateApproximation can now handle variable lengths
 
+### Fixed
+
+* Estimators that can operate on variable length time series now allow 
+for test time datasets to have a different length from the one that was
+passed at fit time
+
+
 ## [v0.3.0]
 
 ### Changed

--- a/tslearn/neighbors.py
+++ b/tslearn/neighbors.py
@@ -319,7 +319,8 @@ class KNeighborsTimeSeries(KNeighborsTimeSeriesMixin, NearestNeighbors,
                     del metric_params["verbose"]
             check_is_fitted(self, '_ts_fit')
             X = check_array(X, allow_nd=True, force_all_finite=False)
-            X = to_time_series_dataset(X)
+            X = check_dims(X, self._X_fit.shape, extend=True,
+                           check_n_features_only=True)
             if self._ts_metric == "dtw":
                 X_ = cdist_dtw(X, self._ts_fit, n_jobs=self.n_jobs,
                                verbose=self.verbose, **metric_params)
@@ -515,6 +516,8 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
         """
         if self.metric in TSLEARN_VALID_METRICS:
             check_is_fitted(self, '_ts_fit')
+            X = check_dims(X, self._ts_fit.shape, extend=True,
+                           check_n_features_only=True)
             X_ = self._precompute_cross_dist(X)
             pred = super(KNeighborsTimeSeriesClassifier, self).predict(X_)
             self.metric = self._ts_metric
@@ -542,6 +545,8 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
         """
         if self.metric in TSLEARN_VALID_METRICS:
             check_is_fitted(self, '_ts_fit')
+            X = check_dims(X, self._ts_fit.shape, extend=True,
+                           check_n_features_only=True)
             X_ = self._precompute_cross_dist(X)
             pred = super(KNeighborsTimeSeriesClassifier,
                          self).predict_proba(X_)
@@ -694,6 +699,8 @@ class KNeighborsTimeSeriesRegressor(KNeighborsTimeSeriesMixin,
         """
         if self.metric in TSLEARN_VALID_METRICS:
             check_is_fitted(self, '_ts_fit')
+            X = check_dims(X, self._ts_fit.shape, extend=True,
+                           check_n_features_only=True)
             X_ = self._precompute_cross_dist(X)
             pred = super(KNeighborsTimeSeriesRegressor, self).predict(X_)
             self.metric = self._ts_metric

--- a/tslearn/neighbors.py
+++ b/tslearn/neighbors.py
@@ -319,7 +319,7 @@ class KNeighborsTimeSeries(KNeighborsTimeSeriesMixin, NearestNeighbors,
                     del metric_params["verbose"]
             check_is_fitted(self, '_ts_fit')
             X = check_array(X, allow_nd=True, force_all_finite=False)
-            X = check_dims(X, self._X_fit.shape, extend=True,
+            X = check_dims(X, self._ts_fit.shape, extend=True,
                            check_n_features_only=True)
             if self._ts_metric == "dtw":
                 X_ = cdist_dtw(X, self._ts_fit, n_jobs=self.n_jobs,
@@ -516,6 +516,7 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
         """
         if self.metric in TSLEARN_VALID_METRICS:
             check_is_fitted(self, '_ts_fit')
+            X = to_time_series_dataset(X)
             X = check_dims(X, self._ts_fit.shape, extend=True,
                            check_n_features_only=True)
             X_ = self._precompute_cross_dist(X)
@@ -699,6 +700,7 @@ class KNeighborsTimeSeriesRegressor(KNeighborsTimeSeriesMixin,
         """
         if self.metric in TSLEARN_VALID_METRICS:
             check_is_fitted(self, '_ts_fit')
+            X = to_time_series_dataset(X)
             X = check_dims(X, self._ts_fit.shape, extend=True,
                            check_n_features_only=True)
             X_ = self._precompute_cross_dist(X)

--- a/tslearn/neighbors.py
+++ b/tslearn/neighbors.py
@@ -38,6 +38,20 @@ class KNeighborsTimeSeriesMixin(KNeighborsMixin):
 
         return X
 
+    def _get_metric_params(self):
+        if self.metric_params is None:
+            metric_params = {}
+        else:
+            metric_params = self.metric_params.copy()
+        if "gamma_sdtw" in metric_params.keys():
+            metric_params["gamma"] = metric_params["gamma_sdtw"]
+            del metric_params["gamma_sdtw"]
+        if "n_jobs" in metric_params.keys():
+            del metric_params["n_jobs"]
+        if "verbose" in metric_params.keys():
+            del metric_params["verbose"]
+        return metric_params
+
     def _precompute_cross_dist(self, X, other_X=None):
         if other_X is None:
             other_X = self._ts_fit
@@ -45,14 +59,7 @@ class KNeighborsTimeSeriesMixin(KNeighborsMixin):
         self._ts_metric = self.metric
         self.metric = "precomputed"
 
-        if self.metric_params is None:
-            metric_params = {}
-        else:
-            metric_params = self.metric_params.copy()
-            if "n_jobs" in metric_params.keys():
-                del metric_params["n_jobs"]
-            if "verbose" in metric_params.keys():
-                del metric_params["verbose"]
+        metric_params = self._get_metric_params()
 
         X = check_array(X, allow_nd=True, force_all_finite=False)
         X = to_time_series_dataset(X)
@@ -98,14 +105,6 @@ class KNeighborsTimeSeriesMixin(KNeighborsMixin):
         ind : array
             Indices of the nearest points in the population matrix.
         """
-        if self.metric_params is not None:
-            metric_params = self.metric_params.copy()
-            if "n_jobs" in metric_params.keys():
-                del metric_params["n_jobs"]
-            if "verbose" in metric_params.keys():
-                del metric_params["verbose"]
-        else:
-            metric_params = {}
         self_neighbors = False
         if n_neighbors is None:
             n_neighbors = self.n_neighbors
@@ -309,14 +308,7 @@ class KNeighborsTimeSeries(KNeighborsTimeSeriesMixin, NearestNeighbors,
             self._ts_metric = self.metric
             self.metric = "precomputed"
 
-            if self.metric_params is None:
-                metric_params = {}
-            else:
-                metric_params = self.metric_params.copy()
-                if "n_jobs" in metric_params.keys():
-                    del metric_params["n_jobs"]
-                if "verbose" in metric_params.keys():
-                    del metric_params["verbose"]
+            metric_params = self._get_metric_params()
             check_is_fitted(self, '_ts_fit')
             X = check_array(X, allow_nd=True, force_all_finite=False)
             X = check_dims(X, self._ts_fit.shape, extend=True,

--- a/tslearn/neighbors.py
+++ b/tslearn/neighbors.py
@@ -266,7 +266,7 @@ class KNeighborsTimeSeries(KNeighborsTimeSeriesMixin, NearestNeighbors,
                         allow_nd=True,
                         force_all_finite=(self.metric != "precomputed"))
         X = to_time_series_dataset(X)
-        X = check_dims(X, X_fit_dims=None)
+        X = check_dims(X)
         if self.metric == "precomputed" and hasattr(self, '_ts_metric'):
             self._ts_fit = X
             self._d = X.shape[2]
@@ -311,7 +311,7 @@ class KNeighborsTimeSeries(KNeighborsTimeSeriesMixin, NearestNeighbors,
             metric_params = self._get_metric_params()
             check_is_fitted(self, '_ts_fit')
             X = check_array(X, allow_nd=True, force_all_finite=False)
-            X = check_dims(X, self._ts_fit.shape, extend=True,
+            X = check_dims(X, X_fit_dims=self._ts_fit.shape, extend=True,
                            check_n_features_only=True)
             if self._ts_metric == "dtw":
                 X_ = cdist_dtw(X, self._ts_fit, n_jobs=self.n_jobs,
@@ -336,7 +336,7 @@ class KNeighborsTimeSeries(KNeighborsTimeSeriesMixin, NearestNeighbors,
                 X = check_array(X, allow_nd=True)
                 X = to_time_series_dataset(X)
                 X_ = to_sklearn_dataset(X)
-                X_ = check_dims(X_, self._X_fit.shape, extend=False)
+                X_ = check_dims(X_, X_fit_dims=self._X_fit.shape, extend=False)
             return KNeighborsTimeSeriesMixin.kneighbors(
                 self,
                 X=X_,
@@ -471,7 +471,7 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
                         allow_nd=True,
                         force_all_finite=(self.metric != "precomputed"))
         X = to_time_series_dataset(X)
-        X = check_dims(X, X_fit_dims=None)
+        X = check_dims(X)
         if self.metric == "precomputed" and hasattr(self, '_ts_metric'):
             self._ts_fit = X
             if self._ts_metric == 'sax':
@@ -509,7 +509,7 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
         if self.metric in TSLEARN_VALID_METRICS:
             check_is_fitted(self, '_ts_fit')
             X = to_time_series_dataset(X)
-            X = check_dims(X, self._ts_fit.shape, extend=True,
+            X = check_dims(X, X_fit_dims=self._ts_fit.shape, extend=True,
                            check_n_features_only=True)
             X_ = self._precompute_cross_dist(X)
             pred = super(KNeighborsTimeSeriesClassifier, self).predict(X_)
@@ -520,7 +520,7 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
             X = check_array(X, allow_nd=True)
             X = to_time_series_dataset(X)
             X_ = to_sklearn_dataset(X)
-            X_ = check_dims(X_, self._X_fit.shape, extend=False)
+            X_ = check_dims(X_, X_fit_dims=self._X_fit.shape, extend=False)
             return super(KNeighborsTimeSeriesClassifier, self).predict(X_)
 
     def predict_proba(self, X):
@@ -538,7 +538,7 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
         """
         if self.metric in TSLEARN_VALID_METRICS:
             check_is_fitted(self, '_ts_fit')
-            X = check_dims(X, self._ts_fit.shape, extend=True,
+            X = check_dims(X, X_fit_dims=self._ts_fit.shape, extend=True,
                            check_n_features_only=True)
             X_ = self._precompute_cross_dist(X)
             pred = super(KNeighborsTimeSeriesClassifier,
@@ -550,7 +550,7 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
             X = check_array(X, allow_nd=True)
             X = to_time_series_dataset(X)
             X_ = to_sklearn_dataset(X)
-            X_ = check_dims(X_, self._X_fit.shape, extend=False)
+            X_ = check_dims(X_, X_fit_dims=self._X_fit.shape, extend=False)
             return super(KNeighborsTimeSeriesClassifier,
                          self).predict_proba(X_)
 
@@ -664,7 +664,7 @@ class KNeighborsTimeSeriesRegressor(KNeighborsTimeSeriesMixin,
                         allow_nd=True,
                         force_all_finite=(self.metric != "precomputed"))
         X = to_time_series_dataset(X)
-        X = check_dims(X, X_fit_dims=None)
+        X = check_dims(X)
         if self.metric == "precomputed" and hasattr(self, '_ts_metric'):
             self._ts_fit = X
             self._d = X.shape[2]
@@ -693,7 +693,7 @@ class KNeighborsTimeSeriesRegressor(KNeighborsTimeSeriesMixin,
         if self.metric in TSLEARN_VALID_METRICS:
             check_is_fitted(self, '_ts_fit')
             X = to_time_series_dataset(X)
-            X = check_dims(X, self._ts_fit.shape, extend=True,
+            X = check_dims(X, X_fit_dims=self._ts_fit.shape, extend=True,
                            check_n_features_only=True)
             X_ = self._precompute_cross_dist(X)
             pred = super(KNeighborsTimeSeriesRegressor, self).predict(X_)
@@ -704,7 +704,7 @@ class KNeighborsTimeSeriesRegressor(KNeighborsTimeSeriesMixin,
             X = check_array(X, allow_nd=True)
             X = to_time_series_dataset(X)
             X_ = to_sklearn_dataset(X)
-            X_ = check_dims(X_, self._X_fit.shape, extend=False)
+            X_ = check_dims(X_, X_fit_dims=self._X_fit.shape, extend=False)
             return super(KNeighborsTimeSeriesRegressor, self).predict(X_)
 
     def _get_tags(self):

--- a/tslearn/preprocessing.py
+++ b/tslearn/preprocessing.py
@@ -148,6 +148,7 @@ class TimeSeriesScalerMinMax(BaseEstimator, TransformerMixin):
         self
         """
         X = check_array(X, allow_nd=True, force_all_finite=False)
+        X = to_time_series_dataset(X)
         self._X_fit_dims = X.shape
         return self
 
@@ -186,8 +187,8 @@ class TimeSeriesScalerMinMax(BaseEstimator, TransformerMixin):
                              " than maximum. Got %s." % str(value_range))
 
         X = check_array(X, allow_nd=True, force_all_finite=False)
-        X = check_dims(X, self._X_fit_dims, extend=False)
         X_ = to_time_series_dataset(X)
+        X_ = check_dims(X_, self._X_fit_dims, extend=False)
         min_t = numpy.nanmin(X_, axis=1)[:, numpy.newaxis, :]
         max_t = numpy.nanmax(X_, axis=1)[:, numpy.newaxis, :]
         range_t = max_t - min_t
@@ -248,6 +249,7 @@ class TimeSeriesScalerMeanVariance(BaseEstimator, TransformerMixin):
         self
         """
         X = check_array(X, allow_nd=True, force_all_finite=False)
+        X = to_time_series_dataset(X)
         self._X_fit_dims = X.shape
         return self
 
@@ -265,8 +267,8 @@ class TimeSeriesScalerMeanVariance(BaseEstimator, TransformerMixin):
             Rescaled time series dataset
         """
         X = check_array(X, allow_nd=True, force_all_finite=False)
-        X = check_dims(X, self._X_fit_dims, extend=False)
         X_ = to_time_series_dataset(X)
+        X_ = check_dims(X_, self._X_fit_dims, extend=False)
         mean_t = numpy.nanmean(X_, axis=1)[:, numpy.newaxis, :]
         std_t = numpy.nanstd(X_, axis=1)[:, numpy.newaxis, :]
         std_t[std_t == 0.] = 1.

--- a/tslearn/preprocessing.py
+++ b/tslearn/preprocessing.py
@@ -5,6 +5,7 @@ The :mod:`tslearn.preprocessing` module gathers time series scalers.
 import numpy
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils import check_array
+from sklearn.utils.validation import check_is_fitted
 from scipy.interpolate import interp1d
 import warnings
 
@@ -186,9 +187,10 @@ class TimeSeriesScalerMinMax(BaseEstimator, TransformerMixin):
             raise ValueError("Minimum of desired range must be smaller"
                              " than maximum. Got %s." % str(value_range))
 
+        check_is_fitted(self, '_X_fit_dims')
         X = check_array(X, allow_nd=True, force_all_finite=False)
         X_ = to_time_series_dataset(X)
-        X_ = check_dims(X_, self._X_fit_dims, extend=False)
+        X_ = check_dims(X_, X_fit_dims=self._X_fit_dims, extend=False)
         min_t = numpy.nanmin(X_, axis=1)[:, numpy.newaxis, :]
         max_t = numpy.nanmax(X_, axis=1)[:, numpy.newaxis, :]
         range_t = max_t - min_t
@@ -266,9 +268,10 @@ class TimeSeriesScalerMeanVariance(BaseEstimator, TransformerMixin):
         numpy.ndarray
             Rescaled time series dataset
         """
+        check_is_fitted(self, '_X_fit_dims')
         X = check_array(X, allow_nd=True, force_all_finite=False)
         X_ = to_time_series_dataset(X)
-        X_ = check_dims(X_, self._X_fit_dims, extend=False)
+        X_ = check_dims(X_, X_fit_dims=self._X_fit_dims, extend=False)
         mean_t = numpy.nanmean(X_, axis=1)[:, numpy.newaxis, :]
         std_t = numpy.nanstd(X_, axis=1)[:, numpy.newaxis, :]
         std_t[std_t == 0.] = 1.

--- a/tslearn/shapelets.py
+++ b/tslearn/shapelets.py
@@ -396,7 +396,7 @@ class ShapeletModel(BaseEstimator, ClassifierMixin, TransformerMixin):
 
         X, y = check_X_y(X, y, allow_nd=True)
         X = to_time_series_dataset(X)
-        X = check_dims(X, X_fit_dims=None)
+        X = check_dims(X)
 
         set_random_seed(seed=self.random_state)
         numpy.random.seed(seed=self.random_state)
@@ -467,7 +467,7 @@ class ShapeletModel(BaseEstimator, ClassifierMixin, TransformerMixin):
         check_is_fitted(self, '_X_fit_dims')
         X = check_array(X, allow_nd=True)
         X = to_time_series_dataset(X)
-        X = check_dims(X, self._X_fit_dims)
+        X = check_dims(X, X_fit_dims=self._X_fit_dims)
 
         categorical_preds = self.predict_proba(X)
         if self.categorical_y_:
@@ -491,7 +491,7 @@ class ShapeletModel(BaseEstimator, ClassifierMixin, TransformerMixin):
         check_is_fitted(self, '_X_fit_dims')
         X = check_array(X, allow_nd=True)
         X = to_time_series_dataset(X)
-        X = check_dims(X, self._X_fit_dims)
+        X = check_dims(X, X_fit_dims=self._X_fit_dims)
         n_ts, sz, d = X.shape
         categorical_preds = self.model_.predict(
             [X[:, :, di].reshape((n_ts, sz, 1)) for di in range(self.d_)],
@@ -520,7 +520,7 @@ class ShapeletModel(BaseEstimator, ClassifierMixin, TransformerMixin):
         check_is_fitted(self, '_X_fit_dims')
         X = check_array(X, allow_nd=True)
         X = to_time_series_dataset(X)
-        X = check_dims(X, self._X_fit_dims)
+        X = check_dims(X, X_fit_dims=self._X_fit_dims)
         n_ts, sz, d = X.shape
         pred = self.transformer_model_.predict(
             [X[:, :, di].reshape((n_ts, sz, 1)) for di in range(self.d_)],
@@ -563,7 +563,7 @@ class ShapeletModel(BaseEstimator, ClassifierMixin, TransformerMixin):
         check_is_fitted(self, '_X_fit_dims')
         X = check_array(X, allow_nd=True)
         X = to_time_series_dataset(X)
-        X = check_dims(X, self._X_fit_dims)
+        X = check_dims(X, X_fit_dims=self._X_fit_dims)
         n_ts, sz, d = X.shape
         locations = self.locator_model_.predict(
             [X[:, :, di].reshape((n_ts, sz, 1)) for di in range(self.d_)],

--- a/tslearn/shapelets.py
+++ b/tslearn/shapelets.py
@@ -560,9 +560,10 @@ class ShapeletModel(BaseEstimator, ClassifierMixin, TransformerMixin):
                [0],
                [0]])
         """
-        X = check_dims(X, self._X_fit_dims)
+        check_is_fitted(self, '_X_fit_dims')
         X = check_array(X, allow_nd=True)
         X = to_time_series_dataset(X)
+        X = check_dims(X, self._X_fit_dims)
         n_ts, sz, d = X.shape
         locations = self.locator_model_.predict(
             [X[:, :, di].reshape((n_ts, sz, 1)) for di in range(self.d_)],

--- a/tslearn/svm.py
+++ b/tslearn/svm.py
@@ -47,11 +47,13 @@ class TimeSeriesSVMMixin:
             self.gamma_ = gamma_soft_dtw(X)
             self.classes_ = numpy.unique(y)
         else:
-            if self.kernel in VARIABLE_LENGTH_METRICS:
-                X = check_dims(X, X_fit_dims=self._X_fit.shape, extend=True,
-                               check_n_features_only=True)
-            else:
-                X = check_dims(X, X_fit_dims=self._X_fit.shape, extend=True)
+            check_is_fitted(self, ['svm_estimator_', '_X_fit'])
+            X = check_dims(
+                X,
+                X_fit_dims=self._X_fit.shape,
+                extend=True,
+                check_n_features_only=(self.kernel in VARIABLE_LENGTH_METRICS)
+            )
 
         if self.kernel in VARIABLE_LENGTH_METRICS:
             assert self.kernel == "gak"
@@ -267,27 +269,22 @@ class TimeSeriesSVC(TimeSeriesSVMMixin, BaseEstimator, ClassifierMixin):
         return self
 
     def predict(self, X):
-        check_is_fitted(self, ['svm_estimator_', '_X_fit'])
         sklearn_X = self._preprocess_sklearn(X, fit_time=False)
         return self.svm_estimator_.predict(sklearn_X)
 
     def decision_function(self, X):
-        check_is_fitted(self, ['svm_estimator_', '_X_fit'])
         sklearn_X = self._preprocess_sklearn(X, fit_time=False)
         return self.svm_estimator_.decision_function(sklearn_X)
 
     def predict_log_proba(self, X):
-        check_is_fitted(self, ['svm_estimator_', '_X_fit'])
         sklearn_X = self._preprocess_sklearn(X, fit_time=False)
         return self.svm_estimator_.predict_log_proba(sklearn_X)
 
     def predict_proba(self, X):
-        check_is_fitted(self, ['svm_estimator_', '_X_fit'])
         sklearn_X = self._preprocess_sklearn(X, fit_time=False)
         return self.svm_estimator_.predict_proba(sklearn_X)
 
     def score(self, X, y, sample_weight=None):
-        check_is_fitted(self, ['svm_estimator_', '_X_fit'])
         sklearn_X = self._preprocess_sklearn(X, fit_time=False)
         return self.svm_estimator_.score(sklearn_X, y,
                                          sample_weight=sample_weight)
@@ -443,12 +440,10 @@ class TimeSeriesSVR(TimeSeriesSVMMixin, BaseEstimator, RegressorMixin):
         return self
 
     def predict(self, X):
-        check_is_fitted(self, ['svm_estimator_', '_X_fit'])
         sklearn_X = self._preprocess_sklearn(X, fit_time=False)
         return self.svm_estimator_.predict(sklearn_X)
 
     def score(self, X, y, sample_weight=None):
-        check_is_fitted(self, ['svm_estimator_', '_X_fit'])
         sklearn_X = self._preprocess_sklearn(X, fit_time=False)
         return self.svm_estimator_.score(sklearn_X, y,
                                          sample_weight=sample_weight)

--- a/tslearn/svm.py
+++ b/tslearn/svm.py
@@ -34,23 +34,24 @@ def _prepare_ts_datasets_sklearn(X):
 class TimeSeriesSVMMixin:
     def _preprocess_sklearn(self, X, y=None, fit_time=False):
         force_all_finite = self.kernel not in VARIABLE_LENGTH_METRICS
-        X = to_time_series_dataset(X)
         if y is None:
             X = check_array(X, allow_nd=True,
                             force_all_finite=force_all_finite)
         else:
             X, y = check_X_y(X, y, allow_nd=True,
                              force_all_finite=force_all_finite)
-        if self.kernel in VARIABLE_LENGTH_METRICS:
-            X = check_dims(X, X_fit_dims=self._X_fit, extend=True,
-                           check_n_features_only=True)
-        else:
-            X = check_dims(X, X_fit_dims=self._X_fit, extend=True)
+        X = to_time_series_dataset(X)
 
         if fit_time:
             self._X_fit = X
             self.gamma_ = gamma_soft_dtw(X)
             self.classes_ = numpy.unique(y)
+        else:
+            if self.kernel in VARIABLE_LENGTH_METRICS:
+                X = check_dims(X, X_fit_dims=self._X_fit.shape, extend=True,
+                               check_n_features_only=True)
+            else:
+                X = check_dims(X, X_fit_dims=self._X_fit.shape, extend=True)
 
         if self.kernel in VARIABLE_LENGTH_METRICS:
             assert self.kernel == "gak"

--- a/tslearn/svm.py
+++ b/tslearn/svm.py
@@ -34,6 +34,7 @@ def _prepare_ts_datasets_sklearn(X):
 class TimeSeriesSVMMixin:
     def _preprocess_sklearn(self, X, y=None, fit_time=False):
         force_all_finite = self.kernel not in VARIABLE_LENGTH_METRICS
+        X = to_time_series_dataset(X)
         if y is None:
             X = check_array(X, allow_nd=True,
                             force_all_finite=force_all_finite)

--- a/tslearn/svm.py
+++ b/tslearn/svm.py
@@ -40,8 +40,11 @@ class TimeSeriesSVMMixin:
         else:
             X, y = check_X_y(X, y, allow_nd=True,
                              force_all_finite=force_all_finite)
-        X = check_dims(X, X_fit_dims=None)
-        X = to_time_series_dataset(X)
+        if self.kernel in VARIABLE_LENGTH_METRICS:
+            X = check_dims(X, X_fit_dims=self._X_fit, extend=True,
+                           check_n_features_only=True)
+        else:
+            X = check_dims(X, X_fit_dims=self._X_fit, extend=True)
 
         if fit_time:
             self._X_fit = X

--- a/tslearn/tests/sklearn_patches.py
+++ b/tslearn/tests/sklearn_patches.py
@@ -52,6 +52,8 @@ from sklearn.model_selection import ShuffleSplit
 from sklearn.model_selection._validation import _safe_split
 from sklearn.pipeline import make_pipeline
 
+from tslearn.clustering import TimeSeriesKMeans
+
 import warnings
 import numpy as np
 
@@ -531,9 +533,16 @@ def check_different_length_fit_predict(name, estimator):
     # Check if classifier can predict a dataset that does not have the same
     # number of timestamps as the data passed at fit time
 
+    # Default for kmeans is Euclidean
+    if isinstance(estimator, TimeSeriesKMeans):
+        new_estimator = clone(estimator)
+        new_estimator.metric = "dtw"
+    else:
+        new_estimator = estimator
+
     X, y = _create_small_ts_dataset()
     X2 = np.hstack((X, X))
-    estimator.fit(X, y).predict(X2)
+    new_estimator.fit(X, y).predict(X2)
 
 
 def yield_all_checks(name, estimator):

--- a/tslearn/tests/sklearn_patches.py
+++ b/tslearn/tests/sklearn_patches.py
@@ -526,6 +526,16 @@ def check_pipeline_consistency(name, estimator_orig):
             assert_allclose_dense_sparse(result, result_pipe)
 
 
+@ignore_warnings(category=(DeprecationWarning, FutureWarning))
+def check_different_length_fit_predict(name, estimator):
+    # Check if classifier can predict a dataset that does not have the same
+    # number of timestamps as the data passed at fit time
+
+    X, y = _create_small_ts_dataset()
+    X2 = np.hstack((X, X))
+    estimator.fit(X, y).predict(X2)
+
+
 def yield_all_checks(name, estimator):
     tags = _safe_tags(estimator)
     if "2darray" not in tags["X_types"]:
@@ -556,7 +566,8 @@ def yield_all_checks(name, estimator):
     if is_outlier_detector(estimator):
         for check in _yield_outliers_checks(name, estimator):
             yield check
-    yield check_fit2d_predict1d
+    # We are not strict on presence/absence of the 3rd dimension
+    # yield check_fit2d_predict1d
 
     if not tags["non_deterministic"]:
         yield check_methods_subset_invariance
@@ -569,3 +580,6 @@ def yield_all_checks(name, estimator):
     yield check_dict_unchanged
     yield check_dont_overwrite_parameters
     yield check_fit_idempotent
+
+    if tags["allow_variable_length"]:
+        yield check_different_length_fit_predict

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -9,7 +9,7 @@ from sklearn.utils.validation import check_is_fitted
 import warnings
 
 try:
-    from sklearn.utils.estimator_checks import _NotAnArray
+    from sklearn.utils.estimator_checks import _NotAnArray as NotAnArray
 except ImportError:  # Old sklearn versions
     from sklearn.utils.estimator_checks import NotAnArray
 

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -65,8 +65,9 @@ def check_dims(X, X_fit_dims=None, extend=True, check_n_features_only=False):
     ...     check_n_features_only=True
     ... )  # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
-    ValueError: Dimensions (except first) must match! ((5, 5, 2) and (10, 3, 1)
-    are passed shapes)
+    ValueError: Number of features of the provided timeseries must match!
+    (last dimension) must match the one of the fitted data!
+    ((5, 5, 2) and (10, 3, 1) are passed shapes)
 
     Raises
     ------

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -59,7 +59,11 @@ def check_dims(X, X_fit_dims=None, extend=True, check_n_features_only=False):
     >>> check_dims(X, X_fit_dims, check_n_features_only=True).shape
     (10, 3, 1)
     >>> X_fit_dims = (5, 5, 2)
-    >>> check_dims(X, X_fit_dims, check_n_features_only=True)  # doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_dims(
+    ...     X,
+    ...     X_fit_dims,
+    ...     check_n_features_only=True
+    ... )  # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     ValueError: Dimensions (except first) must match! ((5, 5, 2) and (10, 3, 1)
     are passed shapes)
@@ -78,7 +82,6 @@ def check_dims(X, X_fit_dims=None, extend=True, check_n_features_only=False):
         warnings.warn('2-Dimensional data passed. Assuming these are '
                       '{} 1-dimensional timeseries'.format(X.shape[0]))
         X = X.reshape((X.shape) + (1,))
-
 
     if X_fit_dims is not None:
         if check_n_features_only:

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -201,11 +201,15 @@ def to_time_series_dataset(dataset, dtype=numpy.float):
     --------
     to_time_series : Transforms a single time series
     """
-    if len(dataset) == 0:
+    is_empty = True
+    for _ in dataset:
+        is_empty = False
+        break
+    if is_empty:
         return numpy.zeros((0, 0, 0))
     if numpy.array(dataset[0]).ndim == 0:
         dataset = [dataset]
-    n_ts = len(dataset)
+    n_ts = len([ts for ts in dataset])
     max_sz = max([ts_size(to_time_series(ts)) for ts in dataset])
     d = to_time_series(dataset[0]).shape[1]
     dataset_out = numpy.zeros((n_ts, max_sz, d), dtype=dtype) + numpy.nan

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -11,7 +11,7 @@ import warnings
 __author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
 
 
-def check_dims(X, X_fit_dims=None, extend=True):
+def check_dims(X, X_fit_dims=None, extend=True, check_n_features_only=False):
     """Reshapes X to a 3-dimensional array of X.shape[0] univariate
     timeseries of length X.shape[1] if X is 2-dimensional and extend
     is True. Then checks whether the provided X_fit_dims and the
@@ -27,6 +27,7 @@ def check_dims(X, X_fit_dims=None, extend=True):
         If None, then only perform reshaping of X, if necessary.
     extend : boolean (default: True)
         Whether to reshape X, if it is 2-dimensional.
+    check_n_features_only: boolean (default: False)
 
     Returns
     -------
@@ -49,6 +50,14 @@ def check_dims(X, X_fit_dims=None, extend=True):
     Traceback (most recent call last):
     ValueError: Dimensions (except first) must match! ((5, 3, 2) and (10, 3, 1)
     are passed shapes)
+    >>> X_fit_dims = (5, 5, 1)
+    >>> check_dims(X, X_fit_dims, check_n_features_only=True).shape
+    (10, 3, 1)
+    >>> X_fit_dims = (5, 5, 2)
+    >>> check_dims(X, X_fit_dims, check_n_features_only=True)  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ValueError: Dimensions (except first) must match! ((5, 5, 2) and (10, 3, 1)
+    are passed shapes)
 
     Raises
     ------
@@ -65,11 +74,18 @@ def check_dims(X, X_fit_dims=None, extend=True):
                       '{} 1-dimensional timeseries'.format(X.shape[0]))
         X = X.reshape((X.shape) + (1,))
 
-    if X_fit_dims is not None and X_fit_dims[1:] != X.shape[1:]:
-        raise ValueError('Dimensions of the provided timeseries'
-                         '(except first) must match those of the fitted data!'
-                         ' ({} and {} are passed shapes)'.format(X_fit_dims,
-                                                                 X.shape))
+
+    if X_fit_dims is not None:
+        if X_fit_dims[2] != X.shape[2] and check_n_features_only:
+            raise ValueError(
+                'Number of features of the provided timeseries'
+                '(last dimension) must match the one of the fitted data!'
+                ' ({} and {} are passed shapes)'.format(X_fit_dims, X.shape))
+        elif X_fit_dims[1:] != X.shape[1:]:
+            raise ValueError(
+                'Dimensions of the provided timeseries'
+                '(except first) must match those of the fitted data!'
+                ' ({} and {} are passed shapes)'.format(X_fit_dims, X.shape))
 
     return X
 

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -81,7 +81,7 @@ def check_dims(X, X_fit_dims=None, extend=True, check_n_features_only=False):
                 'Number of features of the provided timeseries'
                 '(last dimension) must match the one of the fitted data!'
                 ' ({} and {} are passed shapes)'.format(X_fit_dims, X.shape))
-        elif X_fit_dims[1:] != X.shape[1:]:
+        if X_fit_dims[1:] != X.shape[1:] and not check_n_features_only:
             raise ValueError(
                 'Dimensions of the provided timeseries'
                 '(except first) must match those of the fitted data!'


### PR DESCRIPTION
This PR ensures that if an estimator can deal with variable-length inputs, then the only constraint at test time is that the number of features is equal to that provided at fit time.

This is a bugfix for #220 