### PR TITLE
[MRG] Bugfix: deprecated method in svm classes was unavailable

### DIFF
--- a/tslearn/svm.py
+++ b/tslearn/svm.py
@@ -509,13 +509,6 @@ class TimeSeriesSVR(TimeSeriesSVMMixin, RegressorMixin,
 
     @deprecated()
     def support_vectors_time_series_(self, X=None):
-        """Support vectors as time series.
-
-        Parameters
-        ----------
-        X : array-like of shape=(n_ts, sz, d)
-            Training time series dataset.
-        """
         warnings.warn('The use of '
                       '`support_vectors_time_series_` is deprecated in '
                       'tslearn v0.4 and will be removed in v0.6. Use '

--- a/tslearn/svm.py
+++ b/tslearn/svm.py
@@ -507,7 +507,7 @@ class TimeSeriesSVR(TimeSeriesSVMMixin, RegressorMixin,
                       'it is non-trivial to access the underlying libsvm')
         return 1
 
-    @deprecated
+    @deprecated()
     def support_vectors_time_series_(self, X=None):
         """Support vectors as time series.
 
@@ -516,11 +516,10 @@ class TimeSeriesSVR(TimeSeriesSVMMixin, RegressorMixin,
         X : array-like of shape=(n_ts, sz, d)
             Training time series dataset.
         """
-        if X is not None:
-            warnings.warn('The use of '
-                          '`support_vectors_time_series_` is deprecated in '
-                          'tslearn v0.4 and will be removed in v0.6. Use '
-                          '`support_vectors_` property instead.')
+        warnings.warn('The use of '
+                      '`support_vectors_time_series_` is deprecated in '
+                      'tslearn v0.4 and will be removed in v0.6. Use '
+                      '`support_vectors_` property instead.')
         check_is_fitted(self, '_X_fit')
         return self._X_fit[self.svm_estimator_.support_]
 

--- a/tslearn/svm.py
+++ b/tslearn/svm.py
@@ -164,8 +164,8 @@ class TimeSeriesSVC(TimeSeriesSVMMixin, ClassifierMixin,
     n_support_ : array-like, dtype=int32, shape = [n_class]
         Number of support vectors for each class.
         
-    support_vectors_ : array of shape [n_SV, sz, d]
-        Support vectors in tslearn dataset format
+    support_vectors_ : list of arrays of shape [n_SV, sz, d]
+        List of support vectors in tslearn dataset format, one array per class
 
     dual_coef_ : array, shape = [n_class-1, n_SV]
         Coefficients of the support vector in the decision function.
@@ -240,20 +240,12 @@ class TimeSeriesSVC(TimeSeriesSVMMixin, ClassifierMixin,
                       'it is non-trivial to access the underlying libsvm')
         return 1
 
-    @deprecated
+    @deprecated()
     def support_vectors_time_series_(self, X=None):
-        """Support vectors as time series.
-
-        Parameters
-        ----------
-        X : array-like of shape=(n_ts, sz, d)
-            Training time series dataset.
-        """
-        if X is not None:
-            warnings.warn('The use of '
-                          '`support_vectors_time_series_` is deprecated in '
-                          'tslearn v0.4 and will be removed in v0.6. Use '
-                          '`support_vectors_` property instead.')
+        warnings.warn('The use of '
+                      '`support_vectors_time_series_` is deprecated in '
+                      'tslearn v0.4 and will be removed in v0.6. Use '
+                      '`support_vectors_` property instead.')
         check_is_fitted(self, '_X_fit')
         return self._X_fit[self.svm_estimator_.support_]
 

--- a/tslearn/svm.py
+++ b/tslearn/svm.py
@@ -240,7 +240,10 @@ class TimeSeriesSVC(TimeSeriesSVMMixin, ClassifierMixin,
                       'it is non-trivial to access the underlying libsvm')
         return 1
 
-    @deprecated()
+    @deprecated('The use of '
+                '`support_vectors_time_series_` is deprecated in '
+                'tslearn v0.4 and will be removed in v0.6. Use '
+                '`support_vectors_` property instead.')
     def support_vectors_time_series_(self, X=None):
         warnings.warn('The use of '
                       '`support_vectors_time_series_` is deprecated in '
@@ -507,7 +510,10 @@ class TimeSeriesSVR(TimeSeriesSVMMixin, RegressorMixin,
                       'it is non-trivial to access the underlying libsvm')
         return 1
 
-    @deprecated()
+    @deprecated('The use of '
+                '`support_vectors_time_series_` is deprecated in '
+                'tslearn v0.4 and will be removed in v0.6. Use '
+                '`support_vectors_` property instead.')
     def support_vectors_time_series_(self, X=None):
         warnings.warn('The use of '
                       '`support_vectors_time_series_` is deprecated in '

--- a/tslearn/tests/test_svm.py
+++ b/tslearn/tests/test_svm.py
@@ -30,6 +30,7 @@ def test_deprecated_still_work():
     X = rng.randn(n, sz, d)
     y = rng.randint(low=0, high=2, size=n)
 
-    clf = TimeSeriesSVC().fit(X, y)
-    np.testing.assert_equal(clf.support_vectors_time_series_().shape[1:],
-                            X.shape[1:])
+    for ModelClass in [TimeSeriesSVC, TimeSeriesSVR]:
+        clf = ModelClass().fit(X, y)
+        np.testing.assert_equal(clf.support_vectors_time_series_().shape[1:],
+                                X.shape[1:])

--- a/tslearn/tests/test_svm.py
+++ b/tslearn/tests/test_svm.py
@@ -22,3 +22,14 @@ def test_gamma_value_svm():
         cdist_mat = cdist_gak(time_series, sigma=np.sqrt(gamma / 2.))
 
         np.testing.assert_allclose(sklearn_X, cdist_mat)
+
+
+def test_deprecated_still_work():
+    n, sz, d = 5, 10, 3
+    rng = np.random.RandomState(0)
+    X = rng.randn(n, sz, d)
+    y = rng.randint(low=0, high=2, size=n)
+
+    clf = TimeSeriesSVC().fit(X, y)
+    np.testing.assert_equal(clf.support_vectors_time_series_().shape[1:],
+                            X.shape[1:])


### PR DESCRIPTION
Starting from v0.4, the method `support_vectors_time_series_` is deprecated.
The way I coded it lead to a bug when calling it. This PR is a bugfix for this unwanted behavior.