### PR TITLE
Small update to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing
+# autopep8
 
 First of all, thank you for considering contributing to `tslearn`. 
 It's people like you that will help make `tslearn` a great toolkit.
@@ -120,8 +120,8 @@ tools:
 -  No PEP8 warnings, check with:
 
   ```bash
-  $ pip install pep8
-  $ pep8 path/to/module.py
+  $ pip install pycodestyle
+  $ pycodestyle path/to/module.py
   ```
 
 -  AutoPEP8 can help you fix some of the easy redundant errors:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# autopep8
+# Contributing
 
 First of all, thank you for considering contributing to `tslearn`. 
 It's people like you that will help make `tslearn` a great toolkit.


### PR DESCRIPTION
After PyCQA/pycodestyle#466, `pep8` was reneamed to `pycodestyle` a long time ago (but still checks for PEP8). This edit reflects that (it gave me a warning about it upon installation).