### PR TITLE
Improve warnings and documentation in UCR_UEA_datasets 

### DIFF
--- a/tslearn/datasets.py
+++ b/tslearn/datasets.py
@@ -399,9 +399,9 @@ class UCR_UEA_datasets:
         for dataset_name in self.list_datasets():
             try:
                 self.load_dataset(dataset_name)
-            except Exception:
-                warnings.warn("Could not cache dataset %s properly."
-                              % dataset_name,
+            except Exception as exception:
+                warnings.warn("Could not cache dataset \"%s\" properly: %s"
+                              % (dataset_name, str(exception)),
                               category=RuntimeWarning, stacklevel=2)
 
 

--- a/tslearn/datasets.py
+++ b/tslearn/datasets.py
@@ -400,7 +400,7 @@ class UCR_UEA_datasets:
             try:
                 self.load_dataset(dataset_name)
             except Exception as exception:
-                warnings.warn("Could not cache dataset \"%s\" properly: %s"
+                warnings.warn("Could not cache dataset \"%s\": %s"
                               % (dataset_name, str(exception)),
                               category=RuntimeWarning, stacklevel=2)
 

--- a/tslearn/datasets.py
+++ b/tslearn/datasets.py
@@ -107,8 +107,7 @@ class UCR_UEA_datasets:
 
     See Also
     --------
-    Class :class:`CachedDatasets`
-        Provides distinct selected datasets for offline use.
+    CachedDatasets : Provides pre-selected datasets for offline use.
 
     References
     ----------
@@ -429,6 +428,10 @@ class CachedDatasets:
     and are distinct from the ones in :class:`UCR_UEA_datasets`.
 
     When using the Trace dataset, please cite [1]_.
+
+    See Also
+    --------
+    UCR_UEA_datasets : Provides more datasets and supports caching.
 
     References
     ----------

--- a/tslearn/datasets.py
+++ b/tslearn/datasets.py
@@ -59,7 +59,7 @@ def extract_from_zip_url(url, target_dir=None, verbose=False):
         return target_dir
     except BadZipFile:
         shutil.rmtree(tmpdir)
-        warnings.warn("Corrupted zip file encountered, aborting",
+        warnings.warn("Corrupted or missing zip file encountered, aborting",
                       category=RuntimeWarning)
         return None
 
@@ -190,7 +190,7 @@ class UCR_UEA_datasets:
         >>> len(dict_acc)
         85
         """
-        with open(self._list_multivariate_filename, "r") as f:
+        with open(self._baseline_scores_filename, "r") as f:
             d_out = dict()
             for perfs_dict in csv.DictReader(f, delimiter=","):
                 dataset_name = perfs_dict[""]
@@ -324,11 +324,11 @@ class UCR_UEA_datasets:
         >>> X_train.shape
         (7494, 8, 2)
 
-        `None`s are returned on failures:
+        `None`s are returned for all four values on failure:
         >>> X_train, y_train, X_test, y_test = data_loader.load_dataset(
         ...         "DatasetThatDoesNotExist")
-        >>> X_train
-        None
+        >>> X_train is None
+        True
         """
         dataset_name = self._filenames.get(dataset_name, dataset_name)
         full_path = os.path.join(self._data_dir, dataset_name)

--- a/tslearn/datasets.py
+++ b/tslearn/datasets.py
@@ -120,13 +120,13 @@ class UCR_UEA_datasets:
         if not os.path.exists(self._data_dir):
             os.makedirs(self._data_dir)
         try:
-            url_multivariate = ("http://www.timeseriesclassification.com/" +
+            url_multivariate = ("https://www.timeseriesclassification.com/" +
                                 "Downloads/Archives/summaryMultivariate.csv")
             self._list_multivariate_filename = os.path.join(
                 self._data_dir, os.path.basename(url_multivariate)
             )
             urlretrieve(url_multivariate, self._list_multivariate_filename)
-            url_baseline = ("http://www.timeseriesclassification.com/" +
+            url_baseline = ("https://www.timeseriesclassification.com/" +
                             "singleTrainTest.csv")
             self._baseline_scores_filename = os.path.join(
                 self._data_dir, os.path.basename(url_baseline))
@@ -322,7 +322,7 @@ class UCR_UEA_datasets:
             # completely clear the target directory first, it will be created
             # by extract_from_zip_url if it does not exist
             shutil.rmtree(full_path)
-            url = ("http://www.timeseriesclassification.com/Downloads/%s.zip"
+            url = ("https://www.timeseriesclassification.com/Downloads/%s.zip"
                    % dataset_name)
             success = extract_from_zip_url(url, target_dir=full_path)
             if not success:

--- a/tslearn/datasets.py
+++ b/tslearn/datasets.py
@@ -65,10 +65,10 @@ def extract_from_zip_url(url, target_dir=None, verbose=False):
 
 
 def in_file_string_replace(filename, old_string, new_string):
-    """ String replacement within a text file. It is used to fix typos in
+    """String replacement within a text file. It is used to fix typos in
     downloaded csv file.
-    The code was modified from "https://stackoverflow.com/questions/4128144/\
-    replace-string-within-file-contents"
+
+    The code was modified from "https://stackoverflow.com/questions/4128144/"
 
     Parameters
     ----------
@@ -78,7 +78,6 @@ def in_file_string_replace(filename, old_string, new_string):
         The string to be replaced in the file.
     new_string : str
         The new string that will replace old_string
-
     """
     with open(filename) as f:
         s = f.read()
@@ -191,19 +190,19 @@ class UCR_UEA_datasets:
         >>> len(dict_acc)
         85
         """
-        d_out = {}
-        for perfs_dict in csv.DictReader(
-                open(self._baseline_scores_filename, "r"), delimiter=","):
-            dataset_name = perfs_dict[""]
-            if list_datasets is None or dataset_name in list_datasets:
-                d_out[dataset_name] = {}
-                for m in perfs_dict.keys():
-                    if m != "" and (list_methods is None or m in list_methods):
-                        try:
-                            d_out[dataset_name][m] = float(perfs_dict[m])
-                        except ValueError:  # Missing score case (score == "")
-                            pass
-        return d_out
+        with open(self._list_multivariate_filename, "r") as f:
+            d_out = dict()
+            for perfs_dict in csv.DictReader(f, delimiter=","):
+                dataset_name = perfs_dict[""]
+                if list_datasets is None or dataset_name in list_datasets:
+                    d_out[dataset_name] = {}
+                    for m in perfs_dict.keys():
+                        if m != "" and (list_methods is None or m in list_methods):
+                            try:
+                                d_out[dataset_name][m] = float(perfs_dict[m])
+                            except ValueError:  # Missing score case (score == "")
+                                pass
+            return d_out
 
     def list_univariate_datasets(self):
         """List univariate datasets in the UCR/UEA archive.
@@ -213,12 +212,17 @@ class UCR_UEA_datasets:
         >>> l = UCR_UEA_datasets().list_univariate_datasets()
         >>> len(l)
         85
+
+        Returns
+        -------
+        list of str:
+            A list of the names of all univariate dataset namas.
         """
-        datasets = []
-        for perfs_dict in csv.DictReader(
-                open(self._baseline_scores_filename, "r"), delimiter=","):
-            datasets.append(perfs_dict[""])
-        return datasets
+        with open(self._baseline_scores_filename, "r") as f:
+            return [
+                perfs_dict[""]  # get the dataset name
+                for perfs_dict in csv.DictReader(f, delimiter=",")
+            ]
 
     def list_multivariate_datasets(self):
         """List multivariate datasets in the UCR/UEA archive.
@@ -228,12 +232,17 @@ class UCR_UEA_datasets:
         >>> l = UCR_UEA_datasets().list_multivariate_datasets()
         >>> "PenDigits" in l
         True
+
+        Returns
+        -------
+        list of str:
+            A list of the names of all multivariate dataset namas.
         """
-        datasets = []
-        for infos_dict in csv.DictReader(
-                open(self._list_multivariate_filename, "r"), delimiter=","):
-            datasets.append(infos_dict["Problem"])
-        return datasets
+        with open(self._list_multivariate_filename, "r") as f:
+            return [
+                infos_dict["Problem"]  # get the dataset name
+                for infos_dict in csv.DictReader(f, delimiter=",")
+            ]
 
     def list_datasets(self):
         """List datasets (both univariate and multivariate) available in the 
@@ -248,6 +257,11 @@ class UCR_UEA_datasets:
         True
         >>> "DatasetThatDoesNotExist" in l
         False
+
+        Returns
+        -------
+        list of str:
+            A list of names of all (univariate and multivariate) dataset namas.
         """
         return (self.list_univariate_datasets()
                 + self.list_multivariate_datasets())
@@ -380,7 +394,7 @@ class UCR_UEA_datasets:
 
         Returns
         -------
-        bool :
+        bool
             if there are both training and test files with the specified
             file extension
         """
@@ -453,6 +467,11 @@ class CachedDatasets:
         (100, 275, 1)
         >>> print(y_train.shape)
         (100,)
+
+        Raises
+        ------
+        IOError
+            If the dataset does not exist or cannot be read.
         """
         npzfile = numpy.load(os.path.join(self.path, dataset_name + ".npz"))
         X_train = npzfile["X_train"]

--- a/tslearn/datasets.py
+++ b/tslearn/datasets.py
@@ -93,14 +93,22 @@ class UCR_UEA_datasets:
     Parameters
     ----------
     use_cache : bool (default: True)
-        Whether a cached version of the dataset should be used, if found.
+        Whether a cached version of the dataset should be used in
+        :meth:`~load_dataset`, if one is found.
+        Datasets are always cached upon loading, and this parameter only
+        determines whether the cached version shall be refreshed upon loading.
 
     Notes
     -----
         Downloading dataset files can be time-consuming, it is recommended
-        using `use_cache=True` (default) in order to
-        only experience downloading time once per dataset and work on a cached
-        version of the datasets after it.
+        using `use_cache=True` (default) in order to only experience
+        downloading time once per dataset and work on a cached version of the
+        datasets afterward.
+
+    See Also
+    --------
+    Class :class:`CachedDatasets`
+        Provides distinct selected datasets for offline use.
 
     References
     ----------
@@ -179,8 +187,8 @@ class UCR_UEA_datasets:
         2
         >>> dict_acc["Adiac"]  # doctest: +ELLIPSIS
         {'C45': 0.542199...}
-        >>> dict_acc = uea_ucr.baseline_accuracy()
-        >>> len(dict_acc)
+        >>> all_dict_acc = uea_ucr.baseline_accuracy()
+        >>> len(all_dict_acc)
         85
         """
         with open(self._baseline_scores_filename, "r") as f:
@@ -319,7 +327,7 @@ class UCR_UEA_datasets:
         dataset_name = self._filenames.get(dataset_name, dataset_name)
         full_path = os.path.join(self._data_dir, dataset_name)
 
-        if not self._has_files(dataset_name):
+        if not self._has_files(dataset_name) or not self.use_cache:
             # completely clear the target directory first, it will be created
             # by extract_from_zip_url if it does not exist
             try:
@@ -416,6 +424,9 @@ class UCR_UEA_datasets:
 
 class CachedDatasets:
     """A convenience class to access cached time series datasets.
+
+    Note, that these *cached datasets* are statically included into *tslearn*
+    and are distinct from the ones in :class:`UCR_UEA_datasets`.
 
     When using the Trace dataset, please cite [1]_.
 

--- a/tslearn/datasets.py
+++ b/tslearn/datasets.py
@@ -135,7 +135,7 @@ class UCR_UEA_datasets:
                                    "CinCECGtorso", "CinCECGTorso")
             in_file_string_replace(self._baseline_scores_filename,
                                    "StarlightCurves", "StarLightCurves")
-        except:
+        except Exception:
             self._baseline_scores_filename = None
 
         self._ignore_list = ["Data Descriptions"]
@@ -351,13 +351,11 @@ class UCR_UEA_datasets:
                     os.path.exists(basename + "_TEST.%s" % ext))
 
     def cache_all(self):
-        """Cache all datasets from the UCR/UEA archive for later 
-        use.
-        """
+        """Cache all datasets from the UCR/UEA archive for later use."""
         for dataset_name in self.list_datasets():
             try:
                 self.load_dataset(dataset_name)
-            except:
+            except Exception:
                 sys.stderr.write("Could not cache dataset %s properly.\n"
                                  % dataset_name)
 

--- a/tslearn/datasets.py
+++ b/tslearn/datasets.py
@@ -216,7 +216,7 @@ class UCR_UEA_datasets:
         Returns
         -------
         list of str:
-            A list of the names of all univariate dataset namas.
+            A list of the names of all univariate datasets.
         """
         with open(self._baseline_scores_filename, "r") as f:
             return [

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -1417,8 +1417,7 @@ class LabelCategorizer(TransformerMixin, TimeSeriesBaseEstimator):
 
 
 def _load_arff_uea(dataset_path):
-    """
-    Load arff file for uni/multi variate dataset
+    """Load arff file for uni/multi variate dataset
     
     Parameters
     ----------
@@ -1431,6 +1430,12 @@ def _load_arff_uea(dataset_path):
         Time series dataset
     y: numpy array of shape (n_timeseries, )
         Vector of targets
+
+    Raises
+    ------
+    ImportError: if the version of *Scipy* is too old (pre 1.3.0)
+    Exception: on any failure, e.g. if the given file does not exist or is
+               corrupted
     """
     if not HAS_ARFF:
         raise ImportError("scipy 1.3.0 or newer is required to load "
@@ -1466,13 +1471,12 @@ def _load_arff_uea(dataset_path):
 
 
 def _load_txt_uea(dataset_path):
-    """
-    Load arff file for uni/multi variate dataset
-    
+    """Load arff file for uni/multi variate dataset
+
     Parameters
     ----------
     dataset_path: string of dataset_path
-        Path to the ARFF file to be read
+        Path to the TXT file to be read
 
     Returns
     -------
@@ -1480,11 +1484,13 @@ def _load_txt_uea(dataset_path):
         Time series dataset
     y: numpy array of shape (n_timeseries, )
         Vector of targets
+
+    Raises
+    ------
+    Exception: on any failure, e.g. if the given file does not exist or is
+               corrupted
     """
-    try:
-        data = numpy.loadtxt(dataset_path, delimiter=None)
-        X = to_time_series_dataset(data[:, 1:])
-        y = data[:, 0].astype(numpy.int)
-        return X, y
-    except:
-        return None, None
+    data = numpy.loadtxt(dataset_path)
+    X = to_time_series_dataset(data[:, 1:])
+    y = data[:, 0].astype(numpy.int)
+    return X, y


### PR DESCRIPTION
This PR improves the documentation (inline and user facing) around `UCR_UEA_datasets.load_dataset()` and prints more specific error messages. Also properly closes all file descriptors after use & actually respect the `use_cached=False` case in `UCR_UEA_datasets.load_dataset()`.

It also uses the `warnings` module for ... warnings. The rationale for that was: (1) more helpful error messages due to the included stack trace excerpt and (2) the possibility to selectively disable such warnings in user or library code. AFAIK, that's what libraries like numpy do as well, instead of raw `sys.stderr.write()`. As I've just seen, this also seems to be the only place where that was used instead of the `warnings` module so maybe it was more of a residue.

Developed as part of debugging #282 and replaces #297