### PR TITLE
[WIP] Add link to GitHub Code in the documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -175,7 +175,7 @@ html_theme_options = {
         ("API", "reference"),
         ("Examples", "auto_examples/index"),
         ("Citing tslearn", "citing"),
-        ("Code on GitHub", "https://github.com/tslearn-team/tslearn"),
+        ("Code on GitHub", "https://github.com/tslearn-team/tslearn/", True),
     ],
 
     # Render the next and previous page links in navbar. (Default: true)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -175,6 +175,7 @@ html_theme_options = {
         ("API", "reference"),
         ("Examples", "auto_examples/index"),
         ("Citing tslearn", "citing"),
+        ("Code on GitHub", "https://github.com/tslearn-team/tslearn"),
     ],
 
     # Render the next and previous page links in navbar. (Default: true)


### PR DESCRIPTION
Now that the doc is front and center on Google it became slightly hard for geeks to reach the Code of tslearn.

I added a button at the top of the documentation that links toward the github page for tslearn.