### PR TITLE
Modernize utils package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ tmp-tslearn-test.txt
 docs/_build/
 docs/auto_examples/
 docs/examples/misc/ks_trained.hdf5
+docs/gen_modules/*/

--- a/tslearn/cycc.pyx
+++ b/tslearn/cycc.pyx
@@ -1,7 +1,6 @@
 STUFF_cycc = "cycc"
 
 import numpy
-from tslearn.utils import bit_length
 
 cimport numpy
 cimport cython
@@ -21,9 +20,8 @@ def normalized_cc(numpy.ndarray[DTYPE_t, ndim=2] s1, numpy.ndarray[DTYPE_t, ndim
     cdef DTYPE_t s = 0.
     cdef int sz = s1.shape[0]
     cdef int d = s1.shape[1]
-    # Compute fft size based on tip from
-    # https://stackoverflow.com/questions/14267555/how-can-i-find-the-smallest-power-of-2-greater-than-n-in-python
-    cdef int fft_sz = 1 << bit_length(2 * sz - 1)
+    # Compute fft size based on tip from https://stackoverflow.com/questions/14267555/
+    cdef int fft_sz = 1 << (2 * sz - 1).bit_length()
     cdef float denom = 0.
     cdef numpy.ndarray[DTYPE_t, ndim=2] cc
 

--- a/tslearn/hdftools.py
+++ b/tslearn/hdftools.py
@@ -39,7 +39,7 @@ def save_dict(d, filename, group, raise_type_fail=True):
         the argument `raise_type_fail` is set to `True`
     """
     if os.path.isfile(filename):
-        raise FileExistsError
+        raise FileExistsError()
 
     with h5py.File(filename, 'w') as h5file:
         _dicts_to_group(h5file, "{}/".format(group), d,

--- a/tslearn/hdftools.py
+++ b/tslearn/hdftools.py
@@ -39,7 +39,7 @@ def save_dict(d, filename, group, raise_type_fail=True):
         the argument `raise_type_fail` is set to `True`
     """
     if os.path.isfile(filename):
-        raise FileExistsError()
+        raise FileExistsError
 
     with h5py.File(filename, 'w') as h5file:
         _dicts_to_group(h5file, "{}/".format(group), d,

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -363,7 +363,7 @@ def save_time_series_txt(fname, dataset, fmt="%.18e"):
     """
     with open(fname, "w") as f:
         for ts in dataset:
-            f.write(time_series_to_str(ts, fmt=fmt) + os.linesep)
+            f.write(time_series_to_str(ts, fmt=fmt) + "\n")
 
 
 save_timeseries_txt = save_time_series_txt
@@ -393,7 +393,10 @@ def load_time_series_txt(fname):
     save_time_series_txt : Save time series to disk
     """
     with open(fname, "r") as f:
-        return to_time_series_dataset(str_to_time_series(f.read()))
+        return to_time_series_dataset([
+            str_to_time_series(row)
+            for row in f.readlines()
+        ])
 
 
 load_timeseries_txt = load_time_series_txt
@@ -458,10 +461,12 @@ def ts_size(ts):
     ...          [numpy.nan, 2],
     ...          [numpy.nan, numpy.nan]])
     4
+    >>> ts_size([numpy.nan, 3, numpy.inf, numpy.nan])
+    3
     """
     ts_ = to_time_series(ts)
     sz = ts_.shape[0]
-    while sz > 0 and not numpy.any(numpy.isfinite(ts_[sz - 1])):
+    while sz > 0 and numpy.all(numpy.isnan(ts_[sz - 1])):
         sz -= 1
     return sz
 

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -172,7 +172,8 @@ def to_time_series_dataset(dataset, dtype=numpy.float):
     Parameters
     ----------
     dataset : array-like
-        The dataset of time series to be transformed.
+        The dataset of time series to be transformed. A single time series will
+        be automatically wrapped into a dataset with a single entry.
     dtype : data type (default: numpy.float)
         Data type for the returned dataset.
 
@@ -186,6 +187,9 @@ def to_time_series_dataset(dataset, dtype=numpy.float):
     >>> to_time_series_dataset([[1, 2]])
     array([[[1.],
             [2.]]])
+    >>> to_time_series_dataset([1, 2])
+    array([[[1.],
+            [2.]]])
     >>> to_time_series_dataset([[1, 2], [1, 4, 3]])
     array([[[ 1.],
             [ 2.],
@@ -194,6 +198,8 @@ def to_time_series_dataset(dataset, dtype=numpy.float):
            [[ 1.],
             [ 4.],
             [ 3.]]])
+    >>> to_time_series_dataset([]).shape
+    (0, 0, 0)
 
     See Also
     --------
@@ -421,6 +427,8 @@ def check_equal_size(dataset):
     True
     >>> check_equal_size([[1, 2, 3, 4], [4, 5, 6], [5, 3, 2]])
     False
+    >>> check_equal_size([])
+    True
     """
     dataset_ = to_time_series_dataset(dataset)
     if len(dataset_) == 0:

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -393,10 +393,7 @@ def load_time_series_txt(fname):
     save_time_series_txt : Save time series to disk
     """
     with open(fname, "r") as f:
-        return to_time_series_dataset([
-            str_to_time_series(row)
-            for row in f.readlines()
-        ])
+        return to_time_series_dataset(str_to_time_series(f.read()))
 
 
 load_timeseries_txt = load_time_series_txt


### PR DESCRIPTION
Modernizes the `tslearn.utils` module by removing code that was kept for Python versions that do not exist any more and using generator expressions and mainly simpler code in many places.


I also benchmarked the replacement for `time_series_to_str()`:
```python
# NEW:
>>> timeit(setup='import numpy as np;from io import StringIO;x = np.linspace(0,10,100); x=np.array((x,x,x))',stmt='i=StringIO();np.savetxt(i, x.T, fmt="%.18e", newline="|",encoding="bytes");s=i.getvalue()[:-1]', number=10000)
4.755633597000269

# OLD:
# already improved version with generators before complete replacement
>>> timeit(setup='import numpy as np;from tslearn.utils import time_series_to_str;x = np.linspace(0,10,100); x=np.array((x,x,x))',stmt='time_series_to_str(x)', number=10000)
4.712957062001806
```

And for `str_to_time_series()`:
```python
# NEW
timeit(setup='import numpy as np;from io import StringIO,BytesIO;from tslearn.utils import time_series_to_str,str_to_time_series,to_time_series;x = np.linspace(0,10,100); x=np.array((x,x,x));s=time_series_to_str(x)',stmt='dimensions = s.split("|");ts = [np.fromstring(dim_str, sep=" ") for dim_str in dimensions];to_time_series(np.transpose(ts))', number=10000)
2.6836724650056567

# OLD
timeit(setup='import numpy as np;from tslearn.utils import time_series_to_str,str_to_time_series;x = np.linspace(0,10,100); x=np.array((x,x,x));s=time_series_to_str(x)',stmt='str_to_time_series(s)', number=10000)
3.1848444619972724
```

I pointed this PR at the `subfolders` branch, is this correct?

I will get the CI to work and only then remove the `[DRAFT]` prefix from the title.