### PR TITLE
Remove unnecessary helper method _arraylike_copy() from utils

### DIFF
--- a/tslearn/tests/test_utils.py
+++ b/tslearn/tests/test_utils.py
@@ -15,12 +15,6 @@ __author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
 EXAMPLE_FILE = join(gettempdir(), "tslearn_pytest_file.txt")
 
 
-def test_arraylike_copy():
-    X_npy = np.array([1, 2, 3])
-    assert_allclose(tslearn.utils._arraylike_copy(X_npy), X_npy)
-    assert_allclose(tslearn.utils._arraylike_copy(X_npy) is X_npy, False)
-
-
 def test_save_load_random():
     n, sz, d = 15, 10, 3
     rng = np.random.RandomState(0)

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -149,7 +149,8 @@ def to_time_series(ts, remove_nans=False):
     Returns
     -------
     numpy.ndarray of shape (sz, d)
-        The transformed time series.
+        The transformed time series. This is always guaraneteed to be a new
+        time series and never just a view into the old one.
 
     Examples
     --------
@@ -168,7 +169,7 @@ def to_time_series(ts, remove_nans=False):
     --------
     to_time_series_dataset : Transforms a dataset of time series
     """
-    ts_out = numpy.array(ts)
+    ts_out = numpy.array(ts, copy=True)
     if ts_out.ndim <= 1:
         ts_out = ts_out.reshape((-1, 1))
     if ts_out.dtype != numpy.float:

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -110,15 +110,6 @@ def check_dims(X, X_fit_dims=None, extend=True, check_n_features_only=False):
     return X
 
 
-def _arraylike_copy(arr):
-    """Duplicate content of arr into a numpy array.
-     """
-    if type(arr) != numpy.ndarray:
-        return numpy.array(arr)
-    else:
-        return arr.copy()
-
-
 def bit_length(n):
     """Returns the number of bits necessary to represent an integer in binary,
     excluding the sign and leading zeros.
@@ -177,7 +168,7 @@ def to_time_series(ts, remove_nans=False):
     --------
     to_time_series_dataset : Transforms a dataset of time series
     """
-    ts_out = _arraylike_copy(ts)
+    ts_out = numpy.array(ts, copy=True)
     if ts_out.ndim <= 1:
         ts_out = ts_out.reshape((-1, 1))
     if ts_out.dtype != numpy.float:

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -168,7 +168,7 @@ def to_time_series(ts, remove_nans=False):
     --------
     to_time_series_dataset : Transforms a dataset of time series
     """
-    ts_out = numpy.array(ts, copy=True)
+    ts_out = numpy.array(ts)
     if ts_out.ndim <= 1:
         ts_out = ts_out.reshape((-1, 1))
     if ts_out.dtype != numpy.float:


### PR DESCRIPTION
The helper method `_arraylike_copy(thing)` can be easily replaced by `numpy.array(thing, copy=True)`. It was only used in `to_time_series()`. The docstring now explicitly says that `to_time_series()` always returns a *copy*.