### PR TITLE
Update CI images and tools

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
     OMP_NUM_THREADS: '2'
     NUMBA_NUM_THREADS: '2'
     PIP_PREFER_BINARY: 'true'
-  
+
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -45,61 +45,22 @@ jobs:
   
   - script: |
       set -xe
-      python -m pip install pytest pytest-azurepipelines
+      python -m pip install pytest pytest-azurepipelines coverage==4.3 "pytest-cov<2.6"
       if [[ "$(python.version)" == '3.5' ]];
       then
-        python -m pytest -v tslearn/ --doctest-modules --ignore tslearn/deprecated.py -k 'not test_all_estimators';
+        python -m pytest -v tslearn/ --doctest-modules --cov=tslearn --ignore tslearn/deprecated.py -k 'not test_all_estimators';
       else
-        python -m pytest -v tslearn/ --doctest-modules --ignore tslearn/deprecated.py;
+        python -m pytest -v tslearn/ --doctest-modules --cov=tslearn --ignore tslearn/deprecated.py;
       fi
     displayName: 'Test'
 
-- job: 'codecov'
-  pool:
-    vmImage: 'ubuntu-latest'
-  strategy:
-    matrix:
-      Python39:
-        python.version: '3.9'
-  variables:
-    OMP_NUM_THREADS: '2'
-    NUMBA_NUM_THREADS: '2'
-    NUMBA_DISABLE_JIT: '1'
-    PIP_PREFER_BINARY: 'true'
-
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '$(python.version)'
-    displayName: 'Use Python $(python.version)'
-
-  - script: |
-      set -xe
-      python --version
-      python -m pip install --upgrade pip
-      python -m pip install -r requirements.txt
-    displayName: 'Install dependencies'
-
-  - script: |
-      set -xe
-      pip install -e .
-    displayName: 'Install tslearn'
-
-  - script: |
-      set -xe
-      python -m pip install pytest pytest-azurepipelines
-      pip install coverage==4.3 "pytest-cov<2.6"
-      pip install cesium pandas stumpy
-      python -m pytest -v tslearn/ --doctest-modules --ignore tslearn/deprecated.py --cov=tslearn
-    displayName: 'Test'
-
-  # Upload coverage to codecov.io
-  - script: |
-      bash <(curl -s https://codecov.io/bash) -v
-    displayName: 'Upload coverage to codecov.io'
+    # Upload coverage to codecov.io
+    - script: |
+        bash <(curl -s https://codecov.io/bash) -v
+      displayName: 'Upload coverage to codecov.io'
 
 
-- job: 'macOS1015'
+- job: 'macOS'
   pool:
     vmImage: 'macOS-latest'
   strategy:
@@ -144,7 +105,7 @@ jobs:
     displayName: 'Test'
 
 
-- job: 'win2016'
+- job: 'windows'
   pool:
     vmImage: 'windows-latest'
   strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,7 +102,7 @@ jobs:
 
 - job: 'macOS'
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-latest'
   strategy:
     matrix:
       Python35:
@@ -147,7 +147,7 @@ jobs:
 
 - job: 'windows'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-latest'
   strategy:
     matrix:
       Python35:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,7 +61,7 @@ jobs:
   strategy:
     matrix:
       Python39:
-        python.version: '3.8'
+        python.version: '3.9'
   variables:
     OMP_NUM_THREADS: '2'
     NUMBA_NUM_THREADS: '2'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,8 +18,6 @@ jobs:
         python.version: '3.7'
       Python38:
         python.version: '3.8'
-      #Python39:
-      #  python.version: '3.9'
   variables:
     OMP_NUM_THREADS: '2'
     NUMBA_NUM_THREADS: '2'
@@ -60,7 +58,7 @@ jobs:
     vmImage: 'ubuntu-latest'
   strategy:
     matrix:
-      Python38:  # TODO: bump
+      Python38:
         python.version: '3.8'
   variables:
     OMP_NUM_THREADS: '2'
@@ -113,8 +111,6 @@ jobs:
         python.version: '3.7'
       Python38:
         python.version: '3.8'
-      #Python39:
-      #  python.version: '3.9'
   variables:
     OMP_NUM_THREADS: '2'
     NUMBA_NUM_THREADS: '2'
@@ -162,9 +158,6 @@ jobs:
       Python38:
         python_ver: '38'
         python.version: '3.8'
-      #Python39:
-      #  python_ver: '39'
-      #  python.version: '3.9'
   variables:
     OMP_NUM_THREADS: '2'
     NUMBA_NUM_THREADS: '2'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,19 +45,56 @@ jobs:
   
   - script: |
       set -xe
-      python -m pip install pytest pytest-azurepipelines coverage==4.3 "pytest-cov<2.6"
+      python -m pip install pytest pytest-azurepipelines
       if [[ "$(python.version)" == '3.5' ]];
       then
-        python -m pytest -v tslearn/ --doctest-modules --cov=tslearn --ignore tslearn/deprecated.py -k 'not test_all_estimators';
+        python -m pytest -v tslearn/ --doctest-modules --ignore tslearn/deprecated.py -k 'not test_all_estimators';
       else
-        python -m pytest -v tslearn/ --doctest-modules --cov=tslearn --ignore tslearn/deprecated.py;
+        python -m pytest -v tslearn/ --doctest-modules --ignore tslearn/deprecated.py;
       fi
     displayName: 'Test'
 
-    # Upload coverage to codecov.io
-    - script: |
-        bash <(curl -s https://codecov.io/bash) -v
-      displayName: 'Upload coverage to codecov.io'
+
+- job: 'codecov'  # must be a separate job to only disable Numbas's JIT here
+  pool:
+    vmImage: 'ubuntu-latest'
+  strategy:
+    matrix:
+      Python39:
+        python.version: '3.8'
+  variables:
+    OMP_NUM_THREADS: '2'
+    NUMBA_NUM_THREADS: '2'
+    NUMBA_DISABLE_JIT: '1'  # special for coverage testing
+    PIP_PREFER_BINARY: 'true'
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+    displayName: 'Use Python $(python.version)'
+
+  - script: |
+      set -xe
+      python --version
+      python -m pip install --upgrade pip
+      python -m pip install -r requirements.txt
+    displayName: 'Install dependencies'
+  - script: |
+      set -xe
+      pip install -e .
+    displayName: 'Install tslearn'
+  - script: |
+      set -xe
+      python -m pip install pytest pytest-azurepipelines
+      pip install coverage pytest-cov
+      pip install cesium pandas stumpy;
+      python -m pytest -v tslearn/ --doctest-modules --ignore tslearn/deprecated.py --cov=tslearn;
+    displayName: 'Test'
+  # Upload coverage to codecov.io
+  - script: |
+      bash <(curl -s https://codecov.io/bash) -v
+    displayName: 'Upload coverage to codecov.io'
 
 
 - job: 'macOS'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,8 @@ jobs:
         python.version: '3.7'
       Python38:
         python.version: '3.8'
+      Python39:
+        python.version: '3.9'
   variables:
     OMP_NUM_THREADS: '2'
     NUMBA_NUM_THREADS: '2'
@@ -58,7 +60,7 @@ jobs:
   strategy:
     matrix:
       Python37:
-        python.version: '3.7'
+        python.version: '3.9'
   variables:
     OMP_NUM_THREADS: '2'
     NUMBA_NUM_THREADS: '2'
@@ -110,6 +112,8 @@ jobs:
         python.version: '3.7'
       Python38:
         python.version: '3.8'
+      Python39:
+        python.version: '3.9'
   variables:
     OMP_NUM_THREADS: '2'
     NUMBA_NUM_THREADS: '2'
@@ -157,6 +161,9 @@ jobs:
       Python38:
         python_ver: '38'
         python.version: '3.8'
+      Python39:
+        python_ver: '39'
+        python.version: '3.9'
   variables:
     OMP_NUM_THREADS: '2'
     NUMBA_NUM_THREADS: '2'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,7 @@ jobs:
     vmImage: 'ubuntu-latest'
   strategy:
     matrix:
-      Python37:
+      Python39:
         python.version: '3.9'
   variables:
     OMP_NUM_THREADS: '2'
@@ -88,9 +88,9 @@ jobs:
   - script: |
       set -xe
       python -m pip install pytest pytest-azurepipelines
-      pip install coverage==4.3 "pytest-cov<2.6";
-      pip install cesium pandas stumpy;
-      python -m pytest -v tslearn/ --doctest-modules --ignore tslearn/deprecated.py --cov=tslearn;
+      pip install coverage==4.3 "pytest-cov<2.6"
+      pip install cesium pandas stumpy
+      python -m pytest -v tslearn/ --doctest-modules --ignore tslearn/deprecated.py --cov=tslearn
     displayName: 'Test'
 
   # Upload coverage to codecov.io
@@ -99,9 +99,9 @@ jobs:
     displayName: 'Upload coverage to codecov.io'
 
 
-- job: 'macOS1014'
+- job: 'macOS1015'
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-latest'
   strategy:
     matrix:
       Python35:
@@ -146,7 +146,7 @@ jobs:
 
 - job: 'win2016'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-latest'
   strategy:
     matrix:
       Python35:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,8 +90,8 @@ jobs:
       set -xe
       python -m pip install pytest pytest-azurepipelines
       pip install coverage pytest-cov
-      pip install cesium pandas stumpy;
-      python -m pytest -v tslearn/ --doctest-modules --ignore tslearn/deprecated.py --cov=tslearn;
+      pip install cesium pandas stumpy
+      python -m pytest -v tslearn/ --doctest-modules --ignore tslearn/deprecated.py --cov=tslearn
     displayName: 'Test'
 
   # Upload coverage to codecov.io

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,8 +60,8 @@ jobs:
     vmImage: 'ubuntu-latest'
   strategy:
     matrix:
-      Python39:
-        python.version: '3.9'
+      Python38:  # TODO: bump
+        python.version: '3.8'
   variables:
     OMP_NUM_THREADS: '2'
     NUMBA_NUM_THREADS: '2'
@@ -80,10 +80,12 @@ jobs:
       python -m pip install --upgrade pip
       python -m pip install -r requirements.txt
     displayName: 'Install dependencies'
+
   - script: |
       set -xe
       pip install -e .
     displayName: 'Install tslearn'
+
   - script: |
       set -xe
       python -m pip install pytest pytest-azurepipelines
@@ -91,6 +93,7 @@ jobs:
       pip install cesium pandas stumpy;
       python -m pytest -v tslearn/ --doctest-modules --ignore tslearn/deprecated.py --cov=tslearn;
     displayName: 'Test'
+
   # Upload coverage to codecov.io
   - script: |
       bash <(curl -s https://codecov.io/bash) -v

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,8 +18,8 @@ jobs:
         python.version: '3.7'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
+      #Python39:
+      #  python.version: '3.9'
   variables:
     OMP_NUM_THREADS: '2'
     NUMBA_NUM_THREADS: '2'
@@ -73,8 +73,8 @@ jobs:
         python.version: '3.7'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
+      #Python39:
+      #  python.version: '3.9'
   variables:
     OMP_NUM_THREADS: '2'
     NUMBA_NUM_THREADS: '2'
@@ -122,9 +122,9 @@ jobs:
       Python38:
         python_ver: '38'
         python.version: '3.8'
-      Python39:
-        python_ver: '39'
-        python.version: '3.9'
+      #Python39:
+      #  python_ver: '39'
+      #  python.version: '3.9'
   variables:
     OMP_NUM_THREADS: '2'
     NUMBA_NUM_THREADS: '2'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,7 +102,7 @@ jobs:
 
 - job: 'macOS'
   pool:
-    vmImage: 'macOS-latest'
+    vmImage: 'macOS-10.14'
   strategy:
     matrix:
       Python35:
@@ -147,7 +147,7 @@ jobs:
 
 - job: 'windows'
   pool:
-    vmImage: 'windows-latest'
+    vmImage: 'vs2017-win2016'
   strategy:
     matrix:
       Python35:


### PR DESCRIPTION
Also test on python version 3.9 and updates some VM images to their newest version. This way, we will find bugs in our repository CI arising from incompatibility with newer versions, before users will complain.

**EDIT:** This only updates the tools and not the python version to 3.9, which will be tracked in a separate issue (#322) as it is not ready to use for now.