### PR TITLE
Update kmeans.py

### DIFF
--- a/tslearn/clustering/kmeans.py
+++ b/tslearn/clustering/kmeans.py
@@ -2,7 +2,7 @@ from sklearn.base import ClusterMixin, TransformerMixin
 from sklearn.metrics.pairwise import pairwise_kernels
 try:
     # Most recent
-    from sklearn.cluster._k_means import _k_init
+    from sklearn.cluster._kmeans import _k_init
 except ImportError:
     # Deprecated from sklearn v0.24 onwards
     from sklearn.cluster.k_means_ import _k_init


### PR DESCRIPTION
I don't understand this line, sklearn.cluster._k_means doesn't exist in sklearn 0.24, and _kmeans doesn't have _k_init...