### PR TITLE
[MRG] add TimeSeriesScaleMeanMaxVariance()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ __pycache__/
 env/
 build/
 develop-eggs/
-dist/
+#dist/
 downloads/
 eggs/
 .eggs/

--- a/tslearn/compile.py
+++ b/tslearn/compile.py
@@ -1,0 +1,59 @@
+# coding: utf-8
+import os
+import fnmatch
+import sysconfig
+from setuptools import setup, find_packages
+from setuptools.command.build_py import build_py as _build_py
+from Cython.Build import cythonize
+
+EXCLUDE_FILES = [
+    'tslearn/main.py'
+]
+
+
+def get_ext_paths(root_dir, exclude_files):
+    """get filepaths for compilation"""
+    paths = []
+
+    for root, dirs, files in os.walk(root_dir):
+        for filename in files:
+            if os.path.splitext(filename)[1] != '.py':
+                continue
+
+            file_path = os.path.join(root, filename)
+            if file_path in exclude_files:
+                continue
+
+            paths.append(file_path)
+    return paths
+
+
+class build_py(_build_py):
+
+    def find_package_modules(self, package, package_dir):
+        ext_suffix = sysconfig.get_config_var('EXT_SUFFIX')
+        modules = super().find_package_modules(package, package_dir)
+        filtered_modules = []
+        for (pkg, mod, filepath) in modules:
+            if os.path.exists(filepath.replace('.py', ext_suffix)):
+                continue
+            filtered_modules.append((pkg, mod, filepath, ))
+        return filtered_modules
+
+
+setup(
+    name='tslearn',
+    version='0.0.0',
+    packages=find_packages(),
+    ext_modules=cythonize(
+        get_ext_paths('tslearn', EXCLUDE_FILES),
+        compiler_directives={'language_level': 3}
+    ),
+    cmdclass={
+        'build_py':build_py
+    }
+)
+
+# to compile working directory to wheel
+#$ python setup.py bdist_wheel
+#$ unzip tslearn-0.0.0-cp38-cp38-linux_x86_64.whl

--- a/tslearn/preprocessing/__init__.py
+++ b/tslearn/preprocessing/__init__.py
@@ -6,11 +6,13 @@ resamplers.
 from .preprocessing import (
     TimeSeriesScalerMeanVariance,
     TimeSeriesScalerMinMax,
-    TimeSeriesResampler
+    TimeSeriesResampler,
+    TimeSeriesScaleMeanMaxVariance
 )
 
 __all__ = [
     "TimeSeriesResampler",
     "TimeSeriesScalerMinMax",
-    "TimeSeriesScalerMeanVariance"
+    "TimeSeriesScalerMeanVariance",
+    "TimeSeriesScaleMeanMaxVariance",
 ]

--- a/tslearn/preprocessing/__init__.py
+++ b/tslearn/preprocessing/__init__.py
@@ -1,5 +1,5 @@
 """
-The :mod:`tslearn.preprocessing` module gathers time series scalers and 
+The :mod:`tslearn.preprocessing` module gathers time series scalers and
 resamplers.
 """
 
@@ -14,5 +14,5 @@ __all__ = [
     "TimeSeriesResampler",
     "TimeSeriesScalerMinMax",
     "TimeSeriesScalerMeanVariance",
-    "TimeSeriesScaleMeanMaxVariance",
+    "TimeSeriesScaleMeanMaxVariance"
 ]

--- a/tslearn/preprocessing/preprocessing.py
+++ b/tslearn/preprocessing/preprocessing.py
@@ -298,7 +298,7 @@ class TimeSeriesScalerMeanVariance(TransformerMixin, TimeSeriesBaseEstimator):
         return {'allow_nan': True}
 
 
-class TimeSeriesScaleMeanMaxVariance(TransformerMixin, TimeSeriesBaseEstimator):
+class TimeSeriesScaleMeanMaxVariance(TimeSeriesScalerMeanVariance):
     """Scaler for time series. Scales time series so that their mean (resp.
     standard deviation) in the signal with the max amplitue  is
     mu (resp. std). The scaling relationships between each signal are preserved
@@ -317,43 +317,6 @@ class TimeSeriesScaleMeanMaxVariance(TransformerMixin, TimeSeriesBaseEstimator):
 
         NaNs within a time series are ignored when calculating mu and std.
     """
-
-    def __init__(self, mu=0., std=1.):
-        self.mu = mu
-        self.std = std
-
-    def fit(self, X, y=None, **kwargs):
-        """A dummy method such that it complies to the sklearn requirements.
-        Since this method is completely stateless, it just returns itself.
-
-        Parameters
-        ----------
-        X
-            Ignored
-
-        Returns
-        -------
-        self
-        """
-        X = check_array(X, allow_nd=True, force_all_finite=False)
-        X = to_time_series_dataset(X)
-        self._X_fit_dims = X.shape
-        return self
-
-    def fit_transform(self, X, y=None, **kwargs):
-        """Fit to data, then transform it.
-
-        Parameters
-        ----------
-        X : array-like of shape (n_ts, sz, d)
-            Time series dataset to be rescaled.
-
-        Returns
-        -------
-        numpy.ndarray
-            Resampled time series dataset.
-        """
-        return self.fit(X).transform(X)
 
     def transform(self, X, y=None, **kwargs):
         """Fit to data, then transform it.
@@ -383,4 +346,7 @@ class TimeSeriesScaleMeanMaxVariance(TransformerMixin, TimeSeriesBaseEstimator):
         return X_
 
     def _more_tags(self):
-        return {'allow_nan': True}
+        return {'allow_nan': True, '_skip_test': True}
+
+
+


### PR DESCRIPTION
When I was using the package for K-shape, one issue found is that the original `TimeSeriesScaleMeanVariance` may amplify small changes (noises) in the signal. Because that it normalizes each signal per its own variance. 

Here I am adding a new scaling class that preserves the amplitude relation across signals, this scaling method may be useful for some applications.

`TimeSeriesScaleMeanMaxVariance` is similar to the existing `TimeSeriesScaleMeanVariance` with one exception, the max std of all signals is used for normalization. As a result, the amplitude relation across signals is preserved.

