### PR TITLE
Fixed bug in dtw_path when one input is all nans or with empty length

### DIFF
--- a/docs/requirements_rtd.txt
+++ b/docs/requirements_rtd.txt
@@ -12,5 +12,5 @@ tensorflow>=2
 Pygments
 numba
 sphinx_bootstrap_theme
-git+git://github.com/numpy/numpydoc@master
+git+git://github.com/numpy/numpydoc@main
 matplotlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy", "Cython"]
+requires = ["setuptools", "wheel", "numpy<=1.19", "Cython"]

--- a/tslearn/__init__.py
+++ b/tslearn/__init__.py
@@ -1,7 +1,7 @@
 import os
 
 __author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
-__version__ = "0.5.0.4"
+__version__ = "0.5.0.5"
 __bibtex__ = r"""@article{JMLR:v21:20-091,
   author  = {Romain Tavenard and Johann Faouzi and Gilles Vandewiele and
              Felix Divo and Guillaume Androz and Chester Holtz and

--- a/tslearn/metrics/dtw_variants.py
+++ b/tslearn/metrics/dtw_variants.py
@@ -190,7 +190,7 @@ def dtw_path(s1, s2, global_constraint=None, sakoe_chiba_radius=None,
     s2 = to_time_series(s2, remove_nans=True)
 
     if len(s1) == 0 or len(s2) == 0:
-        raise ValueError("One of the input time series contains only nans or has empty length.")
+        raise ValueError("One of the input time series contains only nans or has zero length.")
 
     mask = compute_mask(
         s1, s2, GLOBAL_CONSTRAINT_CODE[global_constraint],

--- a/tslearn/metrics/dtw_variants.py
+++ b/tslearn/metrics/dtw_variants.py
@@ -189,6 +189,9 @@ def dtw_path(s1, s2, global_constraint=None, sakoe_chiba_radius=None,
     s1 = to_time_series(s1, remove_nans=True)
     s2 = to_time_series(s2, remove_nans=True)
 
+    if len(s1) == 0 or len(s2) == 0:
+        raise ValueError("One of the input time series contains only nans or has empty length.")
+
     mask = compute_mask(
         s1, s2, GLOBAL_CONSTRAINT_CODE[global_constraint],
         sakoe_chiba_radius, itakura_max_slope

--- a/tslearn/tests/test_metrics.py
+++ b/tslearn/tests/test_metrics.py
@@ -435,9 +435,9 @@ def test_dtw_path_with_empty_or_nan_inputs():
     s2_empty = np.zeros((0, 10))
     with pytest.raises(ValueError) as excinfo:
         dtw_path(s1, s2_empty)
-    assert str(excinfo.value) == "One of the input time series contains only nans or has empty length."
+    assert str(excinfo.value) == "One of the input time series contains only nans or has zero length."
 
     s2_nan = np.full((3, 10), np.nan)
     with pytest.raises(ValueError) as excinfo:
         dtw_path(s1, s2_nan)
-    assert str(excinfo.value) == "One of the input time series contains only nans or has empty length."
+    assert str(excinfo.value) == "One of the input time series contains only nans or has zero length."

--- a/tslearn/tests/test_metrics.py
+++ b/tslearn/tests/test_metrics.py
@@ -1,8 +1,10 @@
+import pytest
 import numpy as np
 from scipy.spatial.distance import cdist
 import tslearn.metrics
 import tslearn.clustering
 from tslearn.utils import to_time_series
+from tslearn.metrics.dtw_variants import dtw_path
 
 __author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
 
@@ -426,3 +428,16 @@ def test_softdtw():
 
     np.testing.assert_equal(dist, dist_ref ** 2)
     np.testing.assert_allclose(matrix_path, mat_path_ref)
+
+
+def test_dtw_path_with_empty_or_nan_inputs():
+    s1 = np.zeros((3, 10))
+    s2_empty = np.zeros((0, 10))
+    with pytest.raises(ValueError) as excinfo:
+        dtw_path(s1, s2_empty)
+    assert str(excinfo.value) == "One of the input time series contains only nans or has empty length."
+
+    s2_nan = np.full((3, 10), np.nan)
+    with pytest.raises(ValueError) as excinfo:
+        dtw_path(s1, s2_nan)
+    assert str(excinfo.value) == "One of the input time series contains only nans or has empty length."


### PR DESCRIPTION
This pull request fixes #354 and raises a ValueError when one input of dtw_path is an empty sequence or is a only nans sequence. The root of the bug is the numba.njit decorated function `_return_path`, however the numba documentation states that `raise` construct is partially supported inside njit decorated function.

I also added a test to ensure that this issue would never occur.