### PR TITLE
Attempt to fix Cython errors in recent builds

### DIFF
--- a/docs/requirements_rtd.txt
+++ b/docs/requirements_rtd.txt
@@ -1,6 +1,6 @@
 Cython
-numpy==1.19.5
-scipy==1.4.1
+numpy
+scipy
 scikit-learn
 numba
 sphinx>=1.6.1

--- a/docs/requirements_rtd.txt
+++ b/docs/requirements_rtd.txt
@@ -1,6 +1,6 @@
 Cython
-numpy
-scipy
+numpy==1.19.5
+scipy==1.4.1
 scikit-learn
 numba
 sphinx>=1.6.1
@@ -12,5 +12,5 @@ tensorflow>=2
 Pygments
 numba
 sphinx_bootstrap_theme
-git+git://github.com/numpy/numpydoc@master
+git+git://github.com/numpy/numpydoc@main
 matplotlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy", "Cython"]
+requires = ["setuptools", "wheel", "numpy==1.19", "Cython"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy==1.19", "Cython"]
+requires = ["setuptools", "wheel", "numpy<=1.19", "Cython"]

--- a/tslearn/__init__.py
+++ b/tslearn/__init__.py
@@ -1,7 +1,7 @@
 import os
 
 __author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
-__version__ = "0.5.0.4"
+__version__ = "0.5.0.5"
 __bibtex__ = r"""@article{JMLR:v21:20-091,
   author  = {Romain Tavenard and Johann Faouzi and Gilles Vandewiele and
              Felix Divo and Guillaume Androz and Chester Holtz and


### PR DESCRIPTION
This implements:

* https://github.com/scikit-learn-contrib/hdbscan/issues/457#issuecomment-832706637
* also numpydoc has renamed its `master` to `main`, so this has to be updated accordingly

Behavior discovered in #355 