### PR TITLE
Fix deprecation warning for np array

### DIFF
--- a/tslearn/barycenters/softdtw.py
+++ b/tslearn/barycenters/softdtw.py
@@ -100,7 +100,7 @@ def softdtw_barycenter(X, gamma=1.0, weights=None, method="L-BFGS-B", tol=1e-3,
         barycenter = init
 
     if max_iter > 0:
-        X_ = numpy.array([to_time_series(d, remove_nans=True) for d in X_])
+        X_ = numpy.array([to_time_series(d, remove_nans=True) for d in X_],dtype=object)
 
         def f(Z):
             return _softdtw_func(Z, X_, weights, barycenter, gamma)


### PR DESCRIPTION
/databricks/python/lib/python3.8/site-packages/tslearn/barycenters/softdtw.py:103: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray
  X_ = numpy.array([to_time_series(d, remove_nans=True) for d in X_])

Because this method often uses numpy arrays with different shapes, I think the approach is justified here.