### PR TITLE
[MRG] Deprecate python3.5 and build wheels for python3.9 and 3.10

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -29,7 +29,7 @@ jobs:
         python -m pip install cibuildwheel~=2.3
     - name: Build wheel
       env:
-        CIBW_SKIP: "pp*-win* *cp27* *cp35* *pp*"
+        CIBW_SKIP: "pp*-win* *cp27* *pp*"
         CIBW_BEFORE_BUILD: "pip install numpy cython"
       run: |
         python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -26,7 +26,7 @@ jobs:
         pip install -U "cython"
     - name: Install cibuildwheel
       run: |
-        python -m pip install cibuildwheel==1.3.0
+        python -m pip install cibuildwheel~=2.3
     - name: Build wheel
       env:
         CIBW_SKIP: "pp*-win* *cp27* *cp35* *pp*"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,7 +97,7 @@ jobs:
 
 - job: 'macOS'
   pool:
-    vmImage: 'macOS-latest'
+    vmImage: 'macOS-10.15'
   strategy:
     matrix:
       Python36:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,8 +10,6 @@ jobs:
     vmImage: 'ubuntu-latest'
   strategy:
     matrix:
-      Python35:
-        python.version: '3.5'
       Python36:
         python.version: '3.6'
       Python37:
@@ -46,13 +44,8 @@ jobs:
   - script: |
       set -xe
       python -m pip install pytest pytest-azurepipelines
-      if [[ "$(python.version)" == '3.5' ]];
-      then
-        python -m pytest -v tslearn/ --doctest-modules -k 'not test_all_estimators';
-      else
-        python -m pip install scikit-learn==0.23
-        python -m pytest -v tslearn/ --doctest-modules;
-      fi
+      python -m pip install scikit-learn==0.23
+      python -m pytest -v tslearn/ --doctest-modules;
     displayName: 'Test'
 
 
@@ -107,8 +100,6 @@ jobs:
     vmImage: 'macOS-latest'
   strategy:
     matrix:
-      Python35:
-        python.version: '3.5'
       Python36:
         python.version: '3.6'
       Python37:
@@ -155,9 +146,6 @@ jobs:
     vmImage: 'windows-latest'
   strategy:
     matrix:
-      Python35:
-        python_ver: '35'
-        python.version: '3.5'
       Python36:
         python_ver: '36'
         python.version: '3.6'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy<=1.19", "Cython"]
+requires = ["setuptools", "wheel", "numpy", "Cython"]


### PR DESCRIPTION
Fixes: #372 #316
Drops python 3.5 support