### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,9 @@ setup(
     extras_require={'tests': ['pytest']},
     version=VERSION,
     url="http://tslearn.readthedocs.io/",
+    project_urls={
+        "Source": "https://github.com/tslearn-team/tslearn",
+    },
     author="Romain Tavenard",
     author_email="romain.tavenard@univ-rennes2.fr",
     cmdclass=cmdclass


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)