### PR TITLE
changed depricated dtypes

### DIFF
--- a/tslearn/datasets/ucr_uea.py
+++ b/tslearn/datasets/ucr_uea.py
@@ -241,9 +241,9 @@ class UCR_UEA_datasets:
         >>> y_train.shape
         (1000,)
         >>> X_train, y_train, X_test, y_test = data_loader.load_dataset(
-        ...         "CinCECGTorso")
+        ...         "Adiac")
         >>> X_train.shape
-        (40, 1639, 1)
+        (390, 176, 1)
         >>> X_train, y_train, X_test, y_test = data_loader.load_dataset(
         ...         "PenDigits")
         >>> X_train.shape

--- a/tslearn/hdftools/hdftools.py
+++ b/tslearn/hdftools/hdftools.py
@@ -82,8 +82,8 @@ def _dicts_to_group(h5file, path, d, raise_meta_fail):
                 # h5file[path + key].attrs['dtype'] = item.dtype.str
 
         # single pieces of data
-        elif isinstance(item, (str, np.int, np.int8,
-                               np.int16, np.int32, np.int64, np.float,
+        elif isinstance(item, (str, int, np.int8,
+                               np.int16, np.int32, np.int64, float,
                                np.float16, np.float32, np.float64)):
             h5file[path + key] = item
 

--- a/tslearn/metrics/utils.py
+++ b/tslearn/metrics/utils.py
@@ -6,7 +6,7 @@ __author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
 
 
 def _cdist_generic(dist_fun, dataset1, dataset2, n_jobs, verbose,
-                   compute_diagonal=True, dtype=numpy.float, *args, **kwargs):
+                   compute_diagonal=True, dtype=float, *args, **kwargs):
     """Compute cross-similarity matrix with joblib parallelization for a given
     similarity function.
 

--- a/tslearn/piecewise/piecewise.py
+++ b/tslearn/piecewise/piecewise.py
@@ -23,7 +23,7 @@ def _paa_to_symbols(X_paa, breakpoints):
     array([0, 1, 1])
     """
     alphabet_size = breakpoints.shape[0] + 1
-    X_symbols = numpy.zeros(X_paa.shape, dtype=numpy.int) - 1
+    X_symbols = numpy.zeros(X_paa.shape, dtype=int) - 1
     for idx_bp, bp in enumerate(breakpoints):
         indices = numpy.logical_and(X_symbols < 0, X_paa < bp)
         X_symbols[indices] = idx_bp
@@ -663,7 +663,7 @@ class OneD_SymbolicAggregateApproximation(SymbolicAggregateApproximation):
     def _transform(self, X, y=None):
         X = self._scale(X)
         n_ts, sz_raw, d = X.shape
-        X_1d_sax = numpy.empty((n_ts, self.n_segments, 2 * d), dtype=numpy.int)
+        X_1d_sax = numpy.empty((n_ts, self.n_segments, 2 * d), dtype=int)
 
         # Average
         X_1d_sax_avg = SymbolicAggregateApproximation._transform(self, X)
@@ -691,7 +691,7 @@ class OneD_SymbolicAggregateApproximation(SymbolicAggregateApproximation):
             1d-SAX-Transformed dataset
         """
         self._is_fitted()
-        X = check_array(X, allow_nd=True, dtype=numpy.float,
+        X = check_array(X, allow_nd=True, dtype=float,
                         force_all_finite=False)
         X = check_dims(X, X_fit_dims=tuple(self._X_fit_dims_),
                        check_n_features_only=True)

--- a/tslearn/utils/cast.py
+++ b/tslearn/utils/cast.py
@@ -12,7 +12,7 @@ except:
 from .utils import check_dataset, ts_size, to_time_series_dataset
 
 
-def to_sklearn_dataset(dataset, dtype=numpy.float, return_dim=False):
+def to_sklearn_dataset(dataset, dtype=float, return_dim=False):
     """Transforms a time series dataset so that it fits the format used in
     ``sklearn`` estimators.
 
@@ -20,7 +20,7 @@ def to_sklearn_dataset(dataset, dtype=numpy.float, return_dim=False):
     ----------
     dataset : array-like
         The dataset of time series to be transformed.
-    dtype : data type (default: numpy.float)
+    dtype : data type (default: float64)
         Data type for the returned dataset.
     return_dim : boolean  (optional, default: False)
         Whether the dimensionality (third dimension should be returned together
@@ -311,7 +311,7 @@ def to_sktime_dataset(X):
         raise ImportError("Conversion from/to sktime cannot be performed "
                           "if pandas is not installed.")
     X_ = check_dataset(X)
-    X_pd = pd.DataFrame(dtype=numpy.float32)
+    X_pd = pd.DataFrame(dtype=float)
     for dim in range(X_.shape[2]):
         X_pd['dim_' + str(dim)] = [pd.Series(data=Xi[:ts_size(Xi), dim])
                                    for Xi in X_]
@@ -439,7 +439,7 @@ def to_pyflux_dataset(X):
     X_ = check_dataset(X,
                        force_equal_length=True,
                        force_single_time_series=True)
-    X_pd = pd.DataFrame(X[0], dtype=numpy.float32)
+    X_pd = pd.DataFrame(X[0], dtype=float)
     X_pd.columns = ["dim_%d" % di for di in range(X_.shape[2])]
     return X_pd
 
@@ -554,7 +554,7 @@ def to_tsfresh_dataset(X):
         Xi_ = Xi[:ts_size(Xi)]
         sz = Xi_.shape[0]
         df["time"] = numpy.arange(sz)
-        df["id"] = numpy.zeros((sz, ), dtype=numpy.int32) + i
+        df["id"] = numpy.zeros((sz, ), dtype=int) + i
         for di in range(d):
             df["dim_%d" % di] = Xi_[:, di]
         dataframes.append(df)

--- a/tslearn/utils/utils.py
+++ b/tslearn/utils/utils.py
@@ -146,14 +146,14 @@ def to_time_series(ts, remove_nans=False):
     ts_out = numpy.array(ts, copy=True)
     if ts_out.ndim <= 1:
         ts_out = ts_out.reshape((-1, 1))
-    if ts_out.dtype != numpy.float:
-        ts_out = ts_out.astype(numpy.float)
+    if ts_out.dtype != float:
+        ts_out = ts_out.astype(float)
     if remove_nans:
         ts_out = ts_out[:ts_size(ts_out)]
     return ts_out
 
 
-def to_time_series_dataset(dataset, dtype=numpy.float):
+def to_time_series_dataset(dataset, dtype=float):
     """Transforms a time series dataset so that it fits the format used in
     ``tslearn`` models.
 
@@ -162,7 +162,7 @@ def to_time_series_dataset(dataset, dtype=numpy.float):
     dataset : array-like
         The dataset of time series to be transformed. A single time series will
         be automatically wrapped into a dataset with a single entry.
-    dtype : data type (default: numpy.float)
+    dtype : data type (default: float)
         Data type for the returned dataset.
 
     Returns
@@ -682,7 +682,7 @@ def _load_arff_uea(dataset_path):
 
     else:  # uni-variate situation
         x_ = data[names[:-1]]
-        x = numpy.asarray(x_.tolist(), dtype=numpy.float32)
+        x = numpy.asarray(x_.tolist(), dtype=float)
         x = x.reshape(len(x), -1, 1)
 
     return x, y
@@ -710,5 +710,5 @@ def _load_txt_uea(dataset_path):
     """
     data = numpy.loadtxt(dataset_path)
     X = to_time_series_dataset(data[:, 1:])
-    y = data[:, 0].astype(numpy.int)
+    y = data[:, 0].astype(int)
     return X, y


### PR DESCRIPTION
DeprecationWarning: np.float and np.int are deprecated #386

Changed deprecated dtype numpy.float and numpy.int to float and int respectively at all the occurences.