### PR TITLE
[MRG] replace CinCECGTorso by Adiac in doctests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,6 @@ jobs:
       set -xe
       python -m pip install pytest pytest-azurepipelines
       python -m pip install scikit-learn==0.23
-      pip install pycocotools==2.0.0
       python -m pytest -v tslearn/ --doctest-modules;
     displayName: 'Test'
 
@@ -87,7 +86,6 @@ jobs:
       python -m pip install coverage pytest-cov
       python -m pip install cesium pandas stumpy
       python -m pip install scikit-learn==0.23
-      pip install pycocotools==2.0.0
       python -m pytest -v tslearn/ --doctest-modules --cov=tslearn
     displayName: 'Test'
 
@@ -138,7 +136,6 @@ jobs:
   
   - script: |
       set -xe
-      pip install pycocotools==2.0.0
       python -m pip install pytest pytest-azurepipelines
       python -m pytest -v tslearn/ --doctest-modules -k 'not test_all_estimators'
     displayName: 'Test'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,6 +45,7 @@ jobs:
       set -xe
       python -m pip install pytest pytest-azurepipelines
       python -m pip install scikit-learn==0.23
+      pip install pycocotools==2.0.0
       python -m pytest -v tslearn/ --doctest-modules;
     displayName: 'Test'
 
@@ -86,6 +87,7 @@ jobs:
       python -m pip install coverage pytest-cov
       python -m pip install cesium pandas stumpy
       python -m pip install scikit-learn==0.23
+      pip install pycocotools==2.0.0
       python -m pytest -v tslearn/ --doctest-modules --cov=tslearn
     displayName: 'Test'
 
@@ -136,6 +138,7 @@ jobs:
   
   - script: |
       set -xe
+      pip install pycocotools==2.0.0
       python -m pip install pytest pytest-azurepipelines
       python -m pytest -v tslearn/ --doctest-modules -k 'not test_all_estimators'
     displayName: 'Test'

--- a/tslearn/datasets/ucr_uea.py
+++ b/tslearn/datasets/ucr_uea.py
@@ -241,9 +241,9 @@ class UCR_UEA_datasets:
         >>> y_train.shape
         (1000,)
         >>> X_train, y_train, X_test, y_test = data_loader.load_dataset(
-        ...         "CinCECGTorso")
+        ...         "Adiac")
         >>> X_train.shape
-        (40, 1639, 1)
+        (390, 176, 1)
         >>> X_train, y_train, X_test, y_test = data_loader.load_dataset(
         ...         "PenDigits")
         >>> X_train.shape


### PR DESCRIPTION
There seem to be some issues with `CinCECGTorso` which is obtained from timeseriesclassification.com

Replacing it by another dataset to fix doctests.