### PR TITLE
[Bugfix] Fixes an off-by-one error in kshape. (Issue #385)

### DIFF
--- a/tslearn/metrics/cycc.pyx
+++ b/tslearn/metrics/cycc.pyx
@@ -85,7 +85,7 @@ def y_shifted_sbd_vec(numpy.ndarray[DTYPE_t, ndim=2] ref_ts, numpy.ndarray[DTYPE
     for i in range(dataset.shape[0]):
         cc = normalized_cc(ref_ts, dataset[i], norm1=norm_ref, norm2=norms_dataset[i])
         idx = numpy.argmax(cc)
-        shift = idx - sz
+        shift = idx + 1 - sz
         if shift > 0:
             dataset_shifted[i, shift:] = dataset[i, :-shift, :]
         elif shift < 0:


### PR DESCRIPTION
Problem pointed out in [issue #385](https://github.com/tslearn-team/tslearn/issues/385). The original [paper](https://dl.acm.org/doi/pdf/10.1145/2723372.2737793) uses MATLAB-style indexing, i.e. starting on 1, as opposed to Python-style indexing starting on 0. Therefore there was a mismatch between tslearn and line 6, Algorithm 1 of that paper.

It should be noted that this indexing issue seems to be accounted for in [this PR](https://github.com/tslearn-team/tslearn/pull/388). 