### PR TITLE
[MRG] Newer macOS version in azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,7 +95,7 @@ jobs:
 
 - job: 'macOS'
   pool:
-    vmImage: 'macOS-10.15'
+    vmImage: 'macOS-12'
   strategy:
     matrix:
       Python37:


### PR DESCRIPTION
macOS-10.15 will soon not be supported anymore : https://github.com/actions/runner-images/issues/5583
The continuous integration tests with macOS-10.15 are already not supported anymore in some recent other pull requests in tslearn.