### PR TITLE
[MRG] Fix missing comma in metrics.__init__

### DIFF
--- a/tslearn/metrics/__init__.py
+++ b/tslearn/metrics/__init__.py
@@ -39,7 +39,7 @@ __all__ = [
     "GLOBAL_CONSTRAINT_CODE",
     "lb_envelope", "lb_keogh",
     "sakoe_chiba_mask", "itakura_mask",
-    "lcss", "lcss_path", "lcss_path_from_metric"
+    "lcss", "lcss_path", "lcss_path_from_metric",
 
     "ctw_path", "ctw", "cdist_ctw",
 


### PR DESCRIPTION
Without it `from tslearn.metrics import *` throws a `AttributeError: module 'tslearn.metrics' has no attribute 'lcss_path_from_metricctw_path'`. Haven't found a related issue.