### PR TITLE
Fix LearningShapelets continuous integration test error on Linux

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ jobs:
   - script: |
       set -xe
       python -m pip install pytest pytest-azurepipelines
-      python -m pip install scikit-learn==1.0
+#      python -m pip install scikit-learn==1.0
       python -m pytest -v tslearn/ --doctest-modules
     displayName: 'Test'
 
@@ -83,7 +83,7 @@ jobs:
       python -m pip install pytest pytest-azurepipelines
       python -m pip install coverage pytest-cov
       python -m pip install cesium pandas stumpy
-      python -m pip install scikit-learn==1.0
+#      python -m pip install scikit-learn==1.0
       python -m pytest -v tslearn/ --doctest-modules --cov=tslearn
     displayName: 'Test'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,6 +43,7 @@ jobs:
       set -xe
       python -m pip install pytest pytest-azurepipelines
       python -m pip install scikit-learn==1.0
+      python -m pip install tensorflow==2.0
       python -m pytest -v tslearn/ --doctest-modules
     displayName: 'Test'
 
@@ -84,6 +85,7 @@ jobs:
       python -m pip install coverage pytest-cov
       python -m pip install cesium pandas stumpy
       python -m pip install scikit-learn==1.0
+      python -m pip install tensorflow==2.0
       python -m pytest -v tslearn/ --doctest-modules --cov=tslearn
     displayName: 'Test'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,6 +42,7 @@ jobs:
   - script: |
       set -xe
       python -m pip install pytest pytest-azurepipelines
+      python -m pip install scikit-learn==1.0
       python -m pytest -v tslearn/ --doctest-modules
     displayName: 'Test'
 
@@ -82,6 +83,7 @@ jobs:
       python -m pip install pytest pytest-azurepipelines
       python -m pip install coverage pytest-cov
       python -m pip install cesium pandas stumpy
+      python -m pip install scikit-learn==1.0
       python -m pytest -v tslearn/ --doctest-modules --cov=tslearn
     displayName: 'Test'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -135,7 +135,6 @@ jobs:
   - script: |
       set -xe
       python -m pip install pytest pytest-azurepipelines
-      python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules -k 'not test_all_estimators'
     displayName: 'Test'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ jobs:
       set -xe
       python -m pip install pytest pytest-azurepipelines
       python -m pip install scikit-learn==1.0
-      python -m pip install tensorflow==2.8.0
+      python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules
     displayName: 'Test'
 
@@ -85,7 +85,7 @@ jobs:
       python -m pip install coverage pytest-cov
       python -m pip install cesium pandas stumpy
       python -m pip install scikit-learn==1.0
-      python -m pip install tensorflow==2.8.0
+      python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules --cov=tslearn
     displayName: 'Test'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ jobs:
       set -xe
       python -m pip install pytest pytest-azurepipelines
       python -m pip install scikit-learn==1.0
-      python -m pip install tensorflow==2.10.0
+      python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules
     displayName: 'Test'
 
@@ -85,7 +85,7 @@ jobs:
       python -m pip install coverage pytest-cov
       python -m pip install cesium pandas stumpy
       python -m pip install scikit-learn==1.0
-      python -m pip install tensorflow==2.10.0
+      python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules --cov=tslearn
     displayName: 'Test'
 
@@ -135,6 +135,7 @@ jobs:
   - script: |
       set -xe
       python -m pip install pytest pytest-azurepipelines
+      python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules -k 'not test_all_estimators'
     displayName: 'Test'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ jobs:
       set -xe
       python -m pip install pytest pytest-azurepipelines
       python -m pip install scikit-learn==1.0
-      python -m pip install tensorflow==2.9.0
+      python -m pip install tensorflow==2.10.0
       python -m pytest -v tslearn/ --doctest-modules
     displayName: 'Test'
 
@@ -85,7 +85,7 @@ jobs:
       python -m pip install coverage pytest-cov
       python -m pip install cesium pandas stumpy
       python -m pip install scikit-learn==1.0
-      python -m pip install tensorflow==2.9.0
+      python -m pip install tensorflow==2.10.0
       python -m pytest -v tslearn/ --doctest-modules --cov=tslearn
     displayName: 'Test'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,6 @@ jobs:
   - script: |
       set -xe
       python -m pip install pytest pytest-azurepipelines
-#      python -m pip install scikit-learn==1.0
       python -m pytest -v tslearn/ --doctest-modules
     displayName: 'Test'
 
@@ -83,7 +82,6 @@ jobs:
       python -m pip install pytest pytest-azurepipelines
       python -m pip install coverage pytest-cov
       python -m pip install cesium pandas stumpy
-#      python -m pip install scikit-learn==1.0
       python -m pytest -v tslearn/ --doctest-modules --cov=tslearn
     displayName: 'Test'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ jobs:
       set -xe
       python -m pip install pytest pytest-azurepipelines
       python -m pip install scikit-learn==1.0
-      python -m pip install tensorflow==2.0
+      python -m pip install tensorflow==2.8.0
       python -m pytest -v tslearn/ --doctest-modules
     displayName: 'Test'
 
@@ -85,7 +85,7 @@ jobs:
       python -m pip install coverage pytest-cov
       python -m pip install cesium pandas stumpy
       python -m pip install scikit-learn==1.0
-      python -m pip install tensorflow==2.0
+      python -m pip install tensorflow==2.8.0
       python -m pytest -v tslearn/ --doctest-modules --cov=tslearn
     displayName: 'Test'
 

--- a/tslearn/shapelets/shapelets.py
+++ b/tslearn/shapelets/shapelets.py
@@ -417,8 +417,10 @@ class LearningShapelets(ClassifierMixin, TransformerMixin,
         X = check_dims(X)
         self._check_series_length(X)
 
-        if self.random_state is not None:
-            tf.keras.utils.set_random_seed(seed=self.random_state)
+        # if self.random_state is not None:
+        #     tf.keras.utils.set_random_seed(seed=self.random_state)
+        numpy.random.seed(seed=self.random_state)
+        tf.random.set_seed(seed=self.random_state)
 
         n_ts, sz, d = X.shape
         self._X_fit_dims = X.shape

--- a/tslearn/shapelets/shapelets.py
+++ b/tslearn/shapelets/shapelets.py
@@ -417,10 +417,8 @@ class LearningShapelets(ClassifierMixin, TransformerMixin,
         X = check_dims(X)
         self._check_series_length(X)
 
-        # if self.random_state is not None:
-        #     tf.keras.utils.set_random_seed(seed=self.random_state)
-        numpy.random.seed(seed=self.random_state)
-        tf.random.set_seed(seed=self.random_state)
+        if self.random_state is not None:
+            tf.keras.utils.set_random_seed(seed=self.random_state)
 
         n_ts, sz, d = X.shape
         self._X_fit_dims = X.shape

--- a/tslearn/shapelets/shapelets.py
+++ b/tslearn/shapelets/shapelets.py
@@ -417,8 +417,9 @@ class LearningShapelets(ClassifierMixin, TransformerMixin,
         X = check_dims(X)
         self._check_series_length(X)
 
-        numpy.random.seed(seed=self.random_state)
-        tf.random.set_seed(seed=self.random_state)
+        if self.random_state is not None:
+            tf.keras.utils.set_random_seed(seed=self.random_state)
+
         n_ts, sz, d = X.shape
         self._X_fit_dims = X.shape
 

--- a/tslearn/tests/sklearn_patches.py
+++ b/tslearn/tests/sklearn_patches.py
@@ -542,114 +542,19 @@ def check_pipeline_consistency(name, estimator_orig):
     X = pairwise_estimator_convert_X(X, estimator_orig, kernel=rbf_kernel)
     estimator = clone(estimator_orig)
     y = multioutput_estimator_convert_y_2d(estimator, y)
-    if name == 'LearningShapelets':
-        print('\n')
-        print('name')
-        print(name)
-        print('\n')
-        print('X')
-        print(X)
-        print('\n')
-        print('y')
-        print(y)
-        print('\n')
-        print('estimator')
-        print(estimator)
     set_random_state(estimator)
     pipeline = make_pipeline(estimator)
-    if name == 'LearningShapelets':
-        print('\n')
-        print('estimator after set random state')
-        print(estimator)
-
-        print('estimator variables before fit')
-        for key, value in vars(estimator).items():
-            print(key, value)
-
-        print('\n')
-        print('pipeline')
-        print(pipeline)
-        print('\n')
-        print('learningshapelets inside pipeline')
-        print(pipeline['learningshapelets'])
-
-        print('pipeline variables before fit')
-        for key, value in vars(pipeline['learningshapelets']).items():
-            print(key, value)
-
-        print('ESTIMATOR AND PIPELINE ARE EQUAL BEFORE FIT')
-        print(vars(estimator) == vars(pipeline['learningshapelets']))
-
     estimator.fit(X, y)
     pipeline.fit(X, y)
-    if name == 'LearningShapelets':
-        print('\n')
-        print('estimator after fit')
-        print(estimator)
-
-        print('estimator variables after fit')
-        for key, value in vars(estimator).items():
-            print(key, value)
-
-        print('\n')
-        print('pipeline after fit')
-        print(pipeline)
-
-        print('pipeline variables after fit')
-        for key, value in vars(pipeline['learningshapelets']).items():
-            print(key, value)
-
-        print('ESTIMATOR AND PIPELINE ARE EQUAL AFTER FIT')
-        print(vars(estimator) == vars(pipeline['learningshapelets']))
 
     funcs = ["score", "fit_transform"]
 
     for func_name in funcs:
-        if name == 'LearningShapelets':
-            print('\n')
-            print('func_name')
-            print(func_name)
         func = getattr(estimator, func_name, None)
         if func is not None:
             func_pipeline = getattr(pipeline, func_name)
-            if name == 'LearningShapelets':
-                print('\n')
-                print('func')
-                print(func)
-                print('\n')
-                print('func_pipeline')
-                print(func_pipeline)
-                print('\n')
-                print('estimator variables before func')
-                for key, value in vars(estimator).items():
-                    print(key, value)
-                print('\n')
-                print('pipeline variables before func_pipeline')
-                for key, value in vars(pipeline['learningshapelets']).items():
-                    print(key, value)
-                print('\n')
-                print('ESTIMATOR AND PIPELINE ARE EQUAL BEFORE FUNC')
-                print(vars(estimator) == vars(pipeline['learningshapelets']))
             result = func(X, y)
             result_pipe = func_pipeline(X, y)
-            if name == 'LearningShapelets':
-                print('\n')
-                print('estimator variables after func')
-                for key, value in vars(estimator).items():
-                    print(key, value)
-                print('\n')
-                print('pipeline variables after func_pipeline')
-                for key, value in vars(pipeline['learningshapelets']).items():
-                    print(key, value)
-                print('\n')
-                print('ESTIMATOR AND PIPELINE ARE EQUAL AFTER FUNC')
-                print(vars(estimator) == vars(pipeline['learningshapelets']))
-                print('\n')
-                print('result')
-                print(result)
-                print('\n')
-                print('result pipe')
-                print(result_pipe)
             assert_allclose_dense_sparse(result, result_pipe)
 
 

--- a/tslearn/tests/sklearn_patches.py
+++ b/tslearn/tests/sklearn_patches.py
@@ -542,19 +542,114 @@ def check_pipeline_consistency(name, estimator_orig):
     X = pairwise_estimator_convert_X(X, estimator_orig, kernel=rbf_kernel)
     estimator = clone(estimator_orig)
     y = multioutput_estimator_convert_y_2d(estimator, y)
+    if name == 'LearningShapelets':
+        print('\n')
+        print('name')
+        print(name)
+        print('\n')
+        print('X')
+        print(X)
+        print('\n')
+        print('y')
+        print(y)
+        print('\n')
+        print('estimator')
+        print(estimator)
     set_random_state(estimator)
     pipeline = make_pipeline(estimator)
+    if name == 'LearningShapelets':
+        print('\n')
+        print('estimator after set random state')
+        print(estimator)
+
+        print('estimator variables before fit')
+        for key, value in vars(estimator).items():
+            print(key, value)
+
+        print('\n')
+        print('pipeline')
+        print(pipeline)
+        print('\n')
+        print('learningshapelets inside pipeline')
+        print(pipeline['learningshapelets'])
+
+        print('pipeline variables before fit')
+        for key, value in vars(pipeline['learningshapelets']).items():
+            print(key, value)
+
+        print('ESTIMATOR AND PIPELINE ARE EQUAL BEFORE FIT')
+        print(vars(estimator) == vars(pipeline['learningshapelets']))
+
     estimator.fit(X, y)
     pipeline.fit(X, y)
+    if name == 'LearningShapelets':
+        print('\n')
+        print('estimator after fit')
+        print(estimator)
+
+        print('estimator variables after fit')
+        for key, value in vars(estimator).items():
+            print(key, value)
+
+        print('\n')
+        print('pipeline after fit')
+        print(pipeline)
+
+        print('pipeline variables after fit')
+        for key, value in vars(pipeline['learningshapelets']).items():
+            print(key, value)
+
+        print('ESTIMATOR AND PIPELINE ARE EQUAL AFTER FIT')
+        print(vars(estimator) == vars(pipeline['learningshapelets']))
 
     funcs = ["score", "fit_transform"]
 
     for func_name in funcs:
+        if name == 'LearningShapelets':
+            print('\n')
+            print('func_name')
+            print(func_name)
         func = getattr(estimator, func_name, None)
         if func is not None:
             func_pipeline = getattr(pipeline, func_name)
+            if name == 'LearningShapelets':
+                print('\n')
+                print('func')
+                print(func)
+                print('\n')
+                print('func_pipeline')
+                print(func_pipeline)
+                print('\n')
+                print('estimator variables before func')
+                for key, value in vars(estimator).items():
+                    print(key, value)
+                print('\n')
+                print('pipeline variables before func_pipeline')
+                for key, value in vars(pipeline['learningshapelets']).items():
+                    print(key, value)
+                print('\n')
+                print('ESTIMATOR AND PIPELINE ARE EQUAL BEFORE FUNC')
+                print(vars(estimator) == vars(pipeline['learningshapelets']))
             result = func(X, y)
             result_pipe = func_pipeline(X, y)
+            if name == 'LearningShapelets':
+                print('\n')
+                print('estimator variables after func')
+                for key, value in vars(estimator).items():
+                    print(key, value)
+                print('\n')
+                print('pipeline variables after func_pipeline')
+                for key, value in vars(pipeline['learningshapelets']).items():
+                    print(key, value)
+                print('\n')
+                print('ESTIMATOR AND PIPELINE ARE EQUAL AFTER FUNC')
+                print(vars(estimator) == vars(pipeline['learningshapelets']))
+                print('\n')
+                print('result')
+                print(result)
+                print('\n')
+                print('result pipe')
+                print(result_pipe)
             assert_allclose_dense_sparse(result, result_pipe)
 
 


### PR DESCRIPTION
This PR is related to the following issue: https://github.com/tslearn-team/tslearn/issues/426 which is related to a test error in the continuous integration tests of the main branch.
This bug was first noticed in continuous integration tests of the PR https://github.com/tslearn-team/tslearn/pull/411 (which is now merged), but this bug seems unrelated to the PR.
The continuous integration tests are failing with Linux but they pass with Windows and MacOS.
I use Linux and Python 3.8, and the tests pass on my local computer.
The failing test is related to the test the class tslearn.shapelets.shapelets.LearningShapelets by functions:
test_all_estimators (tslearn/tests/test_estimators.py) --> check_estimator (tslearn/tests/test_estimators.py) --> check_pipeline_consistency (tslearn/tests/sklearn_patches.py).
