### PR TITLE
Fix url bibtex

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ If you use `tslearn` in a scientific publication, we would appreciate citations:
   volume  = {21},
   number  = {118},
   pages   = {1-6},
-  url     = {http://jmlr.org/papers/v21/20-091.html}
+  url     = {https://www.jmlr.org/papers/v21/20-091.html}
 }
 ```
 

--- a/docs/citing.rst
+++ b/docs/citing.rst
@@ -17,5 +17,5 @@ citations:
       volume  = {21},
       number  = {118},
       pages   = {1-6},
-      url     = {http://jmlr.org/papers/v21/20-091.html}
+      url     = {https://www.jmlr.org/papers/v21/20-091.html}
     }


### PR DESCRIPTION
The old link in `http://jmlr.org/papers/v21/20-091.html` seems to be dead and moved to `https://www.jmlr.org/papers/v21/20-091.html`