### PR TITLE
Fix KShape failing continuous integration test on MacOS

### DIFF
--- a/tslearn/clustering/kshape.py
+++ b/tslearn/clustering/kshape.py
@@ -117,7 +117,6 @@ class KShape(ClusterMixin, TimeSeriesCentroidBasedClusteringMixin,
 
     def _shape_extraction(self, X, k):
         sz = X.shape[1]
-        print('y_shifted_sbd_vec')
         Xp = y_shifted_sbd_vec(self.cluster_centers_[k], X[self.labels_ == k],
                                norm_ref=-1,
                                norms_dataset=self.norms_[self.labels_ == k])
@@ -146,7 +145,6 @@ class KShape(ClusterMixin, TimeSeriesCentroidBasedClusteringMixin,
                                                   axis=(1, 2))
 
     def _cross_dists(self, X):
-        print('cdist_normalized_cc')
         return 1. - cdist_normalized_cc(X, self.cluster_centers_,
                                         norms1=self.norms_,
                                         norms2=self.norms_centroids_,

--- a/tslearn/clustering/kshape.py
+++ b/tslearn/clustering/kshape.py
@@ -117,6 +117,7 @@ class KShape(ClusterMixin, TimeSeriesCentroidBasedClusteringMixin,
 
     def _shape_extraction(self, X, k):
         sz = X.shape[1]
+        print('y_shifted_sbd_vec')
         Xp = y_shifted_sbd_vec(self.cluster_centers_[k], X[self.labels_ == k],
                                norm_ref=-1,
                                norms_dataset=self.norms_[self.labels_ == k])
@@ -145,6 +146,7 @@ class KShape(ClusterMixin, TimeSeriesCentroidBasedClusteringMixin,
                                                   axis=(1, 2))
 
     def _cross_dists(self, X):
+        print('cdist_normalized_cc')
         return 1. - cdist_normalized_cc(X, self.cluster_centers_,
                                         norms1=self.norms_,
                                         norms2=self.norms_centroids_,

--- a/tslearn/metrics/cycc.py
+++ b/tslearn/metrics/cycc.py
@@ -6,7 +6,7 @@ from numba import njit, objmode, prange
 __author__ = "Romain Tavenard romain.tavenard[at]univ-rennes2.fr"
 
 
-@njit(parallel=True, fastmath=True)
+@njit(fastmath=True)
 def normalized_cc(s1, s2, norm1=-1.0, norm2=-1.0):
     """Normalize cc.
 


### PR DESCRIPTION
The KShape test is failing on MacOS. 