### PR TITLE
Fix Import Error sklearn pairwise_estimator_convert_X

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -136,6 +136,7 @@ jobs:
       set -xe
       python -m pip install pytest pytest-azurepipelines
       python -m pip install scikit-learn==1.0
+      python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules -k 'not test_all_estimators'
     displayName: 'Test'
 
@@ -177,5 +178,6 @@ jobs:
   - script: |
       python -m pip install pytest pytest-azurepipelines
       python -m pip install scikit-learn==1.0
+      python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules --ignore tslearn/tests/test_estimators.py --ignore tslearn/utils/cast.py
     displayName: 'Test'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -135,6 +135,7 @@ jobs:
   - script: |
       set -xe
       python -m pip install pytest pytest-azurepipelines
+      python -m pip install scikit-learn==1.0
       python -m pytest -v tslearn/ --doctest-modules -k 'not test_all_estimators'
     displayName: 'Test'
 
@@ -175,5 +176,6 @@ jobs:
   
   - script: |
       python -m pip install pytest pytest-azurepipelines
+      python -m pip install scikit-learn==1.0
       python -m pytest -v tslearn/ --doctest-modules --ignore tslearn/tests/test_estimators.py --ignore tslearn/utils/cast.py
     displayName: 'Test'


### PR DESCRIPTION
This PR aims at solving on `ImportError` on Windows and MacOS (not on Linux).
In the file: `tslearn/tests/sklearn_patches.py`
There is the import: 

```
try:
    # Most recent
    from sklearn.utils.estimator_checks import (
        _pairwise_estimator_convert_X as pairwise_estimator_convert_X,
        _choose_check_classifiers_labels as choose_check_classifiers_labels
    )
except ImportError:
    # Deprecated from sklearn v0.24 onwards
    from sklearn.utils.estimator_checks import (
        pairwise_estimator_convert_X,
        choose_check_classifiers_labels
    )
```

which raises the following ImportError:

```
==================================== ERRORS ====================================
______________ ERROR collecting tslearn/tests/sklearn_patches.py _______________
tslearn/tests/sklearn_patches.py:56: in <module>
    from sklearn.utils.estimator_checks import (
E   ImportError: cannot import name '_pairwise_estimator_convert_X' from 'sklearn.utils.estimator_checks' (/Users/runner/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/site-packages/sklearn/utils/estimator_checks.py)

During handling of the above exception, another exception occurred:
tslearn/tests/sklearn_patches.py:62: in <module>
    from sklearn.utils.estimator_checks import (
E   ImportError: cannot import name 'pairwise_estimator_convert_X' from 'sklearn.utils.estimator_checks' (/Users/runner/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/site-packages/sklearn/utils/estimator_checks.py)

```