### PR TITLE
Update CHANGELOG.md before release of tslearn version 0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Changelogs for this project are recorded in this file since v0.2.0.
 
 ## [Towards v0.5.3]
 
+### Changed
+
+* The use of Cython is now replaced by Numba.
+
 ### Fixed
 
 * Fixed a bug about result of path in `lcss_path_from_metric` function.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,25 @@ Changelogs for this project are recorded in this file since v0.2.0.
 
 ### Changed
 
-* Change macOS-10.15 into macOS-12 in the file `azure-pipelines.yml`.
+* Support for  `macOS-10.15` is replaced by support for `macOS-12`
+* Support for `scikit-learn 0.23` is replaced by support for `scikit-learn 1.0`
+* Specify supported `TensorFlow` version (2.9.0)
+
+### Added
+
+* Python 3.9 support
 
 ### Fixed
 
-* Fixed a bug about result of path in `lcss_path_from_metric` function.
-* Fixed incompatibilities between `NumPy`, `TensorFlow` and `scikit-learn` versions.
+* Fixed a bug about result of path in `lcss_path_from_metric` function
+* Fixed incompatibilities between `NumPy`, `TensorFlow` and `scikit-learn` versions
+* Fixed a bug preventing tslearn installation by removing the `NumPy` version constraint (<=1.19) in the file 
+`pyproject.toml`
 
 ### Removed
 
-* Cython is now replaced by Numba.
+* Cython is now replaced by Numba
+* Supports for Python 3.5 and 3.6 are dropped
 
 ## [v0.5.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to
 
 Changelogs for this project are recorded in this file since v0.2.0.
 
-## [Towards v0.5.3]
+## [Towards v0.6]
+
+## [v0.5.3]
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,16 @@ Changelogs for this project are recorded in this file since v0.2.0.
 
 ### Changed
 
-* The use of Cython is now replaced by Numba.
+* Change macOS-10.15 into macOS-12 in the file `azure-pipelines.yml`.
 
 ### Fixed
 
 * Fixed a bug about result of path in `lcss_path_from_metric` function.
+* Fixed incompatibilities between `NumPy`, `TensorFlow` and `scikit-learn` versions.
+
+### Removed
+
+* Cython is now replaced by Numba.
 
 ## [v0.5.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Changelogs for this project are recorded in this file since v0.2.0.
 
 ### Added
 
-* Python 3.9 support
+* Support for Python versions 3.9 and 3.10
 
 ### Fixed
 
@@ -32,7 +32,7 @@ Changelogs for this project are recorded in this file since v0.2.0.
 ### Removed
 
 * Cython is now replaced by Numba
-* Supports for Python 3.5 and 3.6 are dropped
+* Support for Python versions 3.5 and 3.6 is dropped
 
 ## [v0.5.2]
 


### PR DESCRIPTION
The current tslearn version (0.5.2) has been released on August 16, 2021: https://pypi.org/project/tslearn/#history

On tslearn main branch, a change of constraint about the Numpy version has solved the following issue: 
https://github.com/tslearn-team/tslearn/issues/399#issuecomment-1373121143

The current PR aims at updating the file `CHANGELOG.md` before release of tslearn version 0.5.3.
This new version will solve the issue mentioned previously.