### PR TITLE
Update url of UCR UEA dataset zip files

### DIFF
--- a/tslearn/datasets/ucr_uea.py
+++ b/tslearn/datasets/ucr_uea.py
@@ -267,7 +267,7 @@ class UCR_UEA_datasets:
                 shutil.rmtree(full_path, ignore_errors=True)
             # else, actually raise the error!
 
-            url = ("https://www.timeseriesclassification.com/Downloads/%s.zip"
+            url = ("https://www.timeseriesclassification.com/ClassificationDownloads/%s.zip"
                    % dataset_name)
             success = extract_from_zip_url(url, target_dir=full_path)
             if not success:

--- a/tslearn/datasets/ucr_uea.py
+++ b/tslearn/datasets/ucr_uea.py
@@ -51,7 +51,7 @@ class UCR_UEA_datasets:
 
         try:
             url_multivariate = ("https://www.timeseriesclassification.com/"
-                                "Downloads/Archives/summaryMultivariate.csv")
+                                "ClassificationDownloads/Archives/summaryMultivariate.csv")
             self._list_multivariate_filename = os.path.join(
                 self._data_dir, os.path.basename(url_multivariate)
             )


### PR DESCRIPTION
The UEA & UCR Time Series Classification Repository has changed the url used to download its dataset zip files.

The previous url was:
https://www.timeseriesclassification.com/Downloads
It is now:
https://www.timeseriesclassification.com/ClassificationDownloads

For example, for the dataset "ECG200", the url was:
https://www.timeseriesclassification.com/Downloads/ECG200.zip
and is now:
https://www.timeseriesclassification.com/ClassificationDownloads/ECG200.zip