### PR TITLE
Remove support for Python 3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Changelogs for this project are recorded in this file since v0.2.0.
 
 ## [Towards v0.6]
 
+### Removed
+
+* Support for Python version 3.7 is dropped
+
 ## [v0.5.3]
 
 ### Changed

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ jobs:
       set -xe
       python -m pip install pytest pytest-azurepipelines
       python -m pip install scikit-learn==1.0
-      python -m pip install tensorflow==2.9.0
+      python -m pip install tensorflow==2.12.0
       python -m pytest -v tslearn/ --doctest-modules
     displayName: 'Test'
 
@@ -87,7 +87,7 @@ jobs:
       python -m pip install coverage pytest-cov
       python -m pip install cesium pandas stumpy
       python -m pip install scikit-learn==1.0
-      python -m pip install tensorflow==2.9.0
+      python -m pip install tensorflow==2.12.0
       python -m pytest -v tslearn/ --doctest-modules --cov=tslearn
     displayName: 'Test'
 
@@ -140,7 +140,7 @@ jobs:
       set -xe
       python -m pip install pytest pytest-azurepipelines
       python -m pip install scikit-learn==1.0
-      python -m pip install tensorflow==2.9.0
+      python -m pip install tensorflow==2.12.0
       python -m pytest -v tslearn/ --doctest-modules -k 'not test_all_estimators'
     displayName: 'Test'
 
@@ -185,6 +185,6 @@ jobs:
   - script: |
       python -m pip install pytest pytest-azurepipelines
       python -m pip install scikit-learn==1.0
-      python -m pip install tensorflow==2.9.0
+      python -m pip install tensorflow==2.12.0
       python -m pytest -v tslearn/ --doctest-modules --ignore tslearn/tests/test_estimators.py --ignore tslearn/utils/cast.py
     displayName: 'Test'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,8 +16,6 @@ jobs:
         python.version: '3.9'
       Python310:
         python.version: '3.10'
-      Python311:
-        python.version: '3.11'
   variables:
     OMP_NUM_THREADS: '2'
     NUMBA_NUM_THREADS: '2'
@@ -45,7 +43,7 @@ jobs:
       set -xe
       python -m pip install pytest pytest-azurepipelines
       python -m pip install scikit-learn==1.0
-      python -m pip install tensorflow==2.12.0
+      python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules
     displayName: 'Test'
 
@@ -55,8 +53,8 @@ jobs:
     vmImage: 'ubuntu-latest'
   strategy:
     matrix:
-      Python311:
-        python.version: '3.11'
+      Python310:
+        python.version: '3.10'
   variables:
     OMP_NUM_THREADS: '2'
     NUMBA_NUM_THREADS: '2'
@@ -87,7 +85,7 @@ jobs:
       python -m pip install coverage pytest-cov
       python -m pip install cesium pandas stumpy
       python -m pip install scikit-learn==1.0
-      python -m pip install tensorflow==2.12.0
+      python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules --cov=tslearn
     displayName: 'Test'
 
@@ -108,8 +106,6 @@ jobs:
         python.version: '3.9'
       Python310:
         python.version: '3.10'
-      Python311:
-        python.version: '3.11'
   variables:
     OMP_NUM_THREADS: '2'
     NUMBA_NUM_THREADS: '2'
@@ -140,7 +136,7 @@ jobs:
       set -xe
       python -m pip install pytest pytest-azurepipelines
       python -m pip install scikit-learn==1.0
-      python -m pip install tensorflow==2.12.0
+      python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules -k 'not test_all_estimators'
     displayName: 'Test'
 
@@ -159,9 +155,6 @@ jobs:
       Python310:
         python_ver: '310'
         python.version: '3.10'
-      Python311:
-        python_ver: '311'
-        python.version: '3.11'
   variables:
     OMP_NUM_THREADS: '2'
     NUMBA_NUM_THREADS: '2'
@@ -185,6 +178,6 @@ jobs:
   - script: |
       python -m pip install pytest pytest-azurepipelines
       python -m pip install scikit-learn==1.0
-      python -m pip install tensorflow==2.12.0
+      python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules --ignore tslearn/tests/test_estimators.py --ignore tslearn/utils/cast.py
     displayName: 'Test'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,14 +10,14 @@ jobs:
     vmImage: 'ubuntu-latest'
   strategy:
     matrix:
-      Python37:
-        python.version: '3.7'
       Python38:
         python.version: '3.8'
       Python39:
         python.version: '3.9'
       Python310:
         python.version: '3.10'
+      Python311:
+        python.version: '3.11'
   variables:
     OMP_NUM_THREADS: '2'
     NUMBA_NUM_THREADS: '2'
@@ -55,8 +55,8 @@ jobs:
     vmImage: 'ubuntu-latest'
   strategy:
     matrix:
-      Python310:
-        python.version: '3.10'
+      Python311:
+        python.version: '3.11'
   variables:
     OMP_NUM_THREADS: '2'
     NUMBA_NUM_THREADS: '2'
@@ -102,14 +102,14 @@ jobs:
     vmImage: 'macOS-12'
   strategy:
     matrix:
-      Python37:
-        python.version: '3.7'
       Python38:
         python.version: '3.8'
       Python39:
         python.version: '3.9'
       Python310:
         python.version: '3.10'
+      Python311:
+        python.version: '3.11'
   variables:
     OMP_NUM_THREADS: '2'
     NUMBA_NUM_THREADS: '2'
@@ -150,9 +150,6 @@ jobs:
     vmImage: 'windows-latest'
   strategy:
     matrix:
-      Python37:
-        python_ver: '37'
-        python.version: '3.7'
       Python38:
         python_ver: '38'
         python.version: '3.8'
@@ -162,6 +159,9 @@ jobs:
       Python310:
         python_ver: '310'
         python.version: '3.10'
+      Python311:
+        python_ver: '311'
+        python.version: '3.11'
   variables:
     OMP_NUM_THREADS: '2'
     NUMBA_NUM_THREADS: '2'


### PR DESCRIPTION
Python version 3.7 end of life's date is 2023-06-27:
https://devguide.python.org/versions/#supported-versions