### PR TITLE
Fix readthedocs failing test due to release of scikit-learn 1.3.0

### DIFF
--- a/tslearn/clustering/kmeans.py
+++ b/tslearn/clustering/kmeans.py
@@ -626,10 +626,12 @@ class TimeSeriesKMeans(TransformerMixin, ClusterMixin,
             self.cluster_centers_ = self.init.copy()
         elif isinstance(self.init, str) and self.init == "k-means++":
             if self.metric == "euclidean":
+                sample_weight = _check_sample_weight(None, X, dtype=X.dtype)
                 self.cluster_centers_ = _kmeans_plusplus(
                     X.reshape((n_ts, -1)),
                     self.n_clusters,
                     x_squared_norms=x_squared_norms,
+                    sample_weight=sample_weight,
                     random_state=rs
                 )[0].reshape((-1, sz, d))
             else:


### PR DESCRIPTION
The version 1.3.0 of `scikit-learn` has been released on June 30, 2023:
https://pypi.org/project/scikit-learn/#history

Here is the `Changelog` of version 1.3.0:
https://scikit-learn.org/dev/whats_new/v1.3.html

Amoung these differences, there is:

Enhancement The sample_weight parameter now will be used in centroids initialization for [](url) [cluster.KMeans](https://scikit-learn.org/dev/modules/generated/sklearn.cluster.KMeans.html#sklearn.cluster.KMeans), [cluster.BisectingKMeans](https://scikit-learn.org/dev/modules/generated/sklearn.cluster.BisectingKMeans.html#sklearn.cluster.BisectingKMeans) and [cluster.MiniBatchKMeans](https://scikit-learn.org/dev/modules/generated/sklearn.cluster.MiniBatchKMeans.html#sklearn.cluster.MiniBatchKMeans). This change will break backward compatibility, since numbers generated from same random seeds will be different. [#25752](https://github.com/scikit-learn/scikit-learn/pull/25752) by [Gleb Levitski](https://github.com/glevv), [Jérémie du Boisberranger](https://github.com/jeremiedbb), [Guillaume Lemaitre](https://github.com/glemaitre).
