### PR TITLE
Improve the docstring of the class SoftDTWLossPyTorch and rename the parameter dist_func into squared_dist_func

### DIFF
--- a/tslearn/metrics/soft_dtw_loss_pytorch.py
+++ b/tslearn/metrics/soft_dtw_loss_pytorch.py
@@ -73,32 +73,120 @@ else:
             return grad_output.view(-1, 1, 1).expand_as(E) * E, None, None
 
     class SoftDTWLossPyTorch(torch.nn.Module):
-        """Class for the Soft-DTW loss function in PyTorch.
+        r"""Define the Soft-DTW loss function in PyTorch.
+
+        Soft-DTW was originally presented in [1]_ and is
+        discussed in more details in our
+        :ref:`user-guide page on DTW and its variants<dtw>`.
+
+        Soft-DTW is computed as:
+
+        .. math::
+
+            \text{soft-DTW}_{\gamma}(X, Y) =
+                \min_{\pi}{}^\gamma \sum_{(i, j) \in \pi} d^{2} \left( X_i, Y_j \right)
+
+        where :math:`d^{2}` is a squared distance function supporting PyTorch automatic differentiation
+        and :math:`\min^\gamma` is the soft-min operator of parameter :math:`\gamma` defined as:
+
+        .. math::
+
+            \min^\gamma \left( a_{1}, ..., a_{n} \right) =
+                - \gamma \log \sum_{i=1}^{n} e^{- a_{i} / \gamma}
+
+        In the limit case :math:`\gamma = 0`, :math:`\min^\gamma` reduces to a
+        hard-min operator. The soft-DTW is then defined as the square of the DTW
+        similarity measure when the squared distance function used is the square
+        Euclidean distance.
+
+        Contrary to DTW, soft-DTW is not bounded below by zero, and we even have:
+
+        .. math::
+
+            \text{soft-DTW}_{\gamma}(X, Y) \text{\underbrace{$\rightarrow$}_{$+ \infty$}} - \infty
+
+        In [2]_, new similarity measures are defined, that rely on soft-DTW.
+        In particular, soft-DTW divergence is introduced to counteract the non-positivity of soft-DTW:
+
+        .. math::
+            D_{\gamma} \left( X, Y \right) =
+                \text{soft-DTW}_{\gamma}(X, Y)
+                - \frac{1}{2} \left( \text{soft-DTW}_{\gamma}(X, X) + \text{soft-DTW}_{\gamma}(Y, Y) \right)
+
+        This divergence has the advantage of being minimized for :math:`x = y`
+        and being exactly 0 in that case.
 
         Parameters
         ----------
         gamma : float
             Regularization parameter.
             Lower is less smoothed (closer to true DTW).
+            Should be strictly positive.
         normalize : bool
             If True, the Soft-DTW divergence is used.
             The Soft-DTW divergence is always positive.
             Optional, default: False.
-        dist_func : callable
-            The distance function.
+        squared_dist_func : callable
+            The squared distance function.
             It takes two input arguments of shape (batch_size, ts_length, dim).
             It should support PyTorch automatic differentiation.
             Optional, default: None
+            If None, the squared Euclidean distance is used.
+
+        Examples
+        --------
+        >>> import torch
+        >>> from tslearn.metrics import SoftDTWLossPyTorch
+        >>> soft_dtw_loss = SoftDTWLossPyTorch(gamma=0.1)
+        >>> x = torch.zeros((4, 3, 2), requires_grad=True)
+        >>> y = torch.arange(0, 24).reshape(4, 3, 2)
+        >>> soft_dtw_loss_mean_value = soft_dtw_loss(x, y).mean()
+        >>> print(soft_dtw_loss_mean_value)
+        tensor(1081., grad_fn=<MeanBackward0>)
+        >>> soft_dtw_loss_mean_value.backward()
+        >>> print(x.grad.shape)
+        torch.Size([4, 3, 2])
+        >>> print(x.grad)
+        tensor([[[  0.0000,  -0.5000],
+                 [ -1.0000,  -1.5000],
+                 [ -2.0000,  -2.5000]],
+
+                [[ -3.0000,  -3.5000],
+                 [ -4.0000,  -4.5000],
+                 [ -5.0000,  -5.5000]],
+
+                [[ -6.0000,  -6.5000],
+                 [ -7.0000,  -7.5000],
+                 [ -8.0000,  -8.5000]],
+
+                [[ -9.0000,  -9.5000],
+                 [-10.0000, -10.5000],
+                 [-11.0000, -11.5000]]])
+
+        See Also
+        --------
+        soft_dtw : Compute Soft-DTW metric between two time series.
+        cdist_soft_dtw : Compute cross-similarity matrix using Soft-DTW metric.
+        cdist_soft_dtw_normalized : Compute cross-similarity matrix using a normalized
+            version of the Soft-DTW metric.
+
+        References
+        ----------
+        .. [1] Marco Cuturi & Mathieu Blondel. "Soft-DTW: a Differentiable Loss Function for
+           Time-Series", ICML 2017.
+        .. [2] Mathieu Blondel, Arthur Mensch & Jean-Philippe Vert.
+            "Differentiable divergences between time series",
+            International Conference on Artificial Intelligence and Statistics, 2021.
         """
 
-        def __init__(self, gamma=1.0, normalize=False, dist_func=None):
+        def __init__(self, gamma=1.0, normalize=False, squared_dist_func=None):
             super(SoftDTWLossPyTorch, self).__init__()
             self.gamma = gamma
             self.normalize = normalize
-            if dist_func is not None:
-                self.dist_func = dist_func
+            if squared_dist_func is not None:
+                self.squared_dist_func = squared_dist_func
             else:
-                self.dist_func = SoftDTWLossPyTorch._euclidean_squared_dist
+                self.squared_dist_func = SoftDTWLossPyTorch._euclidean_squared_dist
 
         @staticmethod
         def _euclidean_squared_dist(x, y):
@@ -145,10 +233,10 @@ else:
             if self.normalize:
                 xxy = torch.cat([x, x, y])
                 yxy = torch.cat([y, x, y])
-                d_xxy_yxy = self.dist_func(xxy, yxy)
+                d_xxy_yxy = self.squared_dist_func(xxy, yxy)
                 loss = _SoftDTWLossPyTorch.apply(d_xxy_yxy, self.gamma)
                 loss_xy, loss_xx, loss_yy = torch.split(loss, x.shape[0])
                 return loss_xy - 1 / 2 * (loss_xx + loss_yy)
             else:
-                d_xy = self.dist_func(x, y)
+                d_xy = self.squared_dist_func(x, y)
                 return _SoftDTWLossPyTorch.apply(d_xy, self.gamma)


### PR DESCRIPTION
Improve the docstring of the class `SoftDTWLossPyTorch` and rename the parameter `dist_func` into `squared_dist_func`.
