### PR TITLE
Fix deprecated np.bool, np.int and np.float

### DIFF
--- a/tslearn/barycenters/softdtw.py
+++ b/tslearn/barycenters/softdtw.py
@@ -3,15 +3,14 @@
 import numpy
 from scipy.optimize import minimize
 
-from tslearn.utils import to_time_series_dataset, check_equal_size, \
-    to_time_series
+from tslearn.metrics import SoftDTW, SquaredEuclidean
 from tslearn.preprocessing import TimeSeriesResampler
-from tslearn.metrics import SquaredEuclidean, SoftDTW
+from tslearn.utils import check_equal_size, to_time_series, to_time_series_dataset
 
-from .utils import _set_weights
 from .euclidean import euclidean_barycenter
+from .utils import _set_weights
 
-__author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
+__author__ = "Romain Tavenard romain.tavenard[at]univ-rennes2.fr"
 
 
 def _softdtw_func(Z, X, weights, barycenter, gamma):
@@ -33,8 +32,9 @@ def _softdtw_func(Z, X, weights, barycenter, gamma):
     return obj, G.ravel()
 
 
-def softdtw_barycenter(X, gamma=1.0, weights=None, method="L-BFGS-B", tol=1e-3,
-                       max_iter=50, init=None):
+def softdtw_barycenter(
+    X, gamma=1.0, weights=None, method="L-BFGS-B", tol=1e-3, max_iter=50, init=None
+):
     """Compute barycenter (time series averaging) under the soft-DTW [1]
     geometry.
 
@@ -100,14 +100,22 @@ def softdtw_barycenter(X, gamma=1.0, weights=None, method="L-BFGS-B", tol=1e-3,
         barycenter = init
 
     if max_iter > 0:
-        X_ = numpy.array([to_time_series(d, remove_nans=True) for d in X_])
+        X_ = numpy.array(
+            [to_time_series(d, remove_nans=True) for d in X_], dtype=object
+        )
 
         def f(Z):
             return _softdtw_func(Z, X_, weights, barycenter, gamma)
 
         # The function works with vectors so we need to vectorize barycenter.
-        res = minimize(f, barycenter.ravel(), method=method, jac=True, tol=tol,
-                       options=dict(maxiter=max_iter, disp=False))
+        res = minimize(
+            f,
+            barycenter.ravel(),
+            method=method,
+            jac=True,
+            tol=tol,
+            options=dict(maxiter=max_iter, disp=False),
+        )
         return res.x.reshape(barycenter.shape)
     else:
         return barycenter

--- a/tslearn/barycenters/softdtw.py
+++ b/tslearn/barycenters/softdtw.py
@@ -100,9 +100,7 @@ def softdtw_barycenter(
         barycenter = init
 
     if max_iter > 0:
-        X_ = numpy.array(
-            [to_time_series(d, remove_nans=True) for d in X_], dtype=object
-        )
+        X_ = [to_time_series(d, remove_nans=True) for d in X_]
 
         def f(Z):
             return _softdtw_func(Z, X_, weights, barycenter, gamma)

--- a/tslearn/bases/bases.py
+++ b/tslearn/bases/bases.py
@@ -252,7 +252,7 @@ class BaseModelPackage:
             for k in model[param_type].keys():
                 param = model[param_type][k]
                 if type(param) is list:
-                    arr = np.array(param, dtype=object)
+                    arr = np.array(param)
                     if arr.dtype == object:
                         # Then maybe it was rather a list of arrays
                         # This is very hacky...

--- a/tslearn/bases/bases.py
+++ b/tslearn/bases/bases.py
@@ -252,7 +252,10 @@ class BaseModelPackage:
             for k in model[param_type].keys():
                 param = model[param_type][k]
                 if type(param) is list:
-                    arr = np.array(param)
+                    try:
+                        arr = np.array(param)
+                    except ValueError:
+                        arr = [np.array(p) for p in param]
                     if arr.dtype == object:
                         # Then maybe it was rather a list of arrays
                         # This is very hacky...

--- a/tslearn/bases/bases.py
+++ b/tslearn/bases/bases.py
@@ -254,11 +254,11 @@ class BaseModelPackage:
                 if type(param) is list:
                     try:
                         arr = np.array(param)
+                        if arr.dtype == object:
+                            # Then maybe it was rather a list of arrays
+                            # This is very hacky...
+                            arr = [np.array(p) for p in param]
                     except ValueError:
-                        arr = [np.array(p) for p in param]
-                    if arr.dtype == object:
-                        # Then maybe it was rather a list of arrays
-                        # This is very hacky...
                         arr = [np.array(p) for p in param]
                     model[param_type][k] = arr
 

--- a/tslearn/matrix_profile/matrix_profile.py
+++ b/tslearn/matrix_profile/matrix_profile.py
@@ -171,7 +171,7 @@ class MatrixProfile(TransformerMixin, BaseModelPackage, TimeSeriesBaseEstimator)
                 result = stumpy.stump(
                     T_A=X[i_ts, :, 0].ravel(), m=self.subsequence_length
                 )
-                X_transformed[i_ts, :, 0] = result[:, 0].astype(np.float)
+                X_transformed[i_ts, :, 0] = result[:, 0].astype(float)
 
         elif self.implementation == "gpu_stump":
             if not STUMPY_INSTALLED:
@@ -181,7 +181,7 @@ class MatrixProfile(TransformerMixin, BaseModelPackage, TimeSeriesBaseEstimator)
                 result = stumpy.gpu_stump(
                     T_A=X[i_ts, :, 0].ravel(), m=self.subsequence_length
                 )
-                X_transformed[i_ts, :, 0] = result[:, 0].astype(np.float)
+                X_transformed[i_ts, :, 0] = result[:, 0].astype(float)
 
         elif self.implementation == "numpy":
             scaler = TimeSeriesScalerMeanVariance()

--- a/tslearn/tests/sklearn_patches.py
+++ b/tslearn/tests/sklearn_patches.py
@@ -1,106 +1,130 @@
+import warnings
+
+import sklearn
+from sklearn.base import (
+    ClusterMixin,
+    clone,
+    is_classifier,
+    is_outlier_detector,
+    is_regressor,
+)
+from sklearn.datasets import make_blobs
+from sklearn.exceptions import DataConversionWarning
+from sklearn.metrics.pairwise import rbf_kernel
+from sklearn.utils import shuffle
+
 from tslearn.generators import random_walk_blobs
 from tslearn.preprocessing import TimeSeriesScalerMeanVariance
 
-import sklearn
-import warnings
-from sklearn.base import clone
-
-from sklearn.base import is_classifier, is_outlier_detector, is_regressor
-from sklearn.base import ClusterMixin
-from sklearn.exceptions import DataConversionWarning
-
-from sklearn.datasets import make_blobs
-from sklearn.metrics.pairwise import rbf_kernel
-
-from sklearn.utils import shuffle
 try:
+    from unittest import TestCase
+
     from sklearn.utils._testing import (
-        set_random_state, assert_array_equal,
-        assert_raises, assert_array_almost_equal,
-        assert_allclose, assert_raises_regex, assert_allclose_dense_sparse
+        assert_allclose,
+        assert_allclose_dense_sparse,
+        assert_array_almost_equal,
+        assert_array_equal,
+        assert_raises,
+        assert_raises_regex,
+        set_random_state,
     )
 
-    from unittest import TestCase
-    _dummy = TestCase('__init__')
+    _dummy = TestCase("__init__")
     assert_equal = _dummy.assertEqual
     assert_greater = _dummy.assertGreater
     assert_greater_equal = _dummy.assertGreaterEqual
 except:
     from sklearn.utils.testing import (
-        set_random_state, assert_equal, assert_greater, assert_array_equal,
-        assert_raises, assert_array_almost_equal, assert_greater_equal,
-        assert_allclose, assert_raises_regex, assert_allclose_dense_sparse
+        assert_allclose,
+        assert_allclose_dense_sparse,
+        assert_array_almost_equal,
+        assert_array_equal,
+        assert_equal,
+        assert_greater,
+        assert_greater_equal,
+        assert_raises,
+        assert_raises_regex,
+        set_random_state,
     )
+
     warnings.warn(
-        "Scikit-learn <0.24 will be deprecated in a "
-        "future release of tslearn"
+        "Scikit-learn <0.24 will be deprecated in a " "future release of tslearn"
     )
 
 from sklearn.utils.estimator_checks import (
     check_classifiers_predictions,
-    check_fit2d_1sample,
-    check_fit2d_1feature,
-    check_fit1d,
-    check_get_params_invariance,
-    check_set_params,
     check_dict_unchanged,
     check_dont_overwrite_parameters,
     check_estimators_data_not_an_array,
+    check_fit1d,
+    check_fit2d_1feature,
+    check_fit2d_1sample,
     check_fit2d_predict1d,
+    check_get_params_invariance,
     check_methods_subset_invariance,
-    check_regressors_int
+    check_regressors_int,
+    check_set_params,
 )
 
 try:
     # Most recent
     from sklearn.utils.estimator_checks import (
+        _choose_check_classifiers_labels as choose_check_classifiers_labels,
+    )
+    from sklearn.utils.estimator_checks import (
         _pairwise_estimator_convert_X as pairwise_estimator_convert_X,
-        _choose_check_classifiers_labels as choose_check_classifiers_labels
     )
 except ImportError:
     # Deprecated from sklearn v0.24 onwards
     from sklearn.utils.estimator_checks import (
+        choose_check_classifiers_labels,
         pairwise_estimator_convert_X,
-        choose_check_classifiers_labels
     )
 
 try:
     # Most recent
-    from sklearn.utils._testing import ignore_warnings, SkipTest
+    from sklearn.utils._testing import SkipTest, ignore_warnings
 except ImportError:
     # Deprecated from sklearn v0.24 onwards
     from sklearn.utils.testing import ignore_warnings, SkipTest
+
 from sklearn.exceptions import SkipTestWarning
-from sklearn.utils.estimator_checks import (_yield_classifier_checks,
-                                            _yield_regressor_checks,
-                                            _yield_transformer_checks,
-                                            _yield_clustering_checks,
-                                            _yield_outliers_checks)
+from sklearn.utils.estimator_checks import (
+    _yield_classifier_checks,
+    _yield_clustering_checks,
+    _yield_outliers_checks,
+    _yield_regressor_checks,
+    _yield_transformer_checks,
+)
+
 try:
     from sklearn.utils.estimator_checks import _yield_checks
 except ImportError:
     from sklearn.utils.estimator_checks import _yield_non_meta_checks
+
     _yield_checks = _yield_non_meta_checks
 
-from sklearn.metrics import adjusted_rand_score, accuracy_score
+import warnings
+
+import numpy as np
+from sklearn.metrics import accuracy_score, adjusted_rand_score
 from sklearn.model_selection import ShuffleSplit
 from sklearn.model_selection._validation import _safe_split
 from sklearn.pipeline import make_pipeline
 
 from tslearn.clustering import TimeSeriesKMeans
 
-import warnings
-import numpy as np
-
 
 def _create_small_ts_dataset():
-    return random_walk_blobs(n_ts_per_blob=5, n_blobs=3, random_state=1,
-                             sz=10, noise_level=0.025)
+    return random_walk_blobs(
+        n_ts_per_blob=5, n_blobs=3, random_state=1, sz=10, noise_level=0.025
+    )
 
 
 def _create_large_ts_dataset():
-    return random_walk_blobs(n_ts_per_blob=50, n_blobs=3, random_state=1,
-                             sz=20, noise_level=0.025)
+    return random_walk_blobs(
+        n_ts_per_blob=50, n_blobs=3, random_state=1, sz=20, noise_level=0.025
+    )
 
 
 def enforce_estimator_tags_y(estimator, y):
@@ -135,7 +159,6 @@ sklearn.utils.estimator_checks.BOSTON = BOSTON
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))
 def check_clustering(name, clusterer_orig, readonly_memmap=False):
-
     clusterer = clone(clusterer_orig)
     X, y = _create_small_ts_dataset()
     X, y = shuffle(X, y, random_state=7)
@@ -158,7 +181,7 @@ def check_clustering(name, clusterer_orig, readonly_memmap=False):
     assert_equal(pred.shape, (n_samples,))
     assert_greater(adjusted_rand_score(pred, y), 0.4)
 
-    if clusterer._get_tags()['non_deterministic']:
+    if clusterer._get_tags()["non_deterministic"]:
         return
 
     set_random_state(clusterer)
@@ -167,8 +190,8 @@ def check_clustering(name, clusterer_orig, readonly_memmap=False):
     assert_array_equal(pred, pred2)
 
     # fit_predict(X) and labels_ should be of type int
-    assert pred.dtype in [np.dtype('int32'), np.dtype('int64')]
-    assert pred2.dtype in [np.dtype('int32'), np.dtype('int64')]
+    assert pred.dtype in [np.dtype("int32"), np.dtype("int64")]
+    assert pred2.dtype in [np.dtype("int32"), np.dtype("int64")]
 
     # Add noise to X to test the possible values of the labels
     labels = clusterer.fit_predict(X_noise)
@@ -178,16 +201,17 @@ def check_clustering(name, clusterer_orig, readonly_memmap=False):
     assert_array_equal(labels_sorted, np.arange(0, 3))
 
     # Labels should be less than n_clusters - 1
-    if hasattr(clusterer, 'n_clusters'):
-        n_clusters = getattr(clusterer, 'n_clusters')
+    if hasattr(clusterer, "n_clusters"):
+        n_clusters = getattr(clusterer, "n_clusters")
         assert_greater_equal(n_clusters - 1, labels_sorted[-1])
+
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))
 def check_non_transf_est_n_iter(name, estimator_orig):
     # Test that estimators that are not transformers with a parameter
     # max_iter, return the attribute of n_iter_ at least 1.
     estimator = clone(estimator_orig)
-    if hasattr(estimator, 'max_iter'):
+    if hasattr(estimator, "max_iter"):
         X, y = _create_small_ts_dataset()
         set_random_state(estimator, 0)
         estimator.fit(X, y)
@@ -203,17 +227,16 @@ def check_fit_idempotent(name, estimator_orig):
     # predict(), predict_proba(), decision_function() and transform() return
     # the same results.
 
-    check_methods = ["predict", "transform", "decision_function",
-                     "predict_proba"]
+    check_methods = ["predict", "transform", "decision_function", "predict_proba"]
     rng = np.random.RandomState(0)
 
-    if estimator_orig._get_tags()['non_deterministic']:
-        msg = name + ' is non deterministic'
+    if estimator_orig._get_tags()["non_deterministic"]:
+        msg = name + " is non deterministic"
         raise SkipTest(msg)
 
     estimator = clone(estimator_orig)
     set_random_state(estimator)
-    if 'warm_start' in estimator.get_params().keys():
+    if "warm_start" in estimator.get_params().keys():
         estimator.set_params(warm_start=False)
 
     n_samples = 100
@@ -225,16 +248,18 @@ def check_fit_idempotent(name, estimator_orig):
     else:
         y = rng.randint(low=0, high=2, size=n_samples)
 
-    train, test = next(ShuffleSplit(test_size=.2, random_state=rng).split(X))
+    train, test = next(ShuffleSplit(test_size=0.2, random_state=rng).split(X))
     X_train, y_train = _safe_split(estimator, X, y, train)
     X_test, y_test = _safe_split(estimator, X, y, test, train)
 
     # Fit for the first time
     estimator.fit(X_train, y_train)
 
-    result = {method: getattr(estimator, method)(X_test)
-              for method in check_methods
-              if hasattr(estimator, method)}
+    result = {
+        method: getattr(estimator, method)(X_test)
+        for method in check_methods
+        if hasattr(estimator, method)
+    }
 
     # Fit again
     set_random_state(estimator)
@@ -244,33 +269,35 @@ def check_fit_idempotent(name, estimator_orig):
         if hasattr(estimator, method):
             new_result = getattr(estimator, method)(X_test)
             if np.issubdtype(new_result.dtype, np.floating):
-                tol = 2*np.finfo(new_result.dtype).eps
+                tol = 2 * np.finfo(new_result.dtype).eps
             else:
-                tol = 2*np.finfo(np.float64).eps
+                tol = 2 * np.finfo(np.float64).eps
             assert_allclose_dense_sparse(
-                result[method], new_result,
-                atol=max(tol, 1e-9), rtol=max(tol, 1e-7),
-                err_msg="Idempotency check failed for method {}".format(method)
+                result[method],
+                new_result,
+                atol=max(tol, 1e-9),
+                rtol=max(tol, 1e-7),
+                err_msg="Idempotency check failed for method {}".format(method),
             )
 
 
 def check_classifiers_classes(name, classifier_orig):
     # Case of shapelet models
-    if name in ['LearningShapelets', 'TimeSeriesMLPClassifier']:
+    if name in ["LearningShapelets", "TimeSeriesMLPClassifier"]:
         X_multiclass, y_multiclass = _create_large_ts_dataset()
         classifier_orig = clone(classifier_orig)
         classifier_orig.max_iter = 1000
     else:
         X_multiclass, y_multiclass = _create_small_ts_dataset()
 
-    X_multiclass, y_multiclass = shuffle(X_multiclass, y_multiclass,
-                                         random_state=7)
+    X_multiclass, y_multiclass = shuffle(X_multiclass, y_multiclass, random_state=7)
 
     scaler = TimeSeriesScalerMeanVariance()
     X_multiclass = scaler.fit_transform(X_multiclass)
 
-    X_multiclass = np.reshape(X_multiclass, (X_multiclass.shape[0],
-                                             X_multiclass.shape[1]))
+    X_multiclass = np.reshape(
+        X_multiclass, (X_multiclass.shape[0], X_multiclass.shape[1])
+    )
 
     X_binary = X_multiclass[y_multiclass != 2]
     y_binary = y_multiclass[y_multiclass != 2]
@@ -286,11 +313,11 @@ def check_classifiers_classes(name, classifier_orig):
 
     problems = [(X_binary, y_binary, y_names_binary)]
 
-    if not classifier_orig._get_tags()['binary_only']:
+    if not classifier_orig._get_tags()["binary_only"]:
         problems.append((X_multiclass, y_multiclass, y_names_multiclass))
 
     for X, y, y_names in problems:
-        for y_names_i in [y_names, y_names.astype('O')]:
+        for y_names_i in [y_names, y_names.astype("O")]:
             y_ = choose_check_classifiers_labels(name, y, y_names_i)
             check_classifiers_predictions(X, y_, name, classifier_orig)
 
@@ -301,10 +328,11 @@ def check_classifiers_classes(name, classifier_orig):
 
 
 @ignore_warnings  # Warnings are raised by decision function
-def check_classifiers_train(name, classifier_orig, readonly_memmap=False,
-                            X_dtype='float64'):
+def check_classifiers_train(
+    name, classifier_orig, readonly_memmap=False, X_dtype="float64"
+):
     # Case of shapelet models
-    if name in ['LearningShapelets', 'TimeSeriesMLPClassifier']:
+    if name in ["LearningShapelets", "TimeSeriesMLPClassifier"]:
         X_m, y_m = _create_large_ts_dataset()
         classifier_orig = clone(classifier_orig)
         classifier_orig.max_iter = 1000
@@ -325,7 +353,7 @@ def check_classifiers_train(name, classifier_orig, readonly_memmap=False,
 
     tags = classifier_orig._get_tags()
 
-    for (X, y) in problems:
+    for X, y in problems:
         classes = np.unique(y)
         n_classes = len(classes)
         n_samples, n_features, dim = X.shape
@@ -338,10 +366,11 @@ def check_classifiers_train(name, classifier_orig, readonly_memmap=False,
             with assert_raises(
                 ValueError,
                 msg="The classifier {} does not "
-                    "raise an error when incorrect/malformed input "
-                    "data for fit is passed. The number of training "
-                    "examples is not the same as the number of labels. "
-                    "Perhaps use check_X_y in fit.".format(name)):
+                "raise an error when incorrect/malformed input "
+                "data for fit is passed. The number of training "
+                "examples is not the same as the number of labels. "
+                "Perhaps use check_X_y in fit.".format(name),
+            ):
                 classifier.fit(X, y[:-1])
 
         # fit with lists
@@ -352,30 +381,32 @@ def check_classifiers_train(name, classifier_orig, readonly_memmap=False,
         assert y_pred.shape == (n_samples,)
 
         # training set performance
-        if not tags['poor_score']:
+        if not tags["poor_score"]:
             assert accuracy_score(y, y_pred) > 0.83
 
         # raises error on malformed input for predict
         msg_pairwise = (
             "The classifier {} does not raise an error when shape of X in "
-            " {} is not equal to (n_test_samples, n_training_samples)")
-        msg = ("The classifier {} does not raise an error when the number of "
-               "features in {} is different from the number of features in "
-               "fit.")
+            " {} is not equal to (n_test_samples, n_training_samples)"
+        )
+        msg = (
+            "The classifier {} does not raise an error when the number of "
+            "features in {} is different from the number of features in "
+            "fit."
+        )
 
         if not tags["no_validation"]:
             if bool(getattr(classifier, "_pairwise", False)):
-                with assert_raises(ValueError,
-                                   msg=msg_pairwise.format(name, "predict")):
+                with assert_raises(
+                    ValueError, msg=msg_pairwise.format(name, "predict")
+                ):
                     classifier.predict(X.reshape(-1, 1))
             else:
                 if not tags["allow_variable_length"]:
-                    with assert_raises(ValueError,
-                                       msg=msg.format(name, "predict")):
+                    with assert_raises(ValueError, msg=msg.format(name, "predict")):
                         classifier.predict(X.T)
                 else:
-                    with assert_raises(ValueError,
-                                       msg=msg.format(name, "predict")):
+                    with assert_raises(ValueError, msg=msg.format(name, "predict")):
                         classifier.predict(X.reshape((-1, 5, 2)))
         if hasattr(classifier, "decision_function"):
             try:
@@ -386,7 +417,7 @@ def check_classifiers_train(name, classifier_orig, readonly_memmap=False,
                         assert decision.shape == (n_samples,)
                     else:
                         assert decision.shape == (n_samples, 1)
-                    dec_pred = (decision.ravel() > 0).astype(np.int)
+                    dec_pred = (decision.ravel() > 0).astype(int)
                     assert_array_equal(dec_pred, y_pred)
                 else:
                     assert decision.shape == (n_samples, n_classes)
@@ -404,9 +435,7 @@ def check_classifiers_train(name, classifier_orig, readonly_memmap=False,
                                 classifier.decision_function(X.T)
                         else:
                             with assert_raises(ValueError, msg=error_msg):
-                                classifier.decision_function(
-                                    X.reshape((-1, 5, 2))
-                                )
+                                classifier.decision_function(X.reshape((-1, 5, 2)))
             except NotImplementedError:
                 pass
 
@@ -416,25 +445,25 @@ def check_classifiers_train(name, classifier_orig, readonly_memmap=False,
             assert y_prob.shape == (n_samples, n_classes)
             assert_array_equal(np.argmax(y_prob, axis=1), y_pred)
             # check that probas for all classes sum to one
-            assert_array_almost_equal(np.sum(y_prob, axis=1),
-                                      np.ones(n_samples))
+            assert_array_almost_equal(np.sum(y_prob, axis=1), np.ones(n_samples))
             if not tags["no_validation"]:
                 # raises error on malformed input for predict_proba
                 if bool(getattr(classifier_orig, "_pairwise", False)):
-                    with assert_raises(ValueError, msg=msg_pairwise.format(
-                            name, "predict_proba")):
+                    with assert_raises(
+                        ValueError, msg=msg_pairwise.format(name, "predict_proba")
+                    ):
                         classifier.predict_proba(X.reshape(-1, 1))
                 else:
                     if not tags["allow_variable_length"]:
-                        with assert_raises(ValueError, msg=msg.format(
-                                name, "predict_proba")):
+                        with assert_raises(
+                            ValueError, msg=msg.format(name, "predict_proba")
+                        ):
                             classifier.predict_proba(X.T)
                     else:
-                        with assert_raises(ValueError, msg=msg.format(
-                                name, "predict_proba")):
-                            classifier.predict_proba(
-                                X.reshape((-1, 5, 2))
-                            )
+                        with assert_raises(
+                            ValueError, msg=msg.format(name, "predict_proba")
+                        ):
+                            classifier.predict_proba(X.reshape((-1, 5, 2)))
             if hasattr(classifier, "predict_log_proba"):
                 # predict_log_proba is a transformation of predict_proba
                 y_log_prob = classifier.predict_log_proba(X)
@@ -444,7 +473,7 @@ def check_classifiers_train(name, classifier_orig, readonly_memmap=False,
 
 @ignore_warnings
 def check_estimators_pickle(name, estimator_orig):
-    warnings.warn('Pickling is currently NOT tested!')
+    warnings.warn("Pickling is currently NOT tested!")
     pass
 
 
@@ -452,7 +481,7 @@ def check_estimators_pickle(name, estimator_orig):
 def check_supervised_y_2d(name, estimator_orig):
     tags = estimator_orig._get_tags()
     X, y = _create_small_ts_dataset()
-    if tags['binary_only']:
+    if tags["binary_only"]:
         X = X[y != 2]
         y = y[y != 2]
 
@@ -471,14 +500,18 @@ def check_supervised_y_2d(name, estimator_orig):
         estimator.fit(X, y[:, np.newaxis])
     y_pred_2d = estimator.predict(X)
     msg = "expected 1 DataConversionWarning, got: %s" % (
-        ", ".join([str(w_x) for w_x in w]))
+        ", ".join([str(w_x) for w_x in w])
+    )
 
-    if not tags['multioutput'] and name not in ['TimeSeriesSVR']:
+    if not tags["multioutput"] and name not in ["TimeSeriesSVR"]:
         # check that we warned if we don't support multi-output
         assert len(w) > 0, msg
-        assert "DataConversionWarning('A column-vector y" \
-               " was passed when a 1d array was expected" in msg
+        assert (
+            "DataConversionWarning('A column-vector y"
+            " was passed when a 1d array was expected" in msg
+        )
         assert_allclose(y_pred.ravel(), y_pred_2d.ravel())
+
 
 @ignore_warnings(category=FutureWarning)
 def check_classifier_data_not_an_array(name, estimator_orig):
@@ -489,13 +522,12 @@ def check_classifier_data_not_an_array(name, estimator_orig):
             X_ = X[:, :, 0]  # pandas df cant be 3d
         else:
             X_ = X
-        check_estimators_data_not_an_array(name, estimator_orig, X_, y,
-                                           obj_type)
+        check_estimators_data_not_an_array(name, estimator_orig, X_, y, obj_type)
 
 
 @ignore_warnings(category=DeprecationWarning)
 def check_regressor_data_not_an_array(name, estimator_orig):
-    if name in ['TimeSeriesSVR']:
+    if name in ["TimeSeriesSVR"]:
         return
     X, y = BOSTON
     X = pairwise_estimator_convert_X(X, estimator_orig)
@@ -505,13 +537,12 @@ def check_regressor_data_not_an_array(name, estimator_orig):
             X_ = X[:, :, 0]  # pandas df cant be 3d
         else:
             X_ = X
-        check_estimators_data_not_an_array(name, estimator_orig, X_, y,
-                                           obj_type)
+        check_estimators_data_not_an_array(name, estimator_orig, X_, y, obj_type)
 
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))
 def check_regressors_int_patched(name, regressor_orig):
-    if name in ['TimeSeriesSVR']:
+    if name in ["TimeSeriesSVR"]:
         return
 
     check_regressors_int(name, regressor_orig)
@@ -524,20 +555,25 @@ def check_classifiers_cont_target(name, estimator_orig):
     X, _ = _create_small_ts_dataset()
     y = np.random.random(len(X))
     e = clone(estimator_orig)
-    msg = 'Unknown label type: '
+    msg = "Unknown label type: "
     if not e._get_tags()["no_validation"]:
         assert_raises_regex(ValueError, msg, e.fit, X, y)
 
 
 @ignore_warnings
 def check_pipeline_consistency(name, estimator_orig):
-    if estimator_orig._get_tags()['non_deterministic']:
-        msg = name + ' is non deterministic'
+    if estimator_orig._get_tags()["non_deterministic"]:
+        msg = name + " is non deterministic"
         raise SkipTest(msg)
 
     # check that make_pipeline(est) gives same score as est
-    X, y = make_blobs(n_samples=30, centers=[[0, 0, 0], [1, 1, 1]],
-                      random_state=0, n_features=2, cluster_std=0.1)
+    X, y = make_blobs(
+        n_samples=30,
+        centers=[[0, 0, 0], [1, 1, 1]],
+        random_state=0,
+        n_features=2,
+        cluster_std=0.1,
+    )
     X -= X.min()
     X = pairwise_estimator_convert_X(X, estimator_orig, kernel=rbf_kernel)
     estimator = clone(estimator_orig)
@@ -579,8 +615,7 @@ def check_different_length_fit_predict_transform(name, estimator):
 
     X2 = np.hstack((X, X))
     X3 = np.stack((X[:, :, 0], X[:, :, 0]), axis=-1)
-    check_methods = ["predict", "transform", "decision_function",
-                     "predict_proba"]
+    check_methods = ["predict", "transform", "decision_function", "predict_proba"]
     for func_name in check_methods:
         func = getattr(estimator, func_name, None)
         if func is not None:
@@ -590,22 +625,26 @@ def check_different_length_fit_predict_transform(name, estimator):
             with assert_raises(
                 ValueError,
                 msg="The estimator {} does not raise an error when number of "
-                    "features (last dimension) is different between "
-                    "fit and {}.".format(name, func_name)):
+                "features (last dimension) is different between "
+                "fit and {}.".format(name, func_name),
+            ):
                 method(X3)
 
 
 def yield_all_checks(name, estimator):
     tags = estimator._get_tags()
     if "2darray" not in tags["X_types"]:
-        warnings.warn("Can't test estimator {} which requires input "
-                      " of type {}".format(name, tags["X_types"]),
-                      SkipTestWarning)
+        warnings.warn(
+            "Can't test estimator {} which requires input "
+            " of type {}".format(name, tags["X_types"]),
+            SkipTestWarning,
+        )
         return
     if tags["_skip_test"]:
-        warnings.warn("Explicit SKIP via _skip_test tag for estimator "
-                      "{}.".format(name),
-                      SkipTestWarning)
+        warnings.warn(
+            "Explicit SKIP via _skip_test tag for estimator " "{}.".format(name),
+            SkipTestWarning,
+        )
         return
 
     yield from _yield_checks(estimator)
@@ -613,7 +652,7 @@ def yield_all_checks(name, estimator):
         yield from _yield_classifier_checks(estimator)
     if is_regressor(estimator):
         yield from _yield_regressor_checks(estimator)
-    if hasattr(estimator, 'transform'):
+    if hasattr(estimator, "transform"):
         if not tags["allow_variable_length"]:
             # Transformer tests ensure that shapes are the same at fit and
             # transform time, hence we need to skip them for estimators that
@@ -638,8 +677,10 @@ def yield_all_checks(name, estimator):
     yield check_dont_overwrite_parameters
     yield check_fit_idempotent
 
-    if (is_classifier(estimator) or
-            is_regressor(estimator) or
-            isinstance(estimator, ClusterMixin)):
+    if (
+        is_classifier(estimator)
+        or is_regressor(estimator)
+        or isinstance(estimator, ClusterMixin)
+    ):
         if tags["allow_variable_length"]:
             yield check_different_length_fit_predict_transform

--- a/tslearn/tests/test_matrixprofile.py
+++ b/tslearn/tests/test_matrixprofile.py
@@ -18,7 +18,7 @@ def test_consistent_with_stumpy():
 
     X_tr = mp.fit_transform(X)
     X_tr_stumpy_wrap = mp_stumpy.fit_transform(X)
-    X_tr_stumpy = stumpy.stump(X_stumpy, m=10)[:, 0].astype(np.float)
+    X_tr_stumpy = stumpy.stump(X_stumpy, m=10)[:, 0].astype(float)
 
     np.testing.assert_allclose(X_tr.ravel(), X_tr_stumpy)
     np.testing.assert_allclose(X_tr, X_tr_stumpy_wrap)

--- a/tslearn/utils/cast.py
+++ b/tslearn/utils/cast.py
@@ -5,11 +5,12 @@ from sklearn.utils import check_array
 
 try:
     from scipy.io import arff
+
     HAS_ARFF = True
 except:
     HAS_ARFF = False
 
-from .utils import check_dataset, ts_size, to_time_series_dataset
+from .utils import check_dataset, to_time_series_dataset, ts_size
 
 
 def to_sklearn_dataset(dataset, dtype=float, return_dim=False):
@@ -127,9 +128,11 @@ def from_pyts_dataset(X):
     elif X_.ndim == 3:
         return X_.transpose((0, 2, 1))
     else:
-        raise ValueError("X is not a valid input pyts array. "
-                         "Its dimensions, once cast to numpy.ndarray "
-                         "are {}".format(X_.shape))
+        raise ValueError(
+            "X is not a valid input pyts array. "
+            "Its dimensions, once cast to numpy.ndarray "
+            "are {}".format(X_.shape)
+        )
 
 
 def to_seglearn_dataset(X):
@@ -166,7 +169,7 @@ def to_seglearn_dataset(X):
     (10, 2)
     """
     X_ = check_dataset(X)
-    return numpy.array([Xi[:ts_size(Xi)] for Xi in X_])
+    return numpy.array([Xi[: ts_size(Xi)] for Xi in X_], dtype=object)
 
 
 def from_seglearn_dataset(X):
@@ -233,11 +236,11 @@ def to_stumpy_dataset(X):
 
     def transpose_or_flatten(ts):
         if ts.shape[1] == 1:
-            return ts.reshape((-1, ))
+            return ts.reshape((-1,))
         else:
             return ts.transpose()
 
-    return [transpose_or_flatten(Xi[:ts_size(Xi)]) for Xi in X_]
+    return [transpose_or_flatten(Xi[: ts_size(Xi)]) for Xi in X_]
 
 
 def from_stumpy_dataset(X):
@@ -264,11 +267,13 @@ def from_stumpy_dataset(X):
     >>> tslearn_arr.shape
     (2, 10, 3)
     """
+
     def transpose_or_expand(ts):
         if ts.ndim == 1:
             return ts.reshape((-1, 1))
         else:
             return ts.transpose()
+
     return to_time_series_dataset([transpose_or_expand(Xi) for Xi in X])
 
 
@@ -308,13 +313,14 @@ def to_sktime_dataset(X):
     try:
         import pandas as pd
     except ImportError:
-        raise ImportError("Conversion from/to sktime cannot be performed "
-                          "if pandas is not installed.")
+        raise ImportError(
+            "Conversion from/to sktime cannot be performed "
+            "if pandas is not installed."
+        )
     X_ = check_dataset(X)
     X_pd = pd.DataFrame(dtype=float)
     for dim in range(X_.shape[2]):
-        X_pd['dim_' + str(dim)] = [pd.Series(data=Xi[:ts_size(Xi), dim])
-                                   for Xi in X_]
+        X_pd["dim_" + str(dim)] = [pd.Series(data=Xi[: ts_size(Xi), dim]) for Xi in X_]
     return X_pd
 
 
@@ -363,20 +369,25 @@ def from_sktime_dataset(X):
     try:
         import pandas as pd
     except ImportError:
-        raise ImportError("Conversion from/to sktime cannot be performed "
-                          "if pandas is not installed.")
+        raise ImportError(
+            "Conversion from/to sktime cannot be performed "
+            "if pandas is not installed."
+        )
     if not isinstance(X, pd.DataFrame):
-        raise ValueError("X is not a valid input sktime array. "
-                         "A pandas DataFrame is expected.")
-    data_dimensions = [col_name
-                       for col_name in X.columns
-                       if col_name.startswith("dim_")]
+        raise ValueError(
+            "X is not a valid input sktime array. " "A pandas DataFrame is expected."
+        )
+    data_dimensions = [
+        col_name for col_name in X.columns if col_name.startswith("dim_")
+    ]
     d = len(data_dimensions)
     ordered_data_dimensions = ["dim_%d" % di for di in range(d)]
     if sorted(ordered_data_dimensions) != sorted(data_dimensions):
-        raise ValueError("X is not a valid input sktime array. "
-                         "Provided dimensions are not conitiguous."
-                         "{}".format(data_dimensions))
+        raise ValueError(
+            "X is not a valid input sktime array. "
+            "Provided dimensions are not conitiguous."
+            "{}".format(data_dimensions)
+        )
     n = X["dim_0"].shape[0]
     max_sz = -1
     for dim_name in ordered_data_dimensions:
@@ -434,11 +445,11 @@ def to_pyflux_dataset(X):
     try:
         import pandas as pd
     except ImportError:
-        raise ImportError("Conversion from/to pyflux cannot be performed "
-                          "if pandas is not installed.")
-    X_ = check_dataset(X,
-                       force_equal_length=True,
-                       force_single_time_series=True)
+        raise ImportError(
+            "Conversion from/to pyflux cannot be performed "
+            "if pandas is not installed."
+        )
+    X_ = check_dataset(X, force_equal_length=True, force_single_time_series=True)
     X_pd = pd.DataFrame(X[0], dtype=float)
     X_pd.columns = ["dim_%d" % di for di in range(X_.shape[2])]
     return X_pd
@@ -488,11 +499,14 @@ def from_pyflux_dataset(X):
     try:
         import pandas as pd
     except ImportError:
-        raise ImportError("Conversion from/to pyflux cannot be performed "
-                          "if pandas is not installed.")
+        raise ImportError(
+            "Conversion from/to pyflux cannot be performed "
+            "if pandas is not installed."
+        )
     if not isinstance(X, pd.DataFrame):
-        raise ValueError("X is not a valid input pyflux array. "
-                         "A pandas DataFrame is expected.")
+        raise ValueError(
+            "X is not a valid input pyflux array. " "A pandas DataFrame is expected."
+        )
     data_dimensions = [col_name for col_name in X.columns]
     d = len(data_dimensions)
     n = 1
@@ -543,15 +557,16 @@ def to_tsfresh_dataset(X):
     try:
         import pandas as pd
     except ImportError:
-        raise ImportError("Conversion from/to tsfresh cannot be performed "
-                          "if pandas is not installed.")
+        raise ImportError(
+            "Conversion from/to tsfresh cannot be performed "
+            "if pandas is not installed."
+        )
     X_ = check_dataset(X)
     n, sz, d = X_.shape
     dataframes = []
     for i, Xi in enumerate(X_):
-        df = pd.DataFrame(columns=["id", "time"] +
-                                  ["dim_%d" % di for di in range(d)])
-        Xi_ = Xi[:ts_size(Xi)]
+        df = pd.DataFrame(columns=["id", "time"] + ["dim_%d" % di for di in range(d)])
+        Xi_ = Xi[: ts_size(Xi)]
         sz = Xi_.shape[0]
         df["time"] = numpy.arange(sz)
         df["id"] = numpy.zeros((sz,), dtype=int) + i
@@ -609,14 +624,17 @@ def from_tsfresh_dataset(X):
     try:
         import pandas as pd
     except ImportError:
-        raise ImportError("Conversion from/to tsfresh cannot be performed "
-                          "if pandas is not installed.")
+        raise ImportError(
+            "Conversion from/to tsfresh cannot be performed "
+            "if pandas is not installed."
+        )
     if not isinstance(X, pd.DataFrame):
-        raise ValueError("X is not a valid input tsfresh array. "
-                         "A pandas DataFrame is expected.")
-    data_dimensions = [col_name
-                       for col_name in X.columns
-                       if col_name not in ["id", "time"]]
+        raise ValueError(
+            "X is not a valid input tsfresh array. " "A pandas DataFrame is expected."
+        )
+    data_dimensions = [
+        col_name for col_name in X.columns if col_name not in ["id", "time"]
+    ]
     d = len(data_dimensions)
     all_ids = set(X["id"])
     n = len(all_ids)
@@ -680,13 +698,15 @@ def to_cesium_dataset(X):
     try:
         from cesium.time_series import TimeSeries
     except ImportError:
-        raise ImportError("Conversion from/to cesium cannot be performed "
-                          "if cesium is not installed.")
+        raise ImportError(
+            "Conversion from/to cesium cannot be performed "
+            "if cesium is not installed."
+        )
 
     def transpose_or_flatten(ts):
-        ts_ = ts[:ts_size(ts)]
+        ts_ = ts[: ts_size(ts)]
         if ts.shape[1] == 1:
-            return ts_.reshape((-1, ))
+            return ts_.reshape((-1,))
         else:
             return ts_.transpose()
 
@@ -730,16 +750,20 @@ def from_cesium_dataset(X):
     try:
         from cesium.time_series import TimeSeries
     except ImportError:
-        raise ImportError("Conversion from/to cesium cannot be performed "
-                          "if cesium is not installed.")
+        raise ImportError(
+            "Conversion from/to cesium cannot be performed "
+            "if cesium is not installed."
+        )
 
     def format_to_tslearn(ts):
         try:
             ts.sort()
         except ValueError:
-            warnings.warn("Cesium dataset could not be sorted, assuming "
-                          "it is already sorted before casting to "
-                          "tslearn format.")
+            warnings.warn(
+                "Cesium dataset could not be sorted, assuming "
+                "it is already sorted before casting to "
+                "tslearn format."
+            )
         if ts.measurement.ndim == 1:
             data = ts.measurement.reshape((1, -1))
         else:
@@ -753,9 +777,10 @@ def from_cesium_dataset(X):
             tslearn_ts[:sz, di] = data[di]
         return tslearn_ts
 
-    if not isinstance(X, list) or \
-            [type(ts) for ts in X] != [TimeSeries] * len(X):
-        raise ValueError("X is not a valid input cesium array. "
-                         "A list of cesium TimeSeries is expected.")
+    if not isinstance(X, list) or [type(ts) for ts in X] != [TimeSeries] * len(X):
+        raise ValueError(
+            "X is not a valid input cesium array. "
+            "A list of cesium TimeSeries is expected."
+        )
     dataset = [format_to_tslearn(ts) for ts in X]
     return to_time_series_dataset(dataset=dataset)


### PR DESCRIPTION
The continuous integration test `docs/readthedocs.org:tslearn` is failing due to `np.bool` being a deprecated alias for the builtin `bool` in NumPy 1.20.

Here is one of the error messages:

```
Extension error:
Here is a summary of the problems encountered when running the examples

Unexpected failing examples:
/home/docs/checkouts/readthedocs.org/user_builds/tslearn/checkouts/467/docs/examples/misc/plot_distance_and_matrix_profile.py failed leaving traceback:
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/tslearn/checkouts/467/docs/examples/misc/plot_distance_and_matrix_profile.py", line 47, in <module>
    mp = matrix_profiler.fit_transform([ts]).flatten()
  File "/home/docs/checkouts/readthedocs.org/user_builds/tslearn/envs/467/lib/python3.8/site-packages/sklearn/utils/_set_output.py", line 140, in wrapped
    data_to_wrap = f(self, X, *args, **kwargs)
  File "/home/docs/checkouts/readthedocs.org/user_builds/tslearn/envs/467/lib/python3.8/site-packages/tslearn-0.6.1-py3.8.egg/tslearn/matrix_profile/matrix_profile.py", line 250, in fit_transform
    return self._fit(X)._transform(X)
  File "/home/docs/checkouts/readthedocs.org/user_builds/tslearn/envs/467/lib/python3.8/site-packages/tslearn-0.6.1-py3.8.egg/tslearn/matrix_profile/matrix_profile.py", line 195, in _transform
    band_width, dtype=np.bool) &
  File "/home/docs/checkouts/readthedocs.org/user_builds/tslearn/envs/467/lib/python3.8/site-packages/numpy/__init__.py", line 305, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'bool'.
`np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```