### PR TITLE
Fix errors deprecated np.bool, np.int and np.float and array of inhomogeneous shape

### DIFF
--- a/tslearn/barycenters/softdtw.py
+++ b/tslearn/barycenters/softdtw.py
@@ -100,7 +100,7 @@ def softdtw_barycenter(X, gamma=1.0, weights=None, method="L-BFGS-B", tol=1e-3,
         barycenter = init
 
     if max_iter > 0:
-        X_ = numpy.array([to_time_series(d, remove_nans=True) for d in X_])
+        X_ = [to_time_series(d, remove_nans=True) for d in X_]
 
         def f(Z):
             return _softdtw_func(Z, X_, weights, barycenter, gamma)

--- a/tslearn/bases/bases.py
+++ b/tslearn/bases/bases.py
@@ -245,10 +245,13 @@ class BaseModelPackage:
             for k in model[param_type].keys():
                 param = model[param_type][k]
                 if type(param) is list:
-                    arr = np.array(param)
-                    if arr.dtype == object:
-                        # Then maybe it was rather a list of arrays
-                        # This is very hacky...
+                    try:
+                        arr = np.array(param)
+                        if arr.dtype == object:
+                            # Then maybe it was rather a list of arrays
+                            # This is very hacky...
+                            arr = [np.array(p) for p in param]
+                    except ValueError:
                         arr = [np.array(p) for p in param]
                     model[param_type][k] = arr
 

--- a/tslearn/matrix_profile/matrix_profile.py
+++ b/tslearn/matrix_profile/matrix_profile.py
@@ -169,7 +169,7 @@ class MatrixProfile(TransformerMixin,
                 result = stumpy.stump(
                     T_A=X[i_ts, :, 0].ravel(),
                     m=self.subsequence_length)
-                X_transformed[i_ts, :, 0] = result[:, 0].astype(np.float)
+                X_transformed[i_ts, :, 0] = result[:, 0].astype(float)
 
         elif self.implementation == "gpu_stump":
             if not STUMPY_INSTALLED:
@@ -179,7 +179,7 @@ class MatrixProfile(TransformerMixin,
                 result = stumpy.gpu_stump(
                     T_A=X[i_ts, :, 0].ravel(),
                     m=self.subsequence_length)
-                X_transformed[i_ts, :, 0] = result[:, 0].astype(np.float)
+                X_transformed[i_ts, :, 0] = result[:, 0].astype(float)
 
         elif self.implementation == "numpy":
             scaler = TimeSeriesScalerMeanVariance()

--- a/tslearn/matrix_profile/matrix_profile.py
+++ b/tslearn/matrix_profile/matrix_profile.py
@@ -192,9 +192,9 @@ class MatrixProfile(TransformerMixin,
                 segments_2d = segments.reshape((-1, self.subsequence_length * d))
                 dists = squareform(pdist(segments_2d, "euclidean"))
                 band = (np.tri(n_segments, n_segments,
-                            band_width, dtype=np.bool) &
+                            band_width, dtype=bool) &
                         ~np.tri(n_segments, n_segments,
-                                -(band_width + 1), dtype=np.bool))
+                                -(band_width + 1), dtype=bool))
                 dists[band] = np.inf
                 X_transformed[i_ts] = dists.min(axis=1, keepdims=True)
 

--- a/tslearn/shapelets/shapelets.py
+++ b/tslearn/shapelets/shapelets.py
@@ -583,7 +583,7 @@ class LearningShapelets(ClassifierMixin, TransformerMixin,
             [X[:, :, di].reshape((n_ts, sz, 1)) for di in range(self.d_)],
             batch_size=self.batch_size, verbose=self.verbose
         )
-        return locations.astype(numpy.int_)
+        return locations.astype(int)
 
     def _check_series_length(self, X):
         """Ensures that time series in X matches the following requirements:

--- a/tslearn/svm/svm.py
+++ b/tslearn/svm/svm.py
@@ -458,7 +458,7 @@ class TimeSeriesSVR(TimeSeriesSVMMixin, RegressorMixin,
     >>> from tslearn.generators import random_walk_blobs
     >>> X, y = random_walk_blobs(n_ts_per_blob=10, sz=64, d=2, n_blobs=2)
     >>> import numpy
-    >>> y = y.astype(numpy.float) + numpy.random.randn(20) * .1
+    >>> y = y.astype(float) + numpy.random.randn(20) * .1
     >>> reg = TimeSeriesSVR(kernel="gak", gamma="auto")
     >>> reg.fit(X, y).predict(X).shape
     (20,)

--- a/tslearn/tests/sklearn_patches.py
+++ b/tslearn/tests/sklearn_patches.py
@@ -386,7 +386,7 @@ def check_classifiers_train(name, classifier_orig, readonly_memmap=False,
                         assert decision.shape == (n_samples,)
                     else:
                         assert decision.shape == (n_samples, 1)
-                    dec_pred = (decision.ravel() > 0).astype(np.int)
+                    dec_pred = (decision.ravel() > 0).astype(int)
                     assert_array_equal(dec_pred, y_pred)
                 else:
                     assert decision.shape == (n_samples, n_classes)

--- a/tslearn/tests/test_matrixprofile.py
+++ b/tslearn/tests/test_matrixprofile.py
@@ -18,7 +18,7 @@ def test_consistent_with_stumpy():
 
     X_tr = mp.fit_transform(X)
     X_tr_stumpy_wrap = mp_stumpy.fit_transform(X)
-    X_tr_stumpy = stumpy.stump(X_stumpy, m=10)[:, 0].astype(np.float)
+    X_tr_stumpy = stumpy.stump(X_stumpy, m=10)[:, 0].astype(float)
 
     np.testing.assert_allclose(X_tr.ravel(), X_tr_stumpy)
     np.testing.assert_allclose(X_tr, X_tr_stumpy_wrap)

--- a/tslearn/tests/test_serialize_models.py
+++ b/tslearn/tests/test_serialize_models.py
@@ -39,7 +39,7 @@ def clear_tmp():
 
 def test_hdftools():
     dtypes = [int, numpy.int8, numpy.int16, numpy.int32, numpy.int64,
-              numpy.float, numpy.float32, numpy.float64]
+              float, numpy.float32, numpy.float64]
 
     d = {}
 

--- a/tslearn/tests/test_serialize_models.py
+++ b/tslearn/tests/test_serialize_models.py
@@ -38,7 +38,7 @@ def clear_tmp():
 
 
 def test_hdftools():
-    dtypes = [numpy.int, numpy.int8, numpy.int16, numpy.int32, numpy.int64,
+    dtypes = [int, numpy.int8, numpy.int16, numpy.int32, numpy.int64,
               numpy.float, numpy.float32, numpy.float64]
 
     d = {}

--- a/tslearn/utils/cast.py
+++ b/tslearn/utils/cast.py
@@ -166,7 +166,7 @@ def to_seglearn_dataset(X):
     (10, 2)
     """
     X_ = check_dataset(X)
-    return numpy.array([Xi[:ts_size(Xi)] for Xi in X_])
+    return numpy.array([Xi[:ts_size(Xi)] for Xi in X_], dtype=object)
 
 
 def from_seglearn_dataset(X):


### PR DESCRIPTION
This PR has the same objective than the PR #468: to fix errors related to deprecated `np.bool`, `np.int` and `np.float` and arrays of inhomogeneous shape.
The package `black` has been used in the PR #468 on the modified files to reformat the codes, which makes the PR difficult to review.
This PR aims to be cleaner, avoiding the use of the package black on the modified files.