### PR TITLE
Fix failing tests for Python 3.10

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
   - script: |
       set -xe
       python -m pip install pytest pytest-azurepipelines
-      python -m pip install scikit-learn==1.3
+      python -m pip install scikit-learn==1.2
       python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules
     displayName: 'Test'
@@ -80,7 +80,7 @@ jobs:
   - script: |
       set -xe
       python -m pip install pytest pytest-azurepipelines
-      python -m pip install scikit-learn==1.3
+      python -m pip install scikit-learn==1.2
       python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules
     displayName: 'Test'
@@ -123,7 +123,7 @@ jobs:
       python -m pip install pytest pytest-azurepipelines
       python -m pip install coverage pytest-cov
       python -m pip install cesium pandas stumpy
-      python -m pip install scikit-learn==1.3
+      python -m pip install scikit-learn==1.2
       python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules --cov=tslearn
     displayName: 'Test'
@@ -175,7 +175,7 @@ jobs:
   - script: |
       set -xe
       python -m pip install pytest pytest-azurepipelines
-      python -m pip install scikit-learn==1.3
+      python -m pip install scikit-learn==1.2
       python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules -k 'not test_all_estimators'
     displayName: 'Test'
@@ -218,7 +218,7 @@ jobs:
   
   - script: |
       python -m pip install pytest pytest-azurepipelines
-      python -m pip install scikit-learn==1.3
+      python -m pip install scikit-learn==1.2
       python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules --ignore tslearn/tests/test_estimators.py --ignore tslearn/utils/cast.py
     displayName: 'Test'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,8 +41,8 @@ jobs:
   - script: |
       set -xe
       python -m pip install pytest pytest-azurepipelines
-      python -m pip install scikit-learn
-      python -m pip install tensorflow
+      python -m pip install scikit-learn==1.2
+      python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules
     displayName: 'Test'
 
@@ -80,8 +80,8 @@ jobs:
   - script: |
       set -xe
       python -m pip install pytest pytest-azurepipelines
-      python -m pip install scikit-learn
-      python -m pip install tensorflow
+      python -m pip install scikit-learn==1.2
+      python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules
     displayName: 'Test'
 
@@ -175,7 +175,7 @@ jobs:
   - script: |
       set -xe
       python -m pip install pytest pytest-azurepipelines
-      python -m pip install scikit-learn
+      python -m pip install scikit-learn==1.1
       python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules -k 'not test_all_estimators'
     displayName: 'Test'
@@ -219,6 +219,6 @@ jobs:
   - script: |
       python -m pip install pytest pytest-azurepipelines
       python -m pip install scikit-learn==1.0
-      python -m pip install tensorflow
+      python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules --ignore tslearn/tests/test_estimators.py --ignore tslearn/utils/cast.py
     displayName: 'Test'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,8 +41,8 @@ jobs:
   - script: |
       set -xe
       python -m pip install pytest pytest-azurepipelines
-      python -m pip install scikit-learn==1.0
-      python -m pip install tensorflow==2.9.0
+      python -m pip install scikit-learn
+      python -m pip install tensorflow
       python -m pytest -v tslearn/ --doctest-modules
     displayName: 'Test'
 
@@ -80,8 +80,8 @@ jobs:
   - script: |
       set -xe
       python -m pip install pytest pytest-azurepipelines
-      python -m pip install scikit-learn==1.0
-      python -m pip install tensorflow==2.9.0
+      python -m pip install scikit-learn
+      python -m pip install tensorflow
       python -m pytest -v tslearn/ --doctest-modules
     displayName: 'Test'
 
@@ -123,8 +123,8 @@ jobs:
       python -m pip install pytest pytest-azurepipelines
       python -m pip install coverage pytest-cov
       python -m pip install cesium pandas stumpy
-      python -m pip install scikit-learn==1.0
-      python -m pip install tensorflow==2.9.0
+      python -m pip install scikit-learn
+      python -m pip install tensorflow
       python -m pytest -v tslearn/ --doctest-modules --cov=tslearn
     displayName: 'Test'
 
@@ -175,7 +175,7 @@ jobs:
   - script: |
       set -xe
       python -m pip install pytest pytest-azurepipelines
-      python -m pip install scikit-learn==1.0
+      python -m pip install scikit-learn
       python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules -k 'not test_all_estimators'
     displayName: 'Test'
@@ -219,6 +219,6 @@ jobs:
   - script: |
       python -m pip install pytest pytest-azurepipelines
       python -m pip install scikit-learn==1.0
-      python -m pip install tensorflow==2.9.0
+      python -m pip install tensorflow
       python -m pytest -v tslearn/ --doctest-modules --ignore tslearn/tests/test_estimators.py --ignore tslearn/utils/cast.py
     displayName: 'Test'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,8 +123,8 @@ jobs:
       python -m pip install pytest pytest-azurepipelines
       python -m pip install coverage pytest-cov
       python -m pip install cesium pandas stumpy
-      python -m pip install scikit-learn
-      python -m pip install tensorflow
+      python -m pip install scikit-learn==1.1
+      python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules --cov=tslearn
     displayName: 'Test'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
   - script: |
       set -xe
       python -m pip install pytest pytest-azurepipelines
-      python -m pip install scikit-learn==1.2
+      python -m pip install scikit-learn==1.1
       python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules
     displayName: 'Test'
@@ -80,7 +80,7 @@ jobs:
   - script: |
       set -xe
       python -m pip install pytest pytest-azurepipelines
-      python -m pip install scikit-learn==1.2
+      python -m pip install scikit-learn==1.1
       python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules
     displayName: 'Test'
@@ -218,7 +218,7 @@ jobs:
   
   - script: |
       python -m pip install pytest pytest-azurepipelines
-      python -m pip install scikit-learn==1.0
+      python -m pip install scikit-learn==1.1
       python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules --ignore tslearn/tests/test_estimators.py --ignore tslearn/utils/cast.py
     displayName: 'Test'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
   - script: |
       set -xe
       python -m pip install pytest pytest-azurepipelines
-      python -m pip install scikit-learn==1.1
+      python -m pip install scikit-learn==1.3
       python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules
     displayName: 'Test'
@@ -80,7 +80,7 @@ jobs:
   - script: |
       set -xe
       python -m pip install pytest pytest-azurepipelines
-      python -m pip install scikit-learn==1.1
+      python -m pip install scikit-learn==1.3
       python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules
     displayName: 'Test'
@@ -123,7 +123,7 @@ jobs:
       python -m pip install pytest pytest-azurepipelines
       python -m pip install coverage pytest-cov
       python -m pip install cesium pandas stumpy
-      python -m pip install scikit-learn==1.1
+      python -m pip install scikit-learn==1.3
       python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules --cov=tslearn
     displayName: 'Test'
@@ -175,7 +175,7 @@ jobs:
   - script: |
       set -xe
       python -m pip install pytest pytest-azurepipelines
-      python -m pip install scikit-learn==1.1
+      python -m pip install scikit-learn==1.3
       python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules -k 'not test_all_estimators'
     displayName: 'Test'
@@ -218,7 +218,7 @@ jobs:
   
   - script: |
       python -m pip install pytest pytest-azurepipelines
-      python -m pip install scikit-learn==1.1
+      python -m pip install scikit-learn==1.3
       python -m pip install tensorflow==2.9.0
       python -m pytest -v tslearn/ --doctest-modules --ignore tslearn/tests/test_estimators.py --ignore tslearn/utils/cast.py
     displayName: 'Test'

--- a/tslearn/tests/sklearn_patches.py
+++ b/tslearn/tests/sklearn_patches.py
@@ -10,9 +10,10 @@ from sklearn.base import ClusterMixin
 from sklearn.exceptions import DataConversionWarning
 
 from sklearn.datasets import make_blobs
-from sklearn.metrics.pairwise import rbf_kernel
+from sklearn.metrics.pairwise import rbf_kernel, linear_kernel, pairwise_distances
 
 from sklearn.utils import shuffle
+
 try:
     from sklearn.utils._testing import (
         set_random_state, assert_array_equal,
@@ -54,13 +55,11 @@ from sklearn.utils.estimator_checks import (
 try:
     # Most recent
     from sklearn.utils.estimator_checks import (
-        _pairwise_estimator_convert_X as pairwise_estimator_convert_X,
         _choose_check_classifiers_labels as choose_check_classifiers_labels
     )
 except ImportError:
     # Deprecated from sklearn v0.24 onwards
     from sklearn.utils.estimator_checks import (
-        pairwise_estimator_convert_X,
         choose_check_classifiers_labels
     )
 
@@ -75,7 +74,8 @@ from sklearn.utils.estimator_checks import (_yield_classifier_checks,
                                             _yield_regressor_checks,
                                             _yield_transformer_checks,
                                             _yield_clustering_checks,
-                                            _yield_outliers_checks)
+                                            _yield_outliers_checks,
+                                            _is_pairwise_metric)
 try:
     from sklearn.utils.estimator_checks import _yield_checks
 except ImportError:
@@ -101,6 +101,15 @@ def _create_small_ts_dataset():
 def _create_large_ts_dataset():
     return random_walk_blobs(n_ts_per_blob=50, n_blobs=3, random_state=1,
                              sz=20, noise_level=0.025)
+
+
+def pairwise_estimator_convert_X(X, estimator, kernel=linear_kernel):
+    if _is_pairwise_metric(estimator):
+        return pairwise_distances(X, metric="euclidean")
+    if estimator._get_tags()["pairwise"]:
+        return kernel(X, X)
+
+    return X
 
 
 def enforce_estimator_tags_y(estimator, y):


### PR DESCRIPTION
All the tests related to Python 3.10 are failing:
- codecov Python 3.10
- linux_without_torch Python 3.10
- macOS Python 3.10
- windows Python 3.10

The error message is the following:
```
+ python -m pip install scikit-learn==1.0
Collecting scikit-learn==1.0
  Downloading scikit-learn-1.0.tar.gz (7.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 7.8/7.8 MB 13.4 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): still running...
  Preparing metadata (pyproject.toml): finished with status 'error'
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [755 lines of output]
      Partial import of sklearn during the build process.
      C compiler: gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -I/usr/local/opt/sqlite/include -I/usr/local/opt/sqlite/include
      
      compile options: '-c'
      gcc: test_program.c
      gcc objects/test_program.o -o test_program
      C compiler: gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -I/usr/local/opt/sqlite/include -I/usr/local/opt/sqlite/include
      
      compile options: '-c'
      extra options: '-fopenmp'
      gcc: test_program.c
      clang: error: unsupported option '-fopenmp'
      /private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-install-ebtyegcb/scikit-learn_1f5ba47121644512ad4ef4ee8cc8d921/sklearn/_build_utils/openmp_helpers.py:126: UserWarning:
      
      
                      ***********
                      * WARNING *
                      ***********
      
      It seems that scikit-learn cannot be built with OpenMP.
      
      - Make sure you have followed the installation instructions:
      
          https://scikit-learn.org/dev/developers/advanced_installation.html
      
      - If your compiler supports OpenMP but you still see this
        message, please submit a bug report at:
      
          https://github.com/scikit-learn/scikit-learn/issues
      
      - The build will continue with OpenMP-based parallelism
        disabled. Note however that some estimators will run in
        sequential mode instead of leveraging thread-based
        parallelism.

```

```
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

```