### PR TITLE
 Fix bug related to SoftDTWLossPytorch with option normalize=True when used on inputs of different lengths

### DIFF
--- a/tslearn/metrics/soft_dtw_loss_pytorch.py
+++ b/tslearn/metrics/soft_dtw_loss_pytorch.py
@@ -230,13 +230,13 @@ else:
             by, ly, dy = y.shape
             assert bx == by
             assert dx == dy
+            d_xy = self.dist_func(x, y)
+            loss_xy = _SoftDTWLossPyTorch.apply(d_xy, self.gamma)
             if self.normalize:
-                xxy = torch.cat([x, x, y])
-                yxy = torch.cat([y, x, y])
-                d_xxy_yxy = self.dist_func(xxy, yxy)
-                loss = _SoftDTWLossPyTorch.apply(d_xxy_yxy, self.gamma)
-                loss_xy, loss_xx, loss_yy = torch.split(loss, x.shape[0])
+                d_xx = self.dist_func(x, x)
+                d_yy = self.dist_func(y, y)
+                loss_xx = _SoftDTWLossPyTorch.apply(d_xx, self.gamma)
+                loss_yy = _SoftDTWLossPyTorch.apply(d_yy, self.gamma)
                 return loss_xy - 1 / 2 * (loss_xx + loss_yy)
             else:
-                d_xy = self.dist_func(x, y)
-                return _SoftDTWLossPyTorch.apply(d_xy, self.gamma)
+                return loss_xy

--- a/tslearn/tests/test_metrics.py
+++ b/tslearn/tests/test_metrics.py
@@ -618,6 +618,9 @@ def test_soft_dtw_loss_pytorch():
         )
     )
 
+    loss_normalized = soft_dtw_loss_pytorch_normalized.forward(batch_ts_1, batch_ts_2)
+    np.testing.assert_allclose(loss_normalized.detach().numpy(), 107.89006805 * torch.ones((b,)))
+
     def euclidean_abs_dist(x, y):
         """Calculates the Euclidean squared distance between each element in x and y per timestep.
 


### PR DESCRIPTION
This PR is related to the issue https://github.com/tslearn-team/tslearn/issues/473 reporting an error message when `SoftDTWLossPytorch`  with option `normalize=True` is used on inputs of different lengths.
The bug is coming from the use of `torch.cat` (https://pytorch.org/docs/stable/generated/torch.cat.html) which impose the lengths of the inputs to be equal. (The shape of the inputs is `[batch_size, length, dim]`.)
The use of `torch.cat` is removed in this PR.