### PR TITLE
Cast the input data to backend option and test functions in metrics for different input data types and different backend options.

### DIFF
--- a/tslearn/backend/__init__.py
+++ b/tslearn/backend/__init__.py
@@ -3,10 +3,11 @@ The :mod:`tslearn.backend` module provides multiple backends.
 The backends provided are NumPy and PyTorch.
 """
 
-from .backend import Backend, instantiate_backend, select_backend
+from .backend import Backend, cast, instantiate_backend, select_backend
 
 __all__ = [
     "Backend",
+    "cast",
     "instantiate_backend",
     "select_backend",
 ]

--- a/tslearn/backend/backend.py
+++ b/tslearn/backend/backend.py
@@ -93,7 +93,7 @@ class Backend(object):
 
 
 def cast(data, array_type="numpy"):
-    """Cast the data.
+    """Cast data to list or specific backend.
 
     Parameters
     ----------
@@ -110,6 +110,8 @@ def cast(data, array_type="numpy"):
     """
     data_type_string = f"{type(data)}".lower()
     array_type = array_type.lower()
+    if array_type == "pytorch":
+        array_type = "torch"
     if array_type in data_type_string:
         return data
     if array_type == "list":

--- a/tslearn/backend/backend.py
+++ b/tslearn/backend/backend.py
@@ -90,3 +90,29 @@ class Backend(object):
 
     def set_backend(self, data=None):
         self.backend = select_backend(data)
+
+
+def cast(data, array_type="numpy"):
+    """Cast the data.
+
+    Parameters
+    ----------
+    data: array-like,
+        The input data should be a list or numpy array or torch array.
+        The data to cast.
+    array_type: string
+        The type to cast the data. It can be "numpy", "pytorch" or "list".
+
+    Returns
+    --------
+    data_cast: array-like
+        Data cast to array_type.
+    """
+    data_type_string = f"{type(data)}".lower()
+    array_type = array_type.lower()
+    if array_type in data_type_string:
+        return data
+    if array_type == "list":
+        return data.tolist()
+    be = Backend(array_type)
+    return be.array(data)

--- a/tslearn/backend/numpy_backend.py
+++ b/tslearn/backend/numpy_backend.py
@@ -82,6 +82,10 @@ class NumPyBackend(object):
         self.zeros_like = _np.zeros_like
 
     @staticmethod
+    def belongs_to_backend(x):
+        return "numpy" in f"{type(x)}".lower()
+
+    @staticmethod
     def cast(x, dtype):
         return x.astype(dtype)
 

--- a/tslearn/backend/pytorch_backend.py
+++ b/tslearn/backend/pytorch_backend.py
@@ -121,6 +121,10 @@ else:
 
             return _torch.tensor(val, dtype=dtype)
 
+        @staticmethod
+        def belongs_to_backend(x):
+            return "torch" in f"{type(x)}".lower()
+
         def cast(self, x, dtype):
             if _torch.is_tensor(x):
                 return x.to(dtype=dtype)

--- a/tslearn/metrics/ctw.py
+++ b/tslearn/metrics/ctw.py
@@ -136,7 +136,7 @@ def ctw_path(
     .. [1] F. Zhou and F. Torre, "Canonical time warping for alignment of
        human behavior". NIPS 2009.
     """
-    be = instantiate_backend(be, s1)
+    be = instantiate_backend(be, s1, s2)
     s1 = to_time_series(s1, remove_nans=True, be=be)
     s2 = to_time_series(s2, remove_nans=True, be=be)
     s1, s2 = be.array(s1, dtype=be.float64), be.array(s2, dtype=be.float64)
@@ -271,7 +271,9 @@ def ctw(
     .. [1] F. Zhou and F. Torre, "Canonical time warping for alignment of
        human behavior". NIPS 2009.
     """
-    be = instantiate_backend(be, s1)
+    be = instantiate_backend(be, s1, s2)
+    s1 = be.array(s1)
+    s2 = be.array(s2)
     return ctw_path(
         s1=s1,
         s2=s2,
@@ -382,7 +384,7 @@ def cdist_ctw(
     .. [1] F. Zhou and F. Torre, "Canonical time warping for alignment of
        human behavior". NIPS 2009.
     """  # noqa: E501
-    be = instantiate_backend(be, dataset1)
+    be = instantiate_backend(be, dataset1, dataset2)
     return _cdist_generic(
         dist_fun=ctw,
         dataset1=dataset1,

--- a/tslearn/metrics/dtw_variants.py
+++ b/tslearn/metrics/dtw_variants.py
@@ -87,7 +87,7 @@ def accumulated_matrix(s1, s2, mask, be=None):
         Accumulated cost matrix.
 
     """
-    be = instantiate_backend(be, s1)
+    be = instantiate_backend(be, s1, s2)
     l1 = be.shape(s1)[0]
     l2 = be.shape(s2)[0]
     cum_sum = be.full((l1 + 1, l2 + 1), be.inf)
@@ -148,7 +148,7 @@ def _dtw(s1, s2, mask, be=None):
         Dynamic Time Warping score between both time series.
 
     """
-    be = instantiate_backend(be, s1)
+    be = instantiate_backend(be, s1, s2)
     cum_sum = accumulated_matrix(s1, s2, mask, be=be)
     return be.sqrt(cum_sum[-1, -1])
 
@@ -293,7 +293,7 @@ def dtw_path(
            Signal Processing, vol. 26(1), pp. 43--49, 1978.
 
     """
-    be = instantiate_backend(be, s1)
+    be = instantiate_backend(be, s1, s2)
     s1 = to_time_series(s1, remove_nans=True, be=be)
     s2 = to_time_series(s2, remove_nans=True, be=be)
 
@@ -526,7 +526,7 @@ def dtw_path_from_metric(
     .. _scipy: https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.pdist.html
 
     """  # noqa: E501
-    be = instantiate_backend(be, s1)
+    be = instantiate_backend(be, s1, s2)
     if metric == "precomputed":  # Pairwise distance given as input
         sz1, sz2 = be.shape(s1)
         mask = compute_mask(
@@ -643,7 +643,7 @@ def dtw(
            Signal Processing, vol. 26(1), pp. 43--49, 1978.
 
     """
-    be = instantiate_backend(be, s1)
+    be = instantiate_backend(be, s1, s2)
     s1 = to_time_series(s1, remove_nans=True, be=be)
     s2 = to_time_series(s2, remove_nans=True, be=be)
 
@@ -720,7 +720,7 @@ def _limited_warping_length_cost(s1, s2, max_length, be=None):
         Accumulated scores. This dict associates (i, j) pairs (keys) to
         dictionnaries with desired length as key and associated score as value.
     """
-    be = instantiate_backend(be, s1)
+    be = instantiate_backend(be, s1, s2)
     dict_costs = {}
     for i in range(s1.shape[0]):
         for j in range(s2.shape[0]):
@@ -812,7 +812,7 @@ def dtw_limited_warping_length(s1, s2, max_length, be=None):
            Dynamic time warping under limited warping path length.
            Information Sciences, vol. 393, pp. 91--107, 2017.
     """
-    be = instantiate_backend(be, s1)
+    be = instantiate_backend(be, s1, s2)
     s1 = to_time_series(s1, remove_nans=True, be=be)
     s2 = to_time_series(s2, remove_nans=True, be=be)
 
@@ -932,7 +932,7 @@ def dtw_path_limited_warping_length(s1, s2, max_length, be=None):
            Dynamic time warping under limited warping path length.
            Information Sciences, vol. 393, pp. 91--107, 2017.
     """
-    be = instantiate_backend(be, s1)
+    be = instantiate_backend(be, s1, s2)
     s1 = to_time_series(s1, remove_nans=True, be=be)
     s2 = to_time_series(s2, remove_nans=True, be=be)
 
@@ -1166,7 +1166,7 @@ def dtw_subsequence_path(subseq, longseq, be=None):
     subsequence_cost_matrix: Calculate the required cost matrix
     subsequence_path: Calculate a matching path manually
     """
-    be = instantiate_backend(be, subseq)
+    be = instantiate_backend(be, subseq, longseq)
     subseq = to_time_series(subseq, be=be)
     longseq = to_time_series(longseq, be=be)
     acc_cost_mat = subsequence_cost_matrix(subseq=subseq, longseq=longseq, be=be)
@@ -1260,7 +1260,7 @@ def sakoe_chiba_mask(sz1, sz2, radius=1, be=None):
            [ 0.,  0.,  0.],
            [inf,  0.,  0.]])
     """
-    be = instantiate_backend(be, "numpy")
+    be = instantiate_backend(be)
     mask = be.full((sz1, sz2), be.inf)
     if sz1 > sz2:
         width = sz1 - sz2 + radius
@@ -1344,6 +1344,7 @@ def _itakura_mask(sz1, sz2, max_slope=2.0, be=None):
     mask : array, shape = (sz1, sz2)
         Itakura mask.
     """
+    be = instantiate_backend(be)
     min_slope = 1 / float(max_slope)
     max_slope *= float(sz1) / float(sz2)
     min_slope *= float(sz1) / float(sz2)
@@ -1481,7 +1482,7 @@ def compute_mask(
     mask : array
         Constraint region.
     """
-    be = instantiate_backend(be, s1)
+    be = instantiate_backend(be, s1, s2)
     # The output mask will be of shape (sz1, sz2)
     if isinstance(s1, int) and isinstance(s2, int):
         sz1, sz2 = s1, s2
@@ -1620,7 +1621,7 @@ def cdist_dtw(
            spoken word recognition," IEEE Transactions on Acoustics, Speech and
            Signal Processing, vol. 26(1), pp. 43--49, 1978.
     """  # noqa: E501
-    be = instantiate_backend(be, dataset1)
+    be = instantiate_backend(be, dataset1, dataset2)
     return _cdist_generic(
         dist_fun=dtw,
         dataset1=dataset1,
@@ -1873,7 +1874,7 @@ def lcss_accumulated_matrix(s1, s2, eps, mask, be=None):
     lcss_score : float
         Longest Common Subsequence similarity score between both time series.
     """
-    be = instantiate_backend(be, s1)
+    be = instantiate_backend(be, s1, s2)
     l1 = s1.shape[0]
     l2 = s2.shape[0]
     acc_cost_mat = be.full((l1 + 1, l2 + 1), 0)
@@ -1946,7 +1947,7 @@ def _lcss(s1, s2, eps, mask, be=None):
     lcss_score : float
         Longest Common Subsquence score between both time series.
     """
-    be = instantiate_backend(be, s1)
+    be = instantiate_backend(be, s1, s2)
     l1 = s1.shape[0]
     l2 = s2.shape[0]
     acc_cost_mat = lcss_accumulated_matrix(s1, s2, eps, mask, be=be)
@@ -2046,7 +2047,7 @@ def lcss(
             IEEE Computer Society, USA, 673.
 
     """
-    be = instantiate_backend(be, s1)
+    be = instantiate_backend(be, s1, s2)
     s1 = to_time_series(s1, remove_nans=True, be=be)
     s2 = to_time_series(s2, remove_nans=True, be=be)
 
@@ -2081,7 +2082,7 @@ def _njit_return_lcss_path(s1, s2, eps, mask, acc_cost_mat, sz1, sz2):
 
 
 def _return_lcss_path(s1, s2, eps, mask, acc_cost_mat, sz1, sz2, be=None):
-    be = instantiate_backend(be, s1)
+    be = instantiate_backend(be, s1, s2, acc_cost_mat)
     i, j = (sz1, sz2)
     path = []
 
@@ -2123,7 +2124,7 @@ def _njit_return_lcss_path_from_dist_matrix(
 def _return_lcss_path_from_dist_matrix(
     dist_matrix, eps, mask, acc_cost_mat, sz1, sz2, be=None
 ):
-    be = instantiate_backend(be, dist_matrix)
+    be = instantiate_backend(be, dist_matrix, acc_cost_mat)
     i, j = (sz1, sz2)
     path = []
 
@@ -2236,7 +2237,7 @@ def lcss_path(
             IEEE Computer Society, USA, 673.
 
     """
-    be = instantiate_backend(be, s1)
+    be = instantiate_backend(be, s1, s2)
     s1 = to_time_series(s1, remove_nans=True, be=be)
     s2 = to_time_series(s2, remove_nans=True, be=be)
 
@@ -2472,7 +2473,7 @@ def lcss_path_from_metric(
     .. _scipy: https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.pdist.html
 
     """  # noqa: E501
-    be = instantiate_backend(be, s1)
+    be = instantiate_backend(be, s1, s2)
     if metric == "precomputed":  # Pairwise distance given as input
         sz1, sz2 = s1.shape
         mask = compute_mask(

--- a/tslearn/metrics/dtw_variants.py
+++ b/tslearn/metrics/dtw_variants.py
@@ -23,7 +23,9 @@ def _njit_local_squared_dist(x, y):
 
 
 def _local_squared_dist(x, y, be=None):
-    be = instantiate_backend(be, x)
+    be = instantiate_backend(be, x, y)
+    x = be.array(x)
+    y = be.array(y)
     dist = 0.0
     for di in range(be.shape(x)[0]):
         diff = x[di] - y[di]
@@ -88,6 +90,8 @@ def accumulated_matrix(s1, s2, mask, be=None):
 
     """
     be = instantiate_backend(be, s1, s2)
+    s1 = be.array(s1)
+    s2 = be.array(s2)
     l1 = be.shape(s1)[0]
     l2 = be.shape(s2)[0]
     cum_sum = be.full((l1 + 1, l2 + 1), be.inf)
@@ -375,6 +379,7 @@ def accumulated_matrix_from_dist_matrix(dist_matrix, mask, be=None):
         Accumulated cost matrix.
     """
     be = instantiate_backend(be, dist_matrix)
+    dist_matrix = be.array(dist_matrix)
     l1, l2 = be.shape(dist_matrix)
     cum_sum = be.full((l1 + 1, l2 + 1), be.inf)
     cum_sum[0, 0] = 0.0

--- a/tslearn/metrics/dtw_variants.py
+++ b/tslearn/metrics/dtw_variants.py
@@ -528,6 +528,7 @@ def dtw_path_from_metric(
     """  # noqa: E501
     be = instantiate_backend(be, s1, s2)
     if metric == "precomputed":  # Pairwise distance given as input
+        s1 = be.array(s1)
         sz1, sz2 = be.shape(s1)
         mask = compute_mask(
             sz1,
@@ -1006,7 +1007,9 @@ def subsequence_cost_matrix(subseq, longseq, be=None):
     mat : array, shape = (sz1, sz2)
         Accumulated cost matrix.
     """
-    be = instantiate_backend(be, subseq)
+    be = instantiate_backend(be, subseq, longseq)
+    subseq = be.array(subseq)
+    longseq = be.array(longseq)
     if be.is_numpy:
         return _njit_subsequence_cost_matrix(subseq, longseq)
     return _subsequence_cost_matrix(subseq, longseq, be=be)
@@ -1805,6 +1808,7 @@ def lb_envelope(ts, radius=1, be=None):
        Conference on Very Large Data Bases, 2002. pp 406-417.
     """
     be = instantiate_backend(be, ts)
+    ts = be.array(ts)
     if be.is_numpy:
         return _njit_lb_envelope(to_time_series(ts), radius=radius)
     return _lb_envelope(to_time_series(ts, be=be), radius=radius, be=be)
@@ -1951,7 +1955,6 @@ def _lcss(s1, s2, eps, mask, be=None):
     l1 = s1.shape[0]
     l2 = s2.shape[0]
     acc_cost_mat = lcss_accumulated_matrix(s1, s2, eps, mask, be=be)
-
     return float(acc_cost_mat[-1][-1]) / min([l1, l2])
 
 

--- a/tslearn/metrics/dtw_variants.py
+++ b/tslearn/metrics/dtw_variants.py
@@ -149,6 +149,8 @@ def _dtw(s1, s2, mask, be=None):
 
     """
     be = instantiate_backend(be, s1, s2)
+    s1 = be.array(s1)
+    s2 = be.array(s2)
     cum_sum = accumulated_matrix(s1, s2, mask, be=be)
     return be.sqrt(cum_sum[-1, -1])
 

--- a/tslearn/metrics/soft_dtw_fast.py
+++ b/tslearn/metrics/soft_dtw_fast.py
@@ -56,7 +56,11 @@ def _softmin3(a, b, c, gamma, be=None):
     -------
     softmin_value : float64
     """
-    be = instantiate_backend(be, a)
+    be = instantiate_backend(be, a, b, c, gamma)
+    a = be.array(a, dtype=be.float64)
+    b = be.array(b, dtype=be.float64)
+    c = be.array(c, dtype=be.float64)
+    gamma = be.array(gamma, dtype=be.float64)
 
     a /= -gamma
     b /= -gamma

--- a/tslearn/metrics/soft_dtw_fast.py
+++ b/tslearn/metrics/soft_dtw_fast.py
@@ -114,9 +114,10 @@ def _soft_dtw(D, R, gamma, be=None):
     be : Backend object or string or None
         Backend.
     """
-    be = instantiate_backend(be, D, R)
-    D = be.array(D)
-    R = be.array(R)
+    be = instantiate_backend(be, D, R, gamma)
+    D = be.array(D, dtype=be.float64)
+    R = be.array(R, dtype=be.float64)
+    gamma = be.array(gamma, dtype=be.float64)
 
     m, n = be.shape(D)
 

--- a/tslearn/metrics/soft_dtw_fast.py
+++ b/tslearn/metrics/soft_dtw_fast.py
@@ -110,10 +110,11 @@ def _soft_dtw(D, R, gamma, be=None):
     be : Backend object or string or None
         Backend.
     """
-    be = instantiate_backend(be, D)
+    be = instantiate_backend(be, D, R)
+    D = be.array(D)
+    R = be.array(R)
 
-    m = D.shape[0]
-    n = D.shape[1]
+    m, n = be.shape(D)
 
     # Initialization.
     R[: m + 1, 0] = be.dbl_max
@@ -158,7 +159,9 @@ def _soft_dtw_batch(D, R, gamma, be=None):
     be : Backend object or string or None
         Backend.
     """
-    be = instantiate_backend(be, D)
+    be = instantiate_backend(be, D, R)
+    D = be.array(D)
+    R = be.array(R)
     for i_sample in range(D.shape[0]):
         _soft_dtw(D[i_sample, :, :], R[i_sample, :, :], gamma, be=be)
 
@@ -207,7 +210,10 @@ def _soft_dtw_grad(D, R, E, gamma, be=None):
     be : Backend object or string or None
         Backend.
     """
-    be = instantiate_backend(be, D)
+    be = instantiate_backend(be, D, R, E)
+    D = be.array(D)
+    R = be.array(R)
+    E = be.array(E)
 
     m = D.shape[0] - 1
     n = D.shape[1] - 1
@@ -257,7 +263,10 @@ def _soft_dtw_grad_batch(D, R, E, gamma, be=None):
     be : Backend object or string or None
         Backend.
     """
-    be = instantiate_backend(be, D)
+    be = instantiate_backend(be, D, R, E)
+    D = be.array(D)
+    R = be.array(R)
+    E = be.array(E)
     for i_sample in prange(D.shape[0]):
         _soft_dtw_grad(D[i_sample, :, :], R[i_sample, :, :], E[i_sample, :, :], gamma, be=be)
 

--- a/tslearn/metrics/softdtw_variants.py
+++ b/tslearn/metrics/softdtw_variants.py
@@ -118,7 +118,7 @@ def unnormalized_gak(s1, s2, sigma=1.0, be=None):
     ----------
     .. [1] M. Cuturi, "Fast global alignment kernels," ICML 2011.
     """
-    be = instantiate_backend(be, s1)
+    be = instantiate_backend(be, s1, s2)
     s1 = to_time_series(s1, remove_nans=True, be=be)
     s2 = to_time_series(s2, remove_nans=True, be=be)
 
@@ -170,7 +170,9 @@ def gak(s1, s2, sigma=1.0, be=None):  # TODO: better doc (formula for the kernel
     ----------
     .. [1] M. Cuturi, "Fast global alignment kernels," ICML 2011.
     """
-    be = instantiate_backend(be, s1)
+    be = instantiate_backend(be, s1, s2)
+    s1 = be.array(s1)
+    s2 = be.array(s2)
     denom = be.sqrt(
         unnormalized_gak(s1, s1, sigma=sigma, be=be)
         * unnormalized_gak(s2, s2, sigma=sigma, be=be)
@@ -425,7 +427,9 @@ def soft_dtw(ts1, ts2, gamma=1.0, be=None):
     .. [1] M. Cuturi, M. Blondel "Soft-DTW: a Differentiable Loss Function for
        Time-Series," ICML 2017.
     """
-    be = instantiate_backend(be, ts1)
+    be = instantiate_backend(be, ts1, ts2)
+    ts1 = be.array(ts1)
+    ts2 = be.array(ts2)
     if gamma == 0.0:
         return dtw(ts1, ts2, be=be) ** 2
     return SoftDTW(
@@ -497,7 +501,9 @@ def soft_dtw_alignment(ts1, ts2, gamma=1.0, be=None):
     .. [1] M. Cuturi, M. Blondel "Soft-DTW: a Differentiable Loss Function for
        Time-Series," ICML 2017.
     """
-    be = instantiate_backend(be, ts1)
+    be = instantiate_backend(be, ts1, ts2)
+    ts1 = be.array(ts1)
+    ts2 = be.array(ts2)
     if gamma == 0.0:
         path, dist = dtw_path(ts1, ts2, be=be)
         dist_sq = dist**2
@@ -573,7 +579,7 @@ def cdist_soft_dtw(dataset1, dataset2=None, gamma=1.0, be=None):
     .. [1] M. Cuturi, M. Blondel "Soft-DTW: a Differentiable Loss Function for
        Time-Series," ICML 2017.
     """
-    be = instantiate_backend(be, dataset1)
+    be = instantiate_backend(be, dataset1, dataset2)
     dataset1 = to_time_series_dataset(dataset1, dtype=be.float64, be=be)
 
     if dataset2 is None:
@@ -676,7 +682,7 @@ def cdist_soft_dtw_normalized(dataset1, dataset2=None, gamma=1.0, be=None):
     .. [1] M. Cuturi, M. Blondel "Soft-DTW: a Differentiable Loss Function for
        Time-Series," ICML 2017.
     """
-    be = instantiate_backend(be, dataset1)
+    be = instantiate_backend(be, dataset1, dataset2)
     dataset1 = be.array(dataset1)
     if dataset2 is not None:
         dataset2 = be.array(dataset2)

--- a/tslearn/metrics/softdtw_variants.py
+++ b/tslearn/metrics/softdtw_variants.py
@@ -30,9 +30,12 @@ VARIABLE_LENGTH_METRICS = ["dtw", "gak", "softdtw", "sax"]
 
 
 def _gak(s1, s2, gram, be=None):
-    be = instantiate_backend(be, s1)
-    l1 = s1.shape[0]
-    l2 = s2.shape[0]
+    be = instantiate_backend(be, s1, s2, gram)
+    s1 = be.array(s1)
+    s2 = be.array(s2)
+    gram = be.array(gram)
+    l1 = be.shape(s1)[0]
+    l2 = be.shape(s2)[0]
 
     cum_sum = be.zeros((l1 + 1, l2 + 1))
     cum_sum[0, 0] = 1.0
@@ -228,7 +231,7 @@ def cdist_gak(dataset1, dataset2=None, sigma=1.0, n_jobs=None, verbose=0, be=Non
     ----------
     .. [1] M. Cuturi, "Fast global alignment kernels," ICML 2011.
     """  # noqa: E501
-    be = instantiate_backend(be, dataset1)
+    be = instantiate_backend(be, dataset1, dataset2)
 
     unnormalized_matrix = _cdist_generic(
         dist_fun=unnormalized_gak,
@@ -573,12 +576,12 @@ def cdist_soft_dtw(dataset1, dataset2=None, gamma=1.0, be=None):
     be = instantiate_backend(be, dataset1)
     dataset1 = to_time_series_dataset(dataset1, dtype=be.float64, be=be)
 
-    self_similarity = False
     if dataset2 is None:
         dataset2 = dataset1
         self_similarity = True
     else:
         dataset2 = to_time_series_dataset(dataset2, dtype=be.float64, be=be)
+        self_similarity = False
 
     dists = be.empty((dataset1.shape[0], dataset2.shape[0]))
 
@@ -674,6 +677,9 @@ def cdist_soft_dtw_normalized(dataset1, dataset2=None, gamma=1.0, be=None):
        Time-Series," ICML 2017.
     """
     be = instantiate_backend(be, dataset1)
+    dataset1 = be.array(dataset1)
+    if dataset2 is not None:
+        dataset2 = be.array(dataset2)
     dists = cdist_soft_dtw(dataset1, dataset2=dataset2, gamma=gamma, be=be)
     if dataset2 is None:
         d_ii = be.diag(dists)
@@ -825,10 +831,10 @@ class SquaredEuclidean:
                [1., 0., 1., 4.],
                [4., 1., 0., 1.]])
         """
-        self.be = instantiate_backend(be, X)
+        self.be = instantiate_backend(be, X, Y)
         self.compute_with_backend = compute_with_backend
-        self.X = self.be.cast(to_time_series(X), dtype=self.be.float64)
-        self.Y = self.be.cast(to_time_series(Y), dtype=self.be.float64)
+        self.X = self.be.cast(to_time_series(X, be=be), dtype=self.be.float64)
+        self.Y = self.be.cast(to_time_series(Y, be=be), dtype=self.be.float64)
 
     def compute(self):
         """Compute distance matrix.

--- a/tslearn/metrics/utils.py
+++ b/tslearn/metrics/utils.py
@@ -64,7 +64,7 @@ def _cdist_generic(
     cdist : numpy.ndarray
         Cross-similarity matrix
     """  # noqa: E501
-    be = instantiate_backend(be, dataset1)
+    be = instantiate_backend(be, dataset1, dataset2)
     dataset1 = to_time_series_dataset(dataset1, dtype=dtype, be=be)
 
     if dataset2 is None:


### PR DESCRIPTION
In the functions of the folder `tslearn/metrics` supporting the backend optional input parameter `be`, cast the input data to the backend option when possible (using `be.array`).
Test the functions of the file `test_metrics.py` for different input data types (list, numpy, pytorch) and different backend options (numpy, pytorch, None). Two nested `for` loops are used.

Therefore the following generic metric function is tested for different input data types and backend options:

```
def metric_function(s1, s2, be=None):
    be = instantiate_backend(be, s1, s2)
    s1 = be.array(s1)
    s2 = be.array(s2)
    ...
```