### PR TITLE
Fix error in function from_hdf5

### DIFF
--- a/tslearn/bases/bases.py
+++ b/tslearn/bases/bases.py
@@ -204,8 +204,9 @@ class BaseModelPackage:
         model = cls._byte2string(model)
 
         for k in model['hyper_params'].keys():
-            if model['hyper_params'][k] == 'None':
-                model['hyper_params'][k] = None
+            if isinstance(model['hyper_params'][k], str):
+                if model['hyper_params'][k] == 'None':
+                    model['hyper_params'][k] = None
 
         return cls._organize_model(cls, model)
 


### PR DESCRIPTION
A test is failing for Python 3.9 and Python 3.10:
`FAILED tslearn/tests/test_serialize_models.py::test_serialize_kshape`
The error is the following:
```
____________________________ test_serialize_kshape _____________________________

    def test_serialize_kshape():
        n, sz, d = 15, 10, 3
        rng = numpy.random.RandomState(0)
        time_series = rng.randn(n, sz, d)
        X = TimeSeriesScalerMeanVariance().fit_transform(time_series)
    
        ks = KShape(n_clusters=3, verbose=True)
    
        _check_not_fitted(ks)
    
        ks.fit(X)
    
        _check_params_predict(ks, X, ['predict'])
    
        seed_ixs = [numpy.random.randint(0, X.shape[0] - 1) for i in range(3)]
        seeds = numpy.array([X[i] for i in seed_ixs])
    
        ks_seeded = KShape(n_clusters=3, verbose=True, init=seeds)
    
        _check_not_fitted(ks_seeded)
    
        ks_seeded.fit(X)
    
>       _check_params_predict(ks_seeded, X, ['predict'])

tslearn/tests/test_serialize_models.py:185: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tslearn/tests/test_serialize_models.py:86: in _check_params_predict
    sm = getattr(model, "from_{}".format(fmt))(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

cls = <class 'tslearn.clustering.kshape.KShape'>
path = '/home/vsts/work/1/s/tslearn/tests/tmp/KShape.hdf5'

    @classmethod
    def from_hdf5(cls, path):
        """
        Load model from a HDF5 file.
        Requires ``h5py`` http://docs.h5py.org/
    
        for k in model['hyper_params'].keys():
>           if model['hyper_params'][k] == 'None':
E           ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()

tslearn/bases/bases.py:207: ValueError
```