### PR TITLE
Fix error in _soft_dtw, add test and add option compute_with_backend in soft_dtw and soft_dtw_alignment.

### DIFF
--- a/tslearn/metrics/soft_dtw_fast.py
+++ b/tslearn/metrics/soft_dtw_fast.py
@@ -115,9 +115,6 @@ def _soft_dtw(D, R, gamma, be=None):
         Backend.
     """
     be = instantiate_backend(be, D, R, gamma)
-    D = be.array(D, dtype=be.float64)
-    R = be.array(R, dtype=be.float64)
-    gamma = be.array(gamma, dtype=be.float64)
 
     m, n = be.shape(D)
 
@@ -165,8 +162,6 @@ def _soft_dtw_batch(D, R, gamma, be=None):
         Backend.
     """
     be = instantiate_backend(be, D, R)
-    D = be.array(D)
-    R = be.array(R)
     for i_sample in range(D.shape[0]):
         _soft_dtw(D[i_sample, :, :], R[i_sample, :, :], gamma, be=be)
 
@@ -216,9 +211,6 @@ def _soft_dtw_grad(D, R, E, gamma, be=None):
         Backend.
     """
     be = instantiate_backend(be, D, R, E)
-    D = be.array(D)
-    R = be.array(R)
-    E = be.array(E)
 
     m = D.shape[0] - 1
     n = D.shape[1] - 1
@@ -269,9 +261,6 @@ def _soft_dtw_grad_batch(D, R, E, gamma, be=None):
         Backend.
     """
     be = instantiate_backend(be, D, R, E)
-    D = be.array(D)
-    R = be.array(R)
-    E = be.array(E)
     for i_sample in prange(D.shape[0]):
         _soft_dtw_grad(D[i_sample, :, :], R[i_sample, :, :], E[i_sample, :, :], gamma, be=be)
 

--- a/tslearn/metrics/softdtw_variants.py
+++ b/tslearn/metrics/softdtw_variants.py
@@ -370,7 +370,7 @@ def gamma_soft_dtw(dataset, n_samples=100, random_state=None, be=None):
     )
 
 
-def soft_dtw(ts1, ts2, gamma=1.0, be=None):
+def soft_dtw(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False):
     r"""Compute Soft-DTW metric between two time series.
 
     Soft-DTW was originally presented in [1]_ and is
@@ -401,6 +401,11 @@ def soft_dtw(ts1, ts2, gamma=1.0, be=None):
         Gamma parameter for Soft-DTW
     be : Backend object or string or None
         Backend.
+    compute_with_backend : bool, default=False
+        This parameter has no influence when the NumPy backend is used.
+        When using a backend different from NumPy is used:
+        If `True`, the computation is done with the corresponding backend.
+        If `False`, a conversion to the NumPy backend can be used to accelerate the computation.
 
     Returns
     -------
@@ -436,10 +441,11 @@ def soft_dtw(ts1, ts2, gamma=1.0, be=None):
         SquaredEuclidean(ts1[: ts_size(ts1)], ts2[: ts_size(ts2)], be=be),
         gamma=gamma,
         be=be,
+        compute_with_backend=compute_with_backend,
     ).compute()
 
 
-def soft_dtw_alignment(ts1, ts2, gamma=1.0, be=None):
+def soft_dtw_alignment(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False):
     r"""Compute Soft-DTW metric between two time series and return both the
     similarity measure and the alignment matrix.
 
@@ -471,6 +477,11 @@ def soft_dtw_alignment(ts1, ts2, gamma=1.0, be=None):
         Gamma parameter for Soft-DTW
     be : Backend object or string or None
         Backend.
+    compute_with_backend : bool, default=False
+        This parameter has no influence when the NumPy backend is used.
+        When using a backend different from NumPy is used:
+        If `True`, the computation is done with the corresponding backend.
+        If `False`, a conversion to the NumPy backend can be used to accelerate the computation.
 
     Returns
     -------
@@ -515,6 +526,7 @@ def soft_dtw_alignment(ts1, ts2, gamma=1.0, be=None):
             SquaredEuclidean(ts1[: ts_size(ts1)], ts2[: ts_size(ts2)], be=be),
             gamma=gamma,
             be=be,
+            compute_with_backend=compute_with_backend,
         )
         dist_sq = sdtw.compute()
         a = sdtw.grad()

--- a/tslearn/metrics/softdtw_variants.py
+++ b/tslearn/metrics/softdtw_variants.py
@@ -533,7 +533,7 @@ def soft_dtw_alignment(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False)
     return a, dist_sq
 
 
-def cdist_soft_dtw(dataset1, dataset2=None, gamma=1.0, be=None):
+def cdist_soft_dtw(dataset1, dataset2=None, gamma=1.0, be=None, compute_with_backend=False):
     r"""Compute cross-similarity matrix using Soft-DTW metric.
 
     Soft-DTW was originally presented in [1]_ and is
@@ -564,6 +564,11 @@ def cdist_soft_dtw(dataset1, dataset2=None, gamma=1.0, be=None):
         Gamma parameter for Soft-DTW
     be : Backend object or string or None
         Backend.
+    compute_with_backend : bool, default=False
+        This parameter has no influence when the NumPy backend is used.
+        When using a backend different from NumPy is used:
+        If `True`, the computation is done with the corresponding backend.
+        If `False`, a conversion to the NumPy backend can be used to accelerate the computation.
 
     Returns
     -------
@@ -619,12 +624,14 @@ def cdist_soft_dtw(dataset1, dataset2=None, gamma=1.0, be=None):
             if self_similarity and j < i:
                 dists[i, j] = dists[j, i]
             else:
-                dists[i, j] = soft_dtw(ts1_short, ts2_short, gamma=gamma, be=be)
+                dists[i, j] = soft_dtw(
+                    ts1_short, ts2_short, gamma=gamma, be=be, compute_with_backend=compute_with_backend
+                )
 
     return dists
 
 
-def cdist_soft_dtw_normalized(dataset1, dataset2=None, gamma=1.0, be=None):
+def cdist_soft_dtw_normalized(dataset1, dataset2=None, gamma=1.0, be=None, compute_with_backend=False):
     r"""Compute cross-similarity matrix using a normalized version of the
     Soft-DTW metric.
 
@@ -668,6 +675,11 @@ def cdist_soft_dtw_normalized(dataset1, dataset2=None, gamma=1.0, be=None):
         Gamma parameter for Soft-DTW
     be : Backend object or string or None
         Backend.
+    compute_with_backend : bool, default=False
+        This parameter has no influence when the NumPy backend is used.
+        When using a backend different from NumPy is used:
+        If `True`, the computation is done with the corresponding backend.
+        If `False`, a conversion to the NumPy backend can be used to accelerate the computation.
 
     Returns
     -------
@@ -698,7 +710,9 @@ def cdist_soft_dtw_normalized(dataset1, dataset2=None, gamma=1.0, be=None):
     dataset1 = be.array(dataset1)
     if dataset2 is not None:
         dataset2 = be.array(dataset2)
-    dists = cdist_soft_dtw(dataset1, dataset2=dataset2, gamma=gamma, be=be)
+    dists = cdist_soft_dtw(
+        dataset1, dataset2=dataset2, gamma=gamma, be=be, compute_with_backend=compute_with_backend
+    )
     if dataset2 is None:
         d_ii = be.diag(dists)
         normalizer = -0.5 * (be.reshape(d_ii, (-1, 1)) + be.reshape(d_ii, (1, -1)))
@@ -706,12 +720,16 @@ def cdist_soft_dtw_normalized(dataset1, dataset2=None, gamma=1.0, be=None):
         self_dists1 = be.empty((dataset1.shape[0], 1))
         for i, ts1 in enumerate(dataset1):
             ts1_short = ts1[:ts_size(ts1)]
-            self_dists1[i, 0] = soft_dtw(ts1_short, ts1_short, gamma=gamma, be=be)
+            self_dists1[i, 0] = soft_dtw(
+                ts1_short, ts1_short, gamma=gamma, be=be, compute_with_backend=compute_with_backend
+            )
 
         self_dists2 = be.empty((1, dataset2.shape[0]))
         for j, ts2 in enumerate(dataset2):
             ts2_short = ts2[:ts_size(ts2)]
-            self_dists2[0, j] = soft_dtw(ts2_short, ts2_short, gamma=gamma, be=be)
+            self_dists2[0, j] = soft_dtw(
+                ts2_short, ts2_short, gamma=gamma, be=be, compute_with_backend=compute_with_backend
+            )
 
         normalizer = -0.5 * (self_dists1 + self_dists2)
     dists += normalizer

--- a/tslearn/tests/test_metrics.py
+++ b/tslearn/tests/test_metrics.py
@@ -639,6 +639,13 @@ def test_softdtw():
             np.testing.assert_equal(dist, dist_ref**2)
             np.testing.assert_allclose(matrix_path, mat_path_ref)
 
+            ts1 = cast([[0.0]], array_type)
+            ts2 = cast([[1.0]], array_type)
+            sim = tslearn.metrics.soft_dtw(
+                ts1=ts1, ts2=ts2, gamma=1.0, be=be, compute_with_backend=True
+            )
+            assert sim == 1.0
+
 
 def test_dtw_path_with_empty_or_nan_inputs():
     for be in backends:


### PR DESCRIPTION
In the file [tslearn/metrics/soft_dtw_fast.py](https://github.com/tslearn-team/tslearn/pull/481/files#diff-42cda75332819109d4b1229c1304c8c849e5545a45818b2ee558e11e20b7ff0d), the functions `_soft_dtw`, `_soft_dtw_batch`, `_soft_dtw_grad` and `_soft_dtw_grad_batch` do not return of value, they modify directly the input value as a mutable object.
An error was introduced in the PR #479 casting the input values to the selected backend with:
```
    D = be.array(D, dtype=be.float64)
    R = be.array(R, dtype=be.float64)
    gamma = be.array(gamma, dtype=be.float64)
```
Indeed, `be.array` cast the input values to the desired backend, but it creates a copy input values. 
Therefore the input values will not be modified as mutable objects.
These lines are removed in this PR.

We add a test to make sure that this error will not be reproduced.

We also add the option `compute_with_backend` in the functions `soft_dtw`, `soft_dtw_alignment`, `cdist_soft_dtw` and `cdist_soft_dtw_normalized`.
Before, the input data was casted to NumPy arrays to use Numba with the decorator `@njit` and the results were converted to the backend of the input data.
We can now use PyTorch automatic differentiation with these functions.