### PR TITLE
Improve backend docstrings

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,7 +82,7 @@ jobs:
       python -m pip install pytest pytest-azurepipelines
       python -m pip install scikit-learn==1.2
       python -m pip install tensorflow==2.9.0
-      python -m pytest -v tslearn/ --doctest-modules
+      python -m pytest -v tslearn/ --doctest-modules -k 'not dtw' -k 'not soft_dtw' -k 'not soft_dtw_alignment' -k 'not cdist_soft_dtw' -k 'not cdist_soft_dtw_normalized'
     displayName: 'Test'
 
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,7 +82,7 @@ jobs:
       python -m pip install pytest pytest-azurepipelines
       python -m pip install scikit-learn==1.2
       python -m pip install tensorflow==2.9.0
-      python -m pytest -v tslearn/ --doctest-modules -k 'not dtw' -k 'not soft_dtw' -k 'not soft_dtw_alignment' -k 'not cdist_soft_dtw' -k 'not cdist_soft_dtw_normalized'
+      python -m pytest -v tslearn/ --doctest-modules -k 'not tslearn.metrics.softdtw_variants.soft_dtw and not tslearn.metrics.softdtw_variants.cdist_soft_dtw and not tslearn.metrics.dtw_variants.dtw or tslearn.metrics.dtw_variants.dtw_'
     displayName: 'Test'
 
 

--- a/docs/backend.rst
+++ b/docs/backend.rst
@@ -1,70 +1,137 @@
 Backend selection and use
 =========================
 
-`tslearn` proposes time series metrics as `DTW` and `Soft-DTW` which are compatible with different backends (`NumPy` and `PyTorch`).
+`tslearn` proposes different backends (`NumPy` and `PyTorch`)
+to compute time series metrics such as `DTW` and `Soft-DTW`.
+The `PyTorch` backend can be used to compute gradients of
+metric functions thanks to automatic differentiation.
 
 Backend selection
 -----------------
 
-A backend can be initialized passing four different kind of input arguments to the function instantiate_backend:
+A backend can be instantiated using the function ``instantiate_backend``.
+To specify which backend should be instantiated (`NumPy` or `PyTorch`),
+this function accepts four different kind of input arguments:
 
-* Input is a Backend instance
-* Input is a string corresponding to "numpy" or "pytorch".
-* Input is a backend object.
-* Input is "None" or anything else than mentioned previously --> The backend `NumPy` is used. 
-
-What happens if there are several inputs? --> A for loop on the inputs.
+* a string equal to ``"numpy"`` or ``"pytorch"``.
+* a `NumPy` array or a `Torch` tensor.
+* a Backend instance. The input backend is then returned.
+* ``None`` or anything else than mentioned previously. The backend `NumPy` is then instantiated.
 
 Examples
 ~~~~~~~~
+
+If the input is the string ``"numpy"``, the ``NumPyBackend`` is instantiated.
 
 .. code-block:: python
 
     >>> from tslearn.backend import instantiate_backend
+    >>> be = instantiate_backend("numpy")
+    >>> print(be.backend_string)
+    "numpy"
+
+If the input is the string ``"pytorch"``, the ``PyTorchBackend`` is instantiated.
+
+.. code-block:: python
+
     >>> be = instantiate_backend("pytorch")
     >>> print(be.backend_string)
     "pytorch"
 
+If the input is a `NumPy` array, the ``NumPyBackend`` is instantiated.
+
 .. code-block:: python
 
-    >>> from tslearn.backend import Backend
-    
+    >>> import numpy as np
+    >>> be = instantiate_backend(np.array([0]))
+    >>> print(be.backend_string)
+    "numpy"
+
+If the input is a `Torch` tensor, the ``PyTorchBackend`` is instantiated.
+
 .. code-block:: python
 
-    >>> from tslearn.backend import Backend
+    >>> import torch
+    >>> be = instantiate_backend(torch.tensor([0]))
+    >>> print(be.backend_string)
+    "pytorch"
 
-Create backend objects
-----------------------
+If the input is a Backend instance, the input backend is returned.
 
-`NumPy` is the reference backend concerning the names of the methods of the backends.
+.. code-block:: python
+
+    >>> print(be.backend_string)
+    "pytorch"
+    >>> be = instantiate_backend(be)
+    >>> print(be.backend_string)
+    "pytorch"
+
+If the input is ``None``, the ``NumPyBackend`` is instantiated.
+
+.. code-block:: python
+
+    >>> be = instantiate_backend(None)
+    >>> print(be.backend_string)
+    "numpy"
+
+If the input is anything else, the ``NumPyBackend`` is instantiated.
+
+.. code-block:: python
+
+    >>> be = instantiate_backend("Hello, World!")
+    >>> print(be.backend_string)
+    "numpy"
+
+The function ``instantiate_backend`` accepts any number of input arguments, including zero.
+To select which backend should be instantiated (`NumPy` or `PyTorch`),
+a for loop is performed on the inputs until a backend is selected.
+
+.. code-block:: python
+
+    >>> be = instantiate_backend(1, None, "Hello, World!", torch.tensor([0]), "numpy")
+    >>> print(be.backend_string)
+    "pytorch"
+
+If none of the inputs are related to `NumPy` or `PyTorch`, the ``NumPyBackend`` is instantiated.
+
+.. code-block:: python
+
+    >>> be = instantiate_backend(1, None, "Hello, World!")
+    >>> print(be.backend_string)
+    "numpy"
+
+Use the backends
+----------------
+
+The names of the attributes and methods of the backends
+are inspired by the `NumPy` backend.
 
 Examples
 ~~~~~~~~
 
+Create backend objects.
+
 .. code-block:: python
 
-    >>> from tslearn.backend import Backend
     >>> be = instantiate_backend("pytorch")
-    >>> print(be.array([0]))
-    Torch.Tensor([0])
+    >>> mat = be.array([[0 , 1], [2, 3]], dtype=float)
+    >>> print(mat)
+    tensor([[0., 1.],
+            [2., 3.]], dtype=torch.float64)
 
-Define metric functions backend
--------------------------------
-
-Pass a backend as an optional input argument of a metric function.
-
-
-Examples
-~~~~~~~~
+Use backend functions.
 
 .. code-block:: python
 
-    >>> from tslearn.backend import Backend
+    >>> norm = be.linalg.norm(mat)
+    >>> print(norm)
+    tensor(3.7417, dtype=torch.float64)
 
-Automatic differentiation
--------------------------
+Choose the backend used by metric functions
+-------------------------------------------
 
-Use the backend's automatic differentiation tools in metric functions
+`tslearn`'s metric functions have an optional input argument "``be``" to specify the
+backend to use to compute the metric.
 
 Examples
 ~~~~~~~~
@@ -78,6 +145,38 @@ Examples
     >>> sim = dtw(s1, s2, be="pytorch")
     >>> print(sim)
     sim tensor(6.4807, grad_fn=<SqrtBackward0>)
+
+By default, ``be=None``.
+Note that the first line of the function ``dtw`` is:
+
+.. code-block:: python
+
+    be = instantiate_backend(be, s1, s2)
+
+Therefore, even if ``be=None``, the ``PyTorchBackend`` is instantiated and used to compute the
+DTW metric since ``s1`` and ``s2`` are `Torch` tensors.
+
+.. code-block:: python
+
+    >>> sim = dtw(s1, s2)
+    >>> print(sim)
+    sim tensor(6.4807, grad_fn=<SqrtBackward0>)
+
+Automatic differentiation
+-------------------------
+
+The `PyTorch` backend can be used to compute the gradients of the metric functions thanks to automatic differentiation.
+
+Examples
+~~~~~~~~
+
+Compute the gradient of the Dynamic Time Warping similarity measure.
+
+.. code-block:: python
+
+    >>> s1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)
+    >>> s2 = torch.tensor([[3.0], [4.0], [-3.0]])
+    >>> sim = dtw(s1, s2, be="pytorch")
     >>> sim.backward()
     >>> d_s1 = s1.grad
     >>> print(d_s1)
@@ -85,32 +184,19 @@ Examples
             [-0.1543],
             [ 0.7715]])
 
+Compute the gradient of the Soft-DTW similarity measure.
+
 .. code-block:: python
 
-    >>> import torch
-    >>> from tslearn.metrics import SoftDTWLossPyTorch
-    >>> soft_dtw_loss = SoftDTWLossPyTorch(gamma=0.1)
-    >>> x = torch.zeros((4, 3, 2), requires_grad=True)
-    >>> y = torch.arange(0, 24).reshape(4, 3, 2)
-    >>> soft_dtw_loss_mean_value = soft_dtw_loss(x, y).mean()
-    >>> print(soft_dtw_loss_mean_value)
-    tensor(1081., grad_fn=<MeanBackward0>)
-    >>> soft_dtw_loss_mean_value.backward()
-    >>> print(x.grad.shape)
-    torch.Size([4, 3, 2])
-    >>> print(x.grad)
-    tensor([[[  0.0000,  -0.5000],
-             [ -1.0000,  -1.5000],
-             [ -2.0000,  -2.5000]],
-
-            [[ -3.0000,  -3.5000],
-             [ -4.0000,  -4.5000],
-             [ -5.0000,  -5.5000]],
-
-            [[ -6.0000,  -6.5000],
-             [ -7.0000,  -7.5000],
-             [ -8.0000,  -8.5000]],
-
-            [[ -9.0000,  -9.5000],
-             [-10.0000, -10.5000],
-             [-11.0000, -11.5000]]])
+    >>> from tslearn.metrics import soft_dtw
+    >>> ts1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)
+    >>> ts2 = torch.tensor([[3.0], [4.0], [-3.0]])
+    >>> sim = soft_dtw(ts1, ts2, gamma=1.0, be="pytorch", compute_with_backend=True)
+    >>> print(sim)
+    tensor(41.1876, dtype=torch.float64, grad_fn=<SelectBackward0>)
+    >>> sim.backward()
+    >>> d_ts1 = ts1.grad
+    >>> print(d_ts1)
+    tensor([[-4.0001],
+            [-2.2852],
+            [10.1643]])

--- a/docs/backend.rst
+++ b/docs/backend.rst
@@ -11,7 +11,7 @@ Backend selection
 
 A backend can be instantiated using the function ``instantiate_backend``.
 To specify which backend should be instantiated (`NumPy` or `PyTorch`),
-this function accepts four different kind of input arguments:
+this function accepts four different kind of input parameters:
 
 * a string equal to ``"numpy"`` or ``"pytorch"``.
 * a `NumPy` array or a `Torch` tensor.
@@ -82,7 +82,7 @@ If the input is anything else, the ``NumPyBackend`` is instantiated.
     >>> print(be.backend_string)
     "numpy"
 
-The function ``instantiate_backend`` accepts any number of input arguments, including zero.
+The function ``instantiate_backend`` accepts any number of input parameters, including zero.
 To select which backend should be instantiated (`NumPy` or `PyTorch`),
 a for loop is performed on the inputs until a backend is selected.
 
@@ -130,7 +130,7 @@ Use backend functions.
 Choose the backend used by metric functions
 -------------------------------------------
 
-`tslearn`'s metric functions have an optional input argument "``be``" to specify the
+`tslearn`'s metric functions have an optional input parameter "``be``" to specify the
 backend to use to compute the metric.
 
 Examples
@@ -146,7 +146,7 @@ Examples
     >>> print(sim)
     sim tensor(6.4807, grad_fn=<SqrtBackward0>)
 
-By default, ``be=None``.
+By default, the optional input parameter ``be`` is equal to ``None``.
 Note that the first line of the function ``dtw`` is:
 
 .. code-block:: python

--- a/docs/backend.rst
+++ b/docs/backend.rst
@@ -1,0 +1,82 @@
+Backend selection and use
+=========================
+
+`tslearn` proposes time series metrics as `DTW` and `Soft-DTW` which are compatible with different backends (`NumPy` and `PyTorch`).
+
+Backend selection
+-----------------
+
+A backend can be initialized passing four different kind of input arguments to the function instantiate_backend:
+* Input is a Backend instance
+* Input is a string corresponding to "numpy" or "pytorch".
+* Input is a backend object.
+* Input is "None" or anything else than mentioned previously --> The backend `NumPy` is used. 
+
+What happens if there are several inputs? --> A for loop on the inputs.
+
+Examples
+~~~~~~~~
+
+.. code-block:: python
+
+    from tslearn.backend import instantiate_backend
+    be = instantiate_backend("pytorch")
+    print(be.backend_string)
+    >>> "pytorch"
+
+.. code-block:: python
+
+    from tslearn.backend import Backend
+    
+.. code-block:: python
+
+    from tslearn.backend import Backend
+
+Create backend objects
+----------------------
+
+`NumPy` is the reference backend concerning the names of the methods of the backends.
+
+Examples
+~~~~~~~~
+
+.. code-block:: python
+
+    from tslearn.backend import Backend
+    be = instantiate_backend("pytorch")
+    print(be.array([0]))
+    >>> Torch.Tensor([0])
+
+Define metric functions backend
+-------------------------------
+
+Pass a backend as an optional input argument of a metric function.
+
+
+Examples
+~~~~~~~~
+
+.. code-block:: python
+
+    from tslearn.backend import Backend
+
+Automatic differentiation
+----------
+
+Use the backend's automatic differentiation tools in metric functions
+
+Examples
+~~~~~~~~
+
+.. code-block:: python
+
+    from tslearn.backend import Backend
+
+.. code-block:: python
+
+    from tslearn.backend import Backend
+
+.. code-block:: python
+
+    from tslearn.backend import Backend
+

--- a/docs/backend.rst
+++ b/docs/backend.rst
@@ -7,6 +7,7 @@ Backend selection
 -----------------
 
 A backend can be initialized passing four different kind of input arguments to the function instantiate_backend:
+
 * Input is a Backend instance
 * Input is a string corresponding to "numpy" or "pytorch".
 * Input is a backend object.
@@ -19,18 +20,18 @@ Examples
 
 .. code-block:: python
 
-    from tslearn.backend import instantiate_backend
-    be = instantiate_backend("pytorch")
-    print(be.backend_string)
-    >>> "pytorch"
+    >>> from tslearn.backend import instantiate_backend
+    >>> be = instantiate_backend("pytorch")
+    >>> print(be.backend_string)
+    "pytorch"
 
 .. code-block:: python
 
-    from tslearn.backend import Backend
+    >>> from tslearn.backend import Backend
     
 .. code-block:: python
 
-    from tslearn.backend import Backend
+    >>> from tslearn.backend import Backend
 
 Create backend objects
 ----------------------
@@ -42,10 +43,10 @@ Examples
 
 .. code-block:: python
 
-    from tslearn.backend import Backend
-    be = instantiate_backend("pytorch")
-    print(be.array([0]))
-    >>> Torch.Tensor([0])
+    >>> from tslearn.backend import Backend
+    >>> be = instantiate_backend("pytorch")
+    >>> print(be.array([0]))
+    Torch.Tensor([0])
 
 Define metric functions backend
 -------------------------------
@@ -58,7 +59,7 @@ Examples
 
 .. code-block:: python
 
-    from tslearn.backend import Backend
+    >>> from tslearn.backend import Backend
 
 Automatic differentiation
 ----------
@@ -70,13 +71,13 @@ Examples
 
 .. code-block:: python
 
-    from tslearn.backend import Backend
+    >>> from tslearn.backend import Backend
 
 .. code-block:: python
 
-    from tslearn.backend import Backend
+    >>> from tslearn.backend import Backend
 
 .. code-block:: python
 
-    from tslearn.backend import Backend
+    >>> from tslearn.backend import Backend
 

--- a/docs/backend.rst
+++ b/docs/backend.rst
@@ -62,7 +62,7 @@ Examples
     >>> from tslearn.backend import Backend
 
 Automatic differentiation
-----------
+-------------------------
 
 Use the backend's automatic differentiation tools in metric functions
 
@@ -71,13 +71,46 @@ Examples
 
 .. code-block:: python
 
-    >>> from tslearn.backend import Backend
+    >>> import torch
+    >>> from tslearn.metrics import dtw
+    >>> s1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)
+    >>> s2 = torch.tensor([[3.0], [4.0], [-3.0]])
+    >>> sim = dtw(s1, s2, be="pytorch")
+    >>> print(sim)
+    sim tensor(6.4807, grad_fn=<SqrtBackward0>)
+    >>> sim.backward()
+    >>> d_s1 = s1.grad
+    >>> print(d_s1)
+    tensor([[-0.3086],
+            [-0.1543],
+            [ 0.7715]])
 
 .. code-block:: python
 
-    >>> from tslearn.backend import Backend
+    >>> import torch
+    >>> from tslearn.metrics import SoftDTWLossPyTorch
+    >>> soft_dtw_loss = SoftDTWLossPyTorch(gamma=0.1)
+    >>> x = torch.zeros((4, 3, 2), requires_grad=True)
+    >>> y = torch.arange(0, 24).reshape(4, 3, 2)
+    >>> soft_dtw_loss_mean_value = soft_dtw_loss(x, y).mean()
+    >>> print(soft_dtw_loss_mean_value)
+    tensor(1081., grad_fn=<MeanBackward0>)
+    >>> soft_dtw_loss_mean_value.backward()
+    >>> print(x.grad.shape)
+    torch.Size([4, 3, 2])
+    >>> print(x.grad)
+    tensor([[[  0.0000,  -0.5000],
+             [ -1.0000,  -1.5000],
+             [ -2.0000,  -2.5000]],
 
-.. code-block:: python
+            [[ -3.0000,  -3.5000],
+             [ -4.0000,  -4.5000],
+             [ -5.0000,  -5.5000]],
 
-    >>> from tslearn.backend import Backend
+            [[ -6.0000,  -6.5000],
+             [ -7.0000,  -7.5000],
+             [ -8.0000,  -8.5000]],
 
+            [[ -9.0000,  -9.5000],
+             [-10.0000, -10.5000],
+             [-11.0000, -11.5000]]])

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -10,5 +10,6 @@ look at our :doc:`API Reference <reference>`.
     installation
     gettingstarted
     variablelength
+    backend
     integration_other_software
     contributing

--- a/tslearn/metrics/dtw_variants.py
+++ b/tslearn/metrics/dtw_variants.py
@@ -695,7 +695,10 @@ def dtw(
     1.0
 
     The PyTorch backend can be used to compute gradients:
-    >>> import torch
+    >>> try:
+    ...     import torch
+    ... except ModuleNotFoundError:
+    ...     pytest.skip('This doctest does not work if Torch is not installed.')
     >>> s1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)
     >>> s2 = torch.tensor([[3.0], [4.0], [-3.0]])
     >>> sim = dtw(s1, s2, be="pytorch")

--- a/tslearn/metrics/dtw_variants.py
+++ b/tslearn/metrics/dtw_variants.py
@@ -695,11 +695,7 @@ def dtw(
     1.0
 
     The PyTorch backend can be used to compute gradients:
-    >>> try:
-    ...     import torch
-    ... except ModuleNotFoundError:
-    ...     import pytest
-    ...     pytest.skip('This doctest does not work if Torch is not installed.')
+    >>> import torch
     >>> s1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)
     >>> s2 = torch.tensor([[3.0], [4.0], [-3.0]])
     >>> sim = dtw(s1, s2, be="pytorch")

--- a/tslearn/metrics/dtw_variants.py
+++ b/tslearn/metrics/dtw_variants.py
@@ -695,6 +695,7 @@ def dtw(
     1.0
 
     The PyTorch backend can be used to compute gradients:
+    
     >>> import torch
     >>> s1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)
     >>> s2 = torch.tensor([[3.0], [4.0], [-3.0]])

--- a/tslearn/metrics/dtw_variants.py
+++ b/tslearn/metrics/dtw_variants.py
@@ -729,7 +729,7 @@ def dtw(
            spoken word recognition," IEEE Transactions on Acoustics, Speech and
            Signal Processing, vol. 26(1), pp. 43--49, 1978.
 
-    """
+    """  # noqa: E501
     be = instantiate_backend(be, s1, s2)
     s1 = to_time_series(s1, remove_nans=True, be=be)
     s2 = to_time_series(s2, remove_nans=True, be=be)

--- a/tslearn/metrics/dtw_variants.py
+++ b/tslearn/metrics/dtw_variants.py
@@ -694,6 +694,29 @@ def dtw(
     >>> dtw([1, 2, 3], [1., 2., 2., 3., 4.])
     1.0
 
+    The PyTorch backend can be used to compute gradients:
+    >>> s1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)
+    >>> s2 = torch.tensor([[3.0], [4.0], [-3.0]])
+    >>> sim = dtw(s1, s2, be="pytorch")
+    >>> print(sim)
+    tensor(6.4807, grad_fn=<SqrtBackward0>)
+    >>> sim.backward()
+    >>> print(s1.grad)
+    tensor([[-0.3086],
+            [-0.1543],
+            [ 0.7715]])
+
+    >>> s1_2d = torch.tensor([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]], requires_grad=True)
+    >>> s2_2d = torch.tensor([[3.0, 3.0], [4.0, 4.0], [-3.0, -3.0]])
+    >>> sim = dtw(s1_2d, s2_2d, be="pytorch")
+    >>> print(sim)
+    tensor(9.1652, grad_fn=<SqrtBackward0>)
+    >>> sim.backward()
+    >>> print(s1_2d.grad)
+    tensor([[-0.2182, -0.2182],
+            [-0.1091, -0.1091],
+            [ 0.5455,  0.5455]])
+
     See Also
     --------
     dtw_path : Get both the matching path and the similarity score for DTW

--- a/tslearn/metrics/dtw_variants.py
+++ b/tslearn/metrics/dtw_variants.py
@@ -698,6 +698,7 @@ def dtw(
     >>> try:
     ...     import torch
     ... except ModuleNotFoundError:
+    ...     import pytest
     ...     pytest.skip('This doctest does not work if Torch is not installed.')
     >>> s1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)
     >>> s2 = torch.tensor([[3.0], [4.0], [-3.0]])

--- a/tslearn/metrics/dtw_variants.py
+++ b/tslearn/metrics/dtw_variants.py
@@ -695,6 +695,7 @@ def dtw(
     1.0
 
     The PyTorch backend can be used to compute gradients:
+    >>> import torch
     >>> s1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)
     >>> s2 = torch.tensor([[3.0], [4.0], [-3.0]])
     >>> sim = dtw(s1, s2, be="pytorch")

--- a/tslearn/metrics/softdtw_variants.py
+++ b/tslearn/metrics/softdtw_variants.py
@@ -487,9 +487,9 @@ def soft_dtw(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False):
     ... except ModuleNotFoundError:
     ...     import pytest
     ...     pytest.skip('This doctest does not work if Torch is not installed.')
-    >>> ts1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    >>> ts2 = torch.tensor([[3.0], [4.0], [-3.0]])  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    >>> sim = soft_dtw(ts1, ts2, gamma=1.0, be="pytorch", compute_with_backend=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> ts1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)
+    >>> ts2 = torch.tensor([[3.0], [4.0], [-3.0]])
+    >>> sim = soft_dtw(ts1, ts2, gamma=1.0, be="pytorch", compute_with_backend=True)
     >>> print(sim)
     tensor(41.1876, dtype=torch.float64, grad_fn=<SelectBackward0>)
     >>> sim.backward()
@@ -597,9 +597,9 @@ def soft_dtw_alignment(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False)
     ... except ModuleNotFoundError:
     ...     import pytest
     ...     pytest.skip('This doctest does not work if Torch is not installed.')
-    >>> ts1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    >>> ts2 = torch.tensor([[3.0], [4.0], [-3.0]])  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    >>> path, sim = soft_dtw_alignment(ts1, ts2, gamma=1.0, be="pytorch", compute_with_backend=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> ts1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)
+    >>> ts2 = torch.tensor([[3.0], [4.0], [-3.0]])
+    >>> path, sim = soft_dtw_alignment(ts1, ts2, gamma=1.0, be="pytorch", compute_with_backend=True)
     >>> print(sim)
     tensor(41.1876, dtype=torch.float64, grad_fn=<AsStridedBackward0>)
     >>> sim.backward()
@@ -608,9 +608,9 @@ def soft_dtw_alignment(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False)
             [-2.2852],
             [10.1643]])
 
-    >>> ts1_2d = torch.tensor([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]], requires_grad=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    >>> ts2_2d = torch.tensor([[3.0, 3.0], [4.0, 4.0], [-3.0, -3.0]])  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    >>> path, sim = soft_dtw_alignment(ts1_2d, ts2_2d, gamma=1.0, be="pytorch", compute_with_backend=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> ts1_2d = torch.tensor([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]], requires_grad=True)
+    >>> ts2_2d = torch.tensor([[3.0, 3.0], [4.0, 4.0], [-3.0, -3.0]])
+    >>> path, sim = soft_dtw_alignment(ts1_2d, ts2_2d, gamma=1.0, be="pytorch", compute_with_backend=True)
     >>> print(sim)
     tensor(83.2951, dtype=torch.float64, grad_fn=<AsStridedBackward0>)
     >>> sim.backward()
@@ -712,9 +712,9 @@ def cdist_soft_dtw(dataset1, dataset2=None, gamma=1.0, be=None, compute_with_bac
     ... except ModuleNotFoundError:
     ...     import pytest
     ...     pytest.skip('This doctest does not work if Torch is not installed.')
-    >>> dataset1 = torch.tensor([[[1.0], [2.0], [3.0]], [[1.0], [2.0], [3.0]]], requires_grad=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    >>> dataset2 = torch.tensor([[[3.0], [4.0], [-3.0]], [[3.0], [4.0], [-3.0]]])  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    >>> sim_mat = cdist_soft_dtw(dataset1, dataset2, gamma=1.0, be="pytorch", compute_with_backend=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> dataset1 = torch.tensor([[[1.0], [2.0], [3.0]], [[1.0], [2.0], [3.0]]], requires_grad=True)
+    >>> dataset2 = torch.tensor([[[3.0], [4.0], [-3.0]], [[3.0], [4.0], [-3.0]]])
+    >>> sim_mat = cdist_soft_dtw(dataset1, dataset2, gamma=1.0, be="pytorch", compute_with_backend=True)
     >>> print(sim_mat)
     tensor([[41.1876, 41.1876],
             [41.1876, 41.1876]], grad_fn=<CopySlices>)

--- a/tslearn/metrics/softdtw_variants.py
+++ b/tslearn/metrics/softdtw_variants.py
@@ -513,7 +513,7 @@ def soft_dtw(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False):
     ----------
     .. [1] M. Cuturi, M. Blondel "Soft-DTW: a Differentiable Loss Function for
        Time-Series," ICML 2017.
-    """
+    """  # noqa: E501
     be = instantiate_backend(be, ts1, ts2)
     ts1 = be.array(ts1)
     ts2 = be.array(ts2)
@@ -619,7 +619,7 @@ def soft_dtw_alignment(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False)
     ----------
     .. [1] M. Cuturi, M. Blondel "Soft-DTW: a Differentiable Loss Function for
        Time-Series," ICML 2017.
-    """
+    """  # noqa: E501
     be = instantiate_backend(be, ts1, ts2)
     ts1 = be.array(ts1)
     ts2 = be.array(ts2)
@@ -727,7 +727,7 @@ def cdist_soft_dtw(dataset1, dataset2=None, gamma=1.0, be=None, compute_with_bac
     ----------
     .. [1] M. Cuturi, M. Blondel "Soft-DTW: a Differentiable Loss Function for
        Time-Series," ICML 2017.
-    """
+    """  # noqa: E501
     be = instantiate_backend(be, dataset1, dataset2)
     dataset1 = to_time_series_dataset(dataset1, dtype=be.float64, be=be)
 
@@ -861,7 +861,7 @@ def cdist_soft_dtw_normalized(dataset1, dataset2=None, gamma=1.0, be=None, compu
     ----------
     .. [1] M. Cuturi, M. Blondel "Soft-DTW: a Differentiable Loss Function for
        Time-Series," ICML 2017.
-    """
+    """  # noqa: E501
     be = instantiate_backend(be, dataset1, dataset2)
     dataset1 = to_time_series_dataset(dataset1, be=be)
     if dataset2 is not None:

--- a/tslearn/metrics/softdtw_variants.py
+++ b/tslearn/metrics/softdtw_variants.py
@@ -485,6 +485,7 @@ def soft_dtw(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False):
     >>> try:
     ...     import torch
     ... except ModuleNotFoundError:
+    ...     import pytest
     ...     pytest.skip('This doctest does not work if Torch is not installed.')
     >>> ts1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     >>> ts2 = torch.tensor([[3.0], [4.0], [-3.0]])  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
@@ -594,6 +595,7 @@ def soft_dtw_alignment(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False)
     >>> try:
     ...     import torch
     ... except ModuleNotFoundError:
+    ...     import pytest
     ...     pytest.skip('This doctest does not work if Torch is not installed.')
     >>> ts1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     >>> ts2 = torch.tensor([[3.0], [4.0], [-3.0]])  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
@@ -708,6 +710,7 @@ def cdist_soft_dtw(dataset1, dataset2=None, gamma=1.0, be=None, compute_with_bac
     >>> try:
     ...     import torch
     ... except ModuleNotFoundError:
+    ...     import pytest
     ...     pytest.skip('This doctest does not work if Torch is not installed.')
     >>> dataset1 = torch.tensor([[[1.0], [2.0], [3.0]], [[1.0], [2.0], [3.0]]], requires_grad=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     >>> dataset2 = torch.tensor([[[3.0], [4.0], [-3.0]], [[3.0], [4.0], [-3.0]]])  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
@@ -845,6 +848,7 @@ def cdist_soft_dtw_normalized(dataset1, dataset2=None, gamma=1.0, be=None, compu
     >>> try:
     ...     import torch
     ... except ModuleNotFoundError:
+    ...     import pytest
     ...     pytest.skip('This doctest does not work if Torch is not installed.')
     >>> dataset1 = torch.tensor([[[1.0], [2.0], [3.0]], [[1.0], [2.0], [3.0]]], requires_grad=True)
     >>> dataset2 = torch.tensor([[[3.0], [4.0], [-3.0]], [[3.0], [4.0], [-3.0]]])

--- a/tslearn/metrics/softdtw_variants.py
+++ b/tslearn/metrics/softdtw_variants.py
@@ -482,6 +482,7 @@ def soft_dtw(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False):
     0.089...
 
     The PyTorch backend can be used to compute gradients:
+    
     >>> import torch
     >>> ts1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)
     >>> ts2 = torch.tensor([[3.0], [4.0], [-3.0]])
@@ -588,6 +589,7 @@ def soft_dtw_alignment(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False)
            [1.37...e-04, 1.31...e-01, 7.30...e-01, 1.00...e+00]])
 
     The PyTorch backend can be used to compute gradients:
+    
     >>> import torch
     >>> ts1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)
     >>> ts2 = torch.tensor([[3.0], [4.0], [-3.0]])
@@ -699,6 +701,7 @@ def cdist_soft_dtw(dataset1, dataset2=None, gamma=1.0, be=None, compute_with_bac
            [ 1.        ,  0.        ]])
 
     The PyTorch backend can be used to compute gradients:
+    
     >>> import torch
     >>> dataset1 = torch.tensor([[[1.0], [2.0], [3.0]], [[1.0], [2.0], [3.0]]], requires_grad=True)
     >>> dataset2 = torch.tensor([[[3.0], [4.0], [-3.0]], [[3.0], [4.0], [-3.0]]])
@@ -833,6 +836,7 @@ def cdist_soft_dtw_normalized(dataset1, dataset2=None, gamma=1.0, be=None, compu
     True
 
     The PyTorch backend can be used to compute gradients:
+    
     >>> import torch
     >>> dataset1 = torch.tensor([[[1.0], [2.0], [3.0]], [[1.0], [2.0], [3.0]]], requires_grad=True)
     >>> dataset2 = torch.tensor([[[3.0], [4.0], [-3.0]], [[3.0], [4.0], [-3.0]]])

--- a/tslearn/metrics/softdtw_variants.py
+++ b/tslearn/metrics/softdtw_variants.py
@@ -482,11 +482,7 @@ def soft_dtw(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False):
     0.089...
 
     The PyTorch backend can be used to compute gradients:
-    >>> try:
-    ...     import torch
-    ... except ModuleNotFoundError:
-    ...     import pytest
-    ...     pytest.skip('This doctest does not work if Torch is not installed.')
+    >>> import torch
     >>> ts1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)
     >>> ts2 = torch.tensor([[3.0], [4.0], [-3.0]])
     >>> sim = soft_dtw(ts1, ts2, gamma=1.0, be="pytorch", compute_with_backend=True)
@@ -592,11 +588,7 @@ def soft_dtw_alignment(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False)
            [1.37...e-04, 1.31...e-01, 7.30...e-01, 1.00...e+00]])
 
     The PyTorch backend can be used to compute gradients:
-    >>> try:
-    ...     import torch
-    ... except ModuleNotFoundError:
-    ...     import pytest
-    ...     pytest.skip('This doctest does not work if Torch is not installed.')
+    >>> import torch
     >>> ts1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)
     >>> ts2 = torch.tensor([[3.0], [4.0], [-3.0]])
     >>> path, sim = soft_dtw_alignment(ts1, ts2, gamma=1.0, be="pytorch", compute_with_backend=True)
@@ -707,11 +699,7 @@ def cdist_soft_dtw(dataset1, dataset2=None, gamma=1.0, be=None, compute_with_bac
            [ 1.        ,  0.        ]])
 
     The PyTorch backend can be used to compute gradients:
-    >>> try:
-    ...     import torch
-    ... except ModuleNotFoundError:
-    ...     import pytest
-    ...     pytest.skip('This doctest does not work if Torch is not installed.')
+    >>> import torch
     >>> dataset1 = torch.tensor([[[1.0], [2.0], [3.0]], [[1.0], [2.0], [3.0]]], requires_grad=True)
     >>> dataset2 = torch.tensor([[[3.0], [4.0], [-3.0]], [[3.0], [4.0], [-3.0]]])
     >>> sim_mat = cdist_soft_dtw(dataset1, dataset2, gamma=1.0, be="pytorch", compute_with_backend=True)
@@ -845,11 +833,7 @@ def cdist_soft_dtw_normalized(dataset1, dataset2=None, gamma=1.0, be=None, compu
     True
 
     The PyTorch backend can be used to compute gradients:
-    >>> try:
-    ...     import torch
-    ... except ModuleNotFoundError:
-    ...     import pytest
-    ...     pytest.skip('This doctest does not work if Torch is not installed.')
+    >>> import torch
     >>> dataset1 = torch.tensor([[[1.0], [2.0], [3.0]], [[1.0], [2.0], [3.0]]], requires_grad=True)
     >>> dataset2 = torch.tensor([[[3.0], [4.0], [-3.0]], [[3.0], [4.0], [-3.0]]])
     >>> sim_mat = cdist_soft_dtw_normalized(dataset1, dataset2, gamma=1.0, be="pytorch", compute_with_backend=True)

--- a/tslearn/metrics/softdtw_variants.py
+++ b/tslearn/metrics/softdtw_variants.py
@@ -582,9 +582,9 @@ def soft_dtw_alignment(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False)
     >>> a, dist = soft_dtw_alignment([1, 2, 2, 3],
     ...                              [1., 2., 3., 4.],
     ...                              gamma=1.)  # doctest: +ELLIPSIS
-    >>> print(dist)
+    >>> dist
     -0.89...
-    >>> print(a)  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> a  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
     array([[1.00...e+00, 1.88...e-01, 2.83...e-04, 4.19...e-11],
            [3.40...e-01, 8.17...e-01, 8.87...e-02, 3.94...e-05],
            [5.05...e-02, 7.09...e-01, 5.30...e-01, 6.98...e-03],

--- a/tslearn/metrics/softdtw_variants.py
+++ b/tslearn/metrics/softdtw_variants.py
@@ -482,6 +482,7 @@ def soft_dtw(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False):
     0.089...
 
     The PyTorch backend can be used to compute gradients:
+    >>> import torch
     >>> ts1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     >>> ts2 = torch.tensor([[3.0], [4.0], [-3.0]])  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     >>> sim = soft_dtw(ts1, ts2, gamma=1.0, be="pytorch", compute_with_backend=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
@@ -587,6 +588,7 @@ def soft_dtw_alignment(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False)
            [1.37...e-04, 1.31...e-01, 7.30...e-01, 1.00...e+00]])
 
     The PyTorch backend can be used to compute gradients:
+    >>> import torch
     >>> ts1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     >>> ts2 = torch.tensor([[3.0], [4.0], [-3.0]])  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     >>> path, sim = soft_dtw_alignment(ts1, ts2, gamma=1.0, be="pytorch", compute_with_backend=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
@@ -697,6 +699,7 @@ def cdist_soft_dtw(dataset1, dataset2=None, gamma=1.0, be=None, compute_with_bac
            [ 1.        ,  0.        ]])
 
     The PyTorch backend can be used to compute gradients:
+    >>> import torch
     >>> dataset1 = torch.tensor([[[1.0], [2.0], [3.0]], [[1.0], [2.0], [3.0]]], requires_grad=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     >>> dataset2 = torch.tensor([[[3.0], [4.0], [-3.0]], [[3.0], [4.0], [-3.0]]])  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     >>> sim_mat = cdist_soft_dtw(dataset1, dataset2, gamma=1.0, be="pytorch", compute_with_backend=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
@@ -830,6 +833,7 @@ def cdist_soft_dtw_normalized(dataset1, dataset2=None, gamma=1.0, be=None, compu
     True
 
     The PyTorch backend can be used to compute gradients:
+    >>> import torch
     >>> dataset1 = torch.tensor([[[1.0], [2.0], [3.0]], [[1.0], [2.0], [3.0]]], requires_grad=True)
     >>> dataset2 = torch.tensor([[[3.0], [4.0], [-3.0]], [[3.0], [4.0], [-3.0]]])
     >>> sim_mat = cdist_soft_dtw_normalized(dataset1, dataset2, gamma=1.0, be="pytorch", compute_with_backend=True)

--- a/tslearn/metrics/softdtw_variants.py
+++ b/tslearn/metrics/softdtw_variants.py
@@ -482,7 +482,10 @@ def soft_dtw(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False):
     0.089...
 
     The PyTorch backend can be used to compute gradients:
-    >>> import torch
+    >>> try:
+    ...     import torch
+    ... except ModuleNotFoundError:
+    ...     pytest.skip('This doctest does not work if Torch is not installed.')
     >>> ts1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     >>> ts2 = torch.tensor([[3.0], [4.0], [-3.0]])  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     >>> sim = soft_dtw(ts1, ts2, gamma=1.0, be="pytorch", compute_with_backend=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
@@ -579,16 +582,19 @@ def soft_dtw_alignment(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False)
     >>> a, dist = soft_dtw_alignment([1, 2, 2, 3],
     ...                              [1., 2., 3., 4.],
     ...                              gamma=1.)  # doctest: +ELLIPSIS
-    >>> dist
+    >>> print(dist)
     -0.89...
-    >>> a  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> print(a)  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
     array([[1.00...e+00, 1.88...e-01, 2.83...e-04, 4.19...e-11],
            [3.40...e-01, 8.17...e-01, 8.87...e-02, 3.94...e-05],
            [5.05...e-02, 7.09...e-01, 5.30...e-01, 6.98...e-03],
            [1.37...e-04, 1.31...e-01, 7.30...e-01, 1.00...e+00]])
 
     The PyTorch backend can be used to compute gradients:
-    >>> import torch
+    >>> try:
+    ...     import torch
+    ... except ModuleNotFoundError:
+    ...     pytest.skip('This doctest does not work if Torch is not installed.')
     >>> ts1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     >>> ts2 = torch.tensor([[3.0], [4.0], [-3.0]])  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     >>> path, sim = soft_dtw_alignment(ts1, ts2, gamma=1.0, be="pytorch", compute_with_backend=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
@@ -699,7 +705,10 @@ def cdist_soft_dtw(dataset1, dataset2=None, gamma=1.0, be=None, compute_with_bac
            [ 1.        ,  0.        ]])
 
     The PyTorch backend can be used to compute gradients:
-    >>> import torch
+    >>> try:
+    ...     import torch
+    ... except ModuleNotFoundError:
+    ...     pytest.skip('This doctest does not work if Torch is not installed.')
     >>> dataset1 = torch.tensor([[[1.0], [2.0], [3.0]], [[1.0], [2.0], [3.0]]], requires_grad=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     >>> dataset2 = torch.tensor([[[3.0], [4.0], [-3.0]], [[3.0], [4.0], [-3.0]]])  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     >>> sim_mat = cdist_soft_dtw(dataset1, dataset2, gamma=1.0, be="pytorch", compute_with_backend=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
@@ -833,7 +842,10 @@ def cdist_soft_dtw_normalized(dataset1, dataset2=None, gamma=1.0, be=None, compu
     True
 
     The PyTorch backend can be used to compute gradients:
-    >>> import torch
+    >>> try:
+    ...     import torch
+    ... except ModuleNotFoundError:
+    ...     pytest.skip('This doctest does not work if Torch is not installed.')
     >>> dataset1 = torch.tensor([[[1.0], [2.0], [3.0]], [[1.0], [2.0], [3.0]]], requires_grad=True)
     >>> dataset2 = torch.tensor([[[3.0], [4.0], [-3.0]], [[3.0], [4.0], [-3.0]]])
     >>> sim_mat = cdist_soft_dtw_normalized(dataset1, dataset2, gamma=1.0, be="pytorch", compute_with_backend=True)

--- a/tslearn/metrics/softdtw_variants.py
+++ b/tslearn/metrics/softdtw_variants.py
@@ -481,6 +481,29 @@ def soft_dtw(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False):
     ...          gamma=0.01)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     0.089...
 
+    The PyTorch backend can be used to compute gradients:
+    >>> ts1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> ts2 = torch.tensor([[3.0], [4.0], [-3.0]])  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> sim = soft_dtw(ts1, ts2, gamma=1.0, be="pytorch", compute_with_backend=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> print(sim)
+    tensor(41.1876, dtype=torch.float64, grad_fn=<SelectBackward0>)
+    >>> sim.backward()
+    >>> print(ts1.grad)
+    tensor([[-4.0001],
+            [-2.2852],
+            [10.1643]])
+
+    >>> ts1_2d = torch.tensor([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]], requires_grad=True)
+    >>> ts2_2d = torch.tensor([[3.0, 3.0], [4.0, 4.0], [-3.0, -3.0]])
+    >>> sim = soft_dtw(ts1_2d, ts2_2d, gamma=1.0, be="pytorch", compute_with_backend=True)
+    >>> print(sim)
+    tensor(83.2951, dtype=torch.float64, grad_fn=<SelectBackward0>)
+    >>> sim.backward()
+    >>> print(ts1_2d.grad)
+    tensor([[-4.0000, -4.0000],
+            [-2.0261, -2.0261],
+            [10.0206, 10.0206]])
+
     See Also
     --------
     cdist_soft_dtw : Cross similarity matrix between time series datasets
@@ -562,6 +585,29 @@ def soft_dtw_alignment(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False)
            [3.40...e-01, 8.17...e-01, 8.87...e-02, 3.94...e-05],
            [5.05...e-02, 7.09...e-01, 5.30...e-01, 6.98...e-03],
            [1.37...e-04, 1.31...e-01, 7.30...e-01, 1.00...e+00]])
+
+    The PyTorch backend can be used to compute gradients:
+    >>> ts1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> ts2 = torch.tensor([[3.0], [4.0], [-3.0]])  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> path, sim = soft_dtw_alignment(ts1, ts2, gamma=1.0, be="pytorch", compute_with_backend=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> print(sim)
+    tensor(41.1876, dtype=torch.float64, grad_fn=<AsStridedBackward0>)
+    >>> sim.backward()
+    >>> print(ts1.grad)
+    tensor([[-4.0001],
+            [-2.2852],
+            [10.1643]])
+
+    >>> ts1_2d = torch.tensor([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]], requires_grad=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> ts2_2d = torch.tensor([[3.0, 3.0], [4.0, 4.0], [-3.0, -3.0]])  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> path, sim = soft_dtw_alignment(ts1_2d, ts2_2d, gamma=1.0, be="pytorch", compute_with_backend=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> print(sim)
+    tensor(83.2951, dtype=torch.float64, grad_fn=<AsStridedBackward0>)
+    >>> sim.backward()
+    >>> print(ts1_2d.grad)
+    tensor([[-4.0000, -4.0000],
+            [-2.0261, -2.0261],
+            [10.0206, 10.0206]])
 
     See Also
     --------
@@ -649,6 +695,24 @@ def cdist_soft_dtw(dataset1, dataset2=None, gamma=1.0, be=None, compute_with_bac
     ...                [[1, 2, 2, 3], [1., 2., 3., 4.]], gamma=.01)
     array([[-0.01098612,  1.        ],
            [ 1.        ,  0.        ]])
+
+    The PyTorch backend can be used to compute gradients:
+    >>> dataset1 = torch.tensor([[[1.0], [2.0], [3.0]], [[1.0], [2.0], [3.0]]], requires_grad=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> dataset2 = torch.tensor([[[3.0], [4.0], [-3.0]], [[3.0], [4.0], [-3.0]]])  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> sim_mat = cdist_soft_dtw(dataset1, dataset2, gamma=1.0, be="pytorch", compute_with_backend=True)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> print(sim_mat)
+    tensor([[41.1876, 41.1876],
+            [41.1876, 41.1876]], grad_fn=<CopySlices>)
+    >>> sim = sim_mat[0, 0]
+    >>> sim.backward()
+    >>> print(dataset1.grad)
+    tensor([[[-4.0001],
+             [-2.2852],
+             [10.1643]],
+    <BLANKLINE>
+            [[ 0.0000],
+             [ 0.0000],
+             [ 0.0000]]])
 
     See Also
     --------
@@ -764,6 +828,24 @@ def cdist_soft_dtw_normalized(dataset1, dataset2=None, gamma=1.0, be=None, compu
     >>> time_series2 = np.random.randn(4, 15, 1)
     >>> np.alltrue(cdist_soft_dtw_normalized(time_series, time_series2) >= 0.)
     True
+
+    The PyTorch backend can be used to compute gradients:
+    >>> dataset1 = torch.tensor([[[1.0], [2.0], [3.0]], [[1.0], [2.0], [3.0]]], requires_grad=True)
+    >>> dataset2 = torch.tensor([[[3.0], [4.0], [-3.0]], [[3.0], [4.0], [-3.0]]])
+    >>> sim_mat = cdist_soft_dtw_normalized(dataset1, dataset2, gamma=1.0, be="pytorch", compute_with_backend=True)
+    >>> print(sim_mat)
+    tensor([[42.0586, 42.0586],
+            [42.0586, 42.0586]], grad_fn=<AddBackward0>)
+    >>> sim = sim_mat[0, 0]
+    >>> sim.backward()
+    >>> print(dataset1.grad)
+    tensor([[[-3.5249],
+             [-2.2852],
+             [ 9.6891]],
+    <BLANKLINE>
+            [[ 0.0000],
+             [ 0.0000],
+             [ 0.0000]]])
 
     See Also
     --------


### PR DESCRIPTION
This PR improves the documentation about the backends to explain how they work.

We will add information about the backends (how it works, how to select the backend, what happens if it is not selected...)  in the Quick-start guide:
https://github.com/tslearn-team/tslearn/blob/main/docs/quickstart.rst
and add a file named `backend.rst` in the folder `main/docs`.

We will also add information about the backends and examples in the docstrings of the functions `dtw` (https://github.com/tslearn-team/tslearn/blob/main/tslearn/metrics/dtw_variants.py) and `soft_dtw` (https://github.com/tslearn-team/tslearn/blob/main/tslearn/metrics/softdtw_variants.py).
