### PR TITLE
Fix readthedocs fail test changing build.image into build.os

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,13 @@
 # Required
 version: 2
 
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-latest
+  tools:
+    python:
+      version: "3.8"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
@@ -16,13 +23,11 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all
 
-# Optionally set the version of Python and requirements required to build your docs
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
-  version: 3.8
   install:
-    - requirements: docs/requirements_rtd.txt
-    - method: setuptools
-      path: .
-
-build:
-  image: latest  # See: https://hub.docker.com/r/readthedocs/build/
+  - requirements: docs/requirements_rtd.txt
+  - method: setuptools
+  path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -29,4 +29,4 @@ python:
   install:
   - requirements: docs/requirements_rtd.txt
   - method: setuptools
-  path: .
+  - path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -29,4 +29,4 @@ python:
   install:
   - requirements: docs/requirements_rtd.txt
   - method: setuptools
-  - path: .
+    path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-  os: ubuntu-latest
+  os: ubuntu-22.04
   tools:
     python:
       version: "3.8"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,8 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python:
-      version: "3.8"
+    python: "3.8"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
The `readthedocs` test is failing on the main branch with the following error message:
`The configuration key "build.image" is deprecated. Use "build.os" instead to continue building your project. Read more at https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os`

Indeed, `build.image` is deprecated since Monday, October 16, 2023 and is now replaced by `build.os`:
https://blog.readthedocs.com/use-build-os-config/

Specific details to write the `.readthedocs.yml` file can be found at:
https://docs.readthedocs.io/en/stable/config-file/v2.html
