### PR TITLE
Specify in the docstrings the shapes of the input arrays of the functions of the file ctw.py

### DIFF
--- a/tslearn/metrics/ctw.py
+++ b/tslearn/metrics/ctw.py
@@ -9,20 +9,21 @@ from .utils import _cdist_generic
 
 
 def _get_warp_matrices(warp_path, be):
-    """
-    Convert warping path sequence to matrices.
+    """Convert warping path sequence to matrices.
 
     Parameters
     ----------
-    warp_path : list of tuple of two indices that are matched together
+    warp_path : list of tuple of two indices that are matched together, length = m
         First output of the dtw_path function.
     be : Backend object or string
         Backend.
 
     Returns
     -------
-    two 2D matrices of size m x T (m = number of step to match the two
-        sequences
+    Wx : array-like, shape=(m, nx)
+        Matrix. The number of steps to match the two sequences is equal to m.
+    Wy : array-like, shape=(m, ny)
+        Matrix.
     """
     be = instantiate_backend(be, warp_path[0][0])
     # number of indices for the alignment
@@ -67,10 +68,10 @@ def ctw_path(
 
     Parameters
     ----------
-    s1
-        A time series.
-    s2
-        Another time series.
+    s1 : array-like, shape=(sz1, d) or (sz1,)
+        A time series. If shape is (sz1,), the time series is assumed to be univariate.
+    s2 : array-like, shape=(sz2, d) or (sz2,)
+        Another time series. If shape is (sz2,), the time series is assumed to be univariate.
     max_iter : int (default: 100)
         Number of iterations for the CTW algorithm. Each iteration
     n_components : int (default: None)
@@ -215,10 +216,10 @@ def ctw(
 
     Parameters
     ----------
-    s1
-        A time series.
-    s2
-        Another time series.
+    s1 : array-like, shape=(sz1, d) or (sz1,)
+        A time series. If shape is (sz1,), the time series is assumed to be univariate.
+    s2 : array-like, shape=(sz2, d) or (sz2,)
+        Another time series. If shape is (sz2,), the time series is assumed to be univariate.
     max_iter : int (default: 100)
         Number of iterations for the CTW algorithm. Each iteration
     n_components : int (default: None)
@@ -313,11 +314,15 @@ def cdist_ctw(
 
     Parameters
     ----------
-    dataset1 : array-like
-        A dataset of time series
-    dataset2 : array-like (default: None)
-        Another dataset of time series. If `None`, self-similarity of
-        `dataset1` is returned.
+    dataset1 : array-like, shape=(n_ts1, sz1, d) or (n_ts1, sz1) or (sz1,)
+        A dataset of time series.
+        If shape is (n_ts1, sz1), the dataset is composed of univariate time series.
+        If shape is (sz1,), the dataset is a composed of a unique univariate time series.
+    dataset2 : None or array-like, shape=(n_ts2, sz2, d) or (n_ts2, sz2) or (sz2,) (default: None)
+        Another dataset of time series. 
+        If `None`, self-similarity of `dataset1` is returned.
+        If shape is (n_ts2, sz2), the dataset is composed of univariate time series.
+        If shape is (sz2,), the dataset is a composed of a unique univariate time series.
     max_iter : int (default: 100)
         Number of iterations for the CTW algorithm. Each iteration
     n_components : int (default: None)
@@ -362,8 +367,8 @@ def cdist_ctw(
 
     Returns
     -------
-    cdist : numpy.ndarray
-        Cross-similarity matrix
+    cdist : array-like, shape=(n_ts1, n_ts2)
+        Cross-similarity matrix.
 
     Examples
     --------

--- a/tslearn/metrics/dtw_variants.py
+++ b/tslearn/metrics/dtw_variants.py
@@ -1725,15 +1725,15 @@ def cdist_dtw(
 
     Parameters
     ----------
-    dataset1 : array-like, shape=(n_ts1, sz1, d) or (sz1, d) or (sz1,)
+    dataset1 : array-like, shape=(n_ts1, sz1, d) or (n_ts1, sz1) or (sz1,)
         A dataset of time series.
-        If shape is (sz1, d), the dataset is composed of a unique time series.
+        If shape is (n_ts1, sz1), the dataset is composed of univariate time series.
         If shape is (sz1,), the dataset is a composed of a unique univariate time series.
 
-    dataset2 : array-like (default: None), shape=(n_ts2, sz2, d) or (sz2, d) or (sz2,)
+    dataset2 : None or array-like, shape=(n_ts2, sz2, d) or (n_ts2, sz2) or (sz2,) (default: None)
         Another dataset of time series. If `None`, self-similarity of
         `dataset1` is returned.
-        If shape is (sz2, d), the dataset is composed of a unique time series.
+        If shape is (n_ts2, sz2), the dataset is composed of univariate time series.
         If shape is (sz2,), the dataset is a composed of a unique univariate time series.
 
     global_constraint : {"itakura", "sakoe_chiba"} or None (default: None)

--- a/tslearn/metrics/utils.py
+++ b/tslearn/metrics/utils.py
@@ -24,14 +24,18 @@ def _cdist_generic(
     Parameters
     ----------
     dist_fun : function
-        Similarity function to be used
+        Similarity function to be used.
 
-    dataset1 : array-like
-        A dataset of time series
+    dataset1 : array-like, shape=(n_ts1, sz1, d) or (n_ts1, sz1) or (sz1,)
+        A dataset of time series.
+        If shape is (n_ts1, sz1), the dataset is composed of univariate time series.
+        If shape is (sz1,), the dataset is a composed of a unique univariate time series.
 
-    dataset2 : array-like (default: None)
-        Another dataset of time series. If `None`, self-similarity of
-        `dataset1` is returned.
+    dataset2 : None or array-like, shape=(n_ts2, sz2, d) or (n_ts2, sz2) or (sz2,) (default: None)
+        Another dataset of time series. 
+        If `None`, self-similarity of `dataset1` is returned.
+        If shape is (n_ts2, sz2), the dataset is composed of univariate time series.
+        If shape is (sz2,), the dataset is a composed of a unique univariate time series.
 
     n_jobs : int or None, optional (default=None)
         The number of jobs to run in parallel.
@@ -61,8 +65,8 @@ def _cdist_generic(
 
     Returns
     -------
-    cdist : numpy.ndarray
-        Cross-similarity matrix
+    cdist : array-like, shape=(n_ts1, n_ts2)
+        Cross-similarity matrix.
     """  # noqa: E501
     be = instantiate_backend(be, dataset1, dataset2)
     dataset1 = to_time_series_dataset(dataset1, dtype=dtype, be=be)

--- a/tslearn/utils/utils.py
+++ b/tslearn/utils/utils.py
@@ -118,8 +118,9 @@ def to_time_series(ts, remove_nans=False, be=None):
 
     Parameters
     ----------
-    ts : array-like
+    ts : array-like, shape=(sz, d) or (sz,)
         The time series to be transformed.
+        If shape is (sz,), the time series is assumed to be univariate.
     remove_nans : bool (default: False)
         Whether trailing NaNs at the end of the time series should be removed
         or not
@@ -128,7 +129,7 @@ def to_time_series(ts, remove_nans=False, be=None):
 
     Returns
     -------
-    numpy.ndarray of shape (sz, d)
+    ts_out : array-like, shape=(sz, d)
         The transformed time series. This is always guaraneteed to be a new
         time series and never just a view into the old one.
 
@@ -166,7 +167,7 @@ def to_time_series_dataset(dataset, dtype=float, be=None):
 
     Parameters
     ----------
-    dataset : array-like
+    dataset : array-like, shape=(n_ts, sz, d) or (n_ts, sz) or (sz,)
         The dataset of time series to be transformed. A single time series will
         be automatically wrapped into a dataset with a single entry.
     dtype : data type (default: float)
@@ -174,7 +175,7 @@ def to_time_series_dataset(dataset, dtype=float, be=None):
 
     Returns
     -------
-    numpy.ndarray of shape (n_ts, sz, d)
+    dataset_out : array-like, shape=(n_ts, sz, d)
         The transformed dataset of time series.
 
     Examples


### PR DESCRIPTION
Specify the possible shapes of the input arrays of the metric functions of the file `ctw.py` in the docstrings.
For example:
```
s1 : array-like, shape=(sz1, d) or (sz1,)
    A time series. If shape is (sz1,), the time series is assumed to be univariate.
```
or
```
dataset1 : array-like, shape=(n_ts, sz, d) or (n_ts, sz) or (sz,)
    A dataset of time series. If shape is (n_ts, sz), the dataset is composed of univariate time series. 
    If shape is (sz,), the dataset is a composed of a unique univariate time series.
```