### PR TITLE
Improve docstrings in several metric functions

### DIFF
--- a/tslearn/metrics/cycc.py
+++ b/tslearn/metrics/cycc.py
@@ -12,14 +12,14 @@ def normalized_cc(s1, s2, norm1=-1.0, norm2=-1.0):
 
     Parameters
     ----------
-    s1 : array-like, shape=[sz, d], dtype=float64
-    s2 : array-like, shape=[sz, d], dtype=float64
+    s1 : array-like, shape=(sz, d), dtype=float64
+    s2 : array-like, shape=(sz, d), dtype=float64
     norm1 : float64, default=-1.0
     norm2 : float64, default=-1.0
 
     Returns
     -------
-    norm_cc : array-like, shape=[2 * sz - 1], dtype=float64
+    norm_cc : array-like, shape=(2 * sz - 1), dtype=float64
     """
     assert s1.shape[1] == s2.shape[1]
     sz = s1.shape[0]
@@ -54,15 +54,15 @@ def cdist_normalized_cc(dataset1, dataset2, norms1, norms2, self_similarity):
 
     Parameters
     ----------
-    dataset1 : array-like, shape=[n_ts1, sz, d], dtype=float64
-    dataset2 : array-like, shape=[n_ts2, sz, d], dtype=float64
-    norms1 : array-like, shape=[n_ts1], dtype=float64
-    norms2 : array-like, shape=[n_ts2], dtype=float64
+    dataset1 : array-like, shape=(n_ts1, sz, d), dtype=float64
+    dataset2 : array-like, shape=(n_ts2, sz, d), dtype=float64
+    norms1 : array-like, shape=(n_ts1,), dtype=float64
+    norms2 : array-like, shape=(n_ts2,), dtype=float64
     self_similarity : bool
 
     Returns
     -------
-    dists : array-like, shape=[n_ts1, n_ts2], dtype=float64
+    dists : array-like, shape=(n_ts1, n_ts2), dtype=float64
     """
     n_ts1, sz, d = dataset1.shape
     n_ts2 = dataset2.shape[0]
@@ -97,17 +97,17 @@ def y_shifted_sbd_vec(ref_ts, dataset, norm_ref, norms_dataset):
 
     Parameters
     ----------
-    ref_ts : array-like, shape=[sz, d], dtype=float64
+    ref_ts : array-like, shape=(sz, d), dtype=float64
         Time series of reference.
-    dataset : array-like, shape=[n_ts, sz, d], dtype=float64
+    dataset : array-like, shape=(n_ts, sz, d), dtype=float64
         Time series dataset.
     norm_ref : float64
-    norms_dataset : array-like, shape=[n_ts], dtype=float64
+    norms_dataset : array-like, shape=(n_ts,), dtype=float64
         Norms of the time series dataset.
 
     Returns
     -------
-    dataset_shifted : array-like, shape=[n_ts, sz, d], dtype=float64
+    dataset_shifted : array-like, shape=(n_ts, sz, d), dtype=float64
     """
     n_ts = dataset.shape[0]
     sz = dataset.shape[1]

--- a/tslearn/metrics/cycc.py
+++ b/tslearn/metrics/cycc.py
@@ -13,7 +13,9 @@ def normalized_cc(s1, s2, norm1=-1.0, norm2=-1.0):
     Parameters
     ----------
     s1 : array-like, shape=(sz, d), dtype=float64
+        A time series.
     s2 : array-like, shape=(sz, d), dtype=float64
+        Another time series.
     norm1 : float64, default=-1.0
     norm2 : float64, default=-1.0
 
@@ -55,7 +57,9 @@ def cdist_normalized_cc(dataset1, dataset2, norms1, norms2, self_similarity):
     Parameters
     ----------
     dataset1 : array-like, shape=(n_ts1, sz, d), dtype=float64
+        A dataset of time series.
     dataset2 : array-like, shape=(n_ts2, sz, d), dtype=float64
+        Another dataset of time series.
     norms1 : array-like, shape=(n_ts1,), dtype=float64
     norms2 : array-like, shape=(n_ts2,), dtype=float64
     self_similarity : bool
@@ -108,6 +112,7 @@ def y_shifted_sbd_vec(ref_ts, dataset, norm_ref, norms_dataset):
     Returns
     -------
     dataset_shifted : array-like, shape=(n_ts, sz, d), dtype=float64
+        Shifted dataset.
     """
     n_ts = dataset.shape[0]
     sz = dataset.shape[1]

--- a/tslearn/metrics/cysax.py
+++ b/tslearn/metrics/cysax.py
@@ -16,6 +16,7 @@ def inv_transform_paa(dataset_paa, original_size):
     dataset_paa : array-like, shape=(n_ts, sz, d), dtype=float64
         A dataset of PAA series.
     original_size : int32
+        Length of the original time series.
 
     Returns
     -------
@@ -44,7 +45,9 @@ def cydist_sax(sax1, sax2, breakpoints, original_size):
     sax2 : array-like, shape=(sz, d), dtype=float64 (Linux and MacOS) or float32 (Windows)
         SAX representation of another time series.
     breakpoints : array-like, ndim=1, dtype=float64
+        The breakpoints used to assign the alphabet symbols.
     original_size : int64 (Linux and MacOS) or int32 (Windows)
+        Length of the original time series.
 
     Returns
     -------
@@ -81,6 +84,7 @@ def inv_transform_sax(dataset_sax, breakpoints_middle_, original_size):
         A dataset of SAX series.
     breakpoints_middle_ : array-like, ndim=1, dtype=float64
     original_size : int64 (Linux and MacOS) or int32 (Windows)
+        Length of the original time series.
 
     Returns
     -------
@@ -142,10 +146,12 @@ def cydist_1d_sax(
     breakpoints_avg_middle_ : array-like, ndim=1, dtype=float64
     breakpoints_slope_middle_ : array-like, ndim=1, dtype=float64
     original_size : int64 (Linux and MacOS) or int32 (Windows)
+        Length of the original time series.
 
     Returns
     -------
     dist_1d_sax : float64
+        1d-SAX distance.
 
     Notes
     -----
@@ -192,6 +198,7 @@ def inv_transform_1d_sax(
     breakpoints_avg_middle_ : array-like, ndim=1, dtype=float64
     breakpoints_slope_middle_ : array-like, ndim=1, dtype=float64
     original_size : int64 (Linux and MacOS) or int32 (Windows)
+        Length of the original time series.
 
     Returns
     -------

--- a/tslearn/metrics/cysax.py
+++ b/tslearn/metrics/cysax.py
@@ -13,13 +13,13 @@ def inv_transform_paa(dataset_paa, original_size):
 
     Parameters
     ----------
-    dataset_paa : array-like, shape=[n_ts, sz, d], dtype=float64
+    dataset_paa : array-like, shape=(n_ts, sz, d), dtype=float64
         A dataset of PAA series.
     original_size : int32
 
     Returns
     -------
-    dataset_out : array-like, shape=[n_ts, original_size, d], dtype=float64
+    dataset_out : array-like, shape=(n_ts, original_size, d), dtype=float64
         A dataset of time series corresponding to the provided
         representation.
     """
@@ -39,9 +39,9 @@ def cydist_sax(sax1, sax2, breakpoints, original_size):
 
     Parameters
     ----------
-    sax1 : array-like, shape=[sz, d], dtype=float64 (Linux and MacOS) or float32 (Windows)
+    sax1 : array-like, shape=(sz, d), dtype=float64 (Linux and MacOS) or float32 (Windows)
         SAX representation of a time series.
-    sax2 : array-like, shape=[sz, d], dtype=float64 (Linux and MacOS) or float32 (Windows)
+    sax2 : array-like, shape=(sz, d), dtype=float64 (Linux and MacOS) or float32 (Windows)
         SAX representation of another time series.
     breakpoints : array-like, ndim=1, dtype=float64
     original_size : int64 (Linux and MacOS) or int32 (Windows)
@@ -77,14 +77,14 @@ def inv_transform_sax(dataset_sax, breakpoints_middle_, original_size):
 
     Parameters
     ----------
-    dataset_sax : array-like, shape=[n_ts, sz, d], dtype=float64 (Linux and MacOS) or float32 (Windows)
+    dataset_sax : array-like, shape=(n_ts, sz, d), dtype=float64 (Linux and MacOS) or float32 (Windows)
         A dataset of SAX series.
     breakpoints_middle_ : array-like, ndim=1, dtype=float64
     original_size : int64 (Linux and MacOS) or int32 (Windows)
 
     Returns
     -------
-    dataset_out : array-like, shape=[n_ts, original_size, d], dtype=float64
+    dataset_out : array-like, shape=(n_ts, original_size, d), dtype=float64
     """
     n_ts, sz, d = dataset_sax.shape
     seg_sz = original_size // sz
@@ -105,12 +105,12 @@ def cyslopes(dataset, t0):
 
     Parameters
     ----------
-    dataset : array-like, shape=[n_ts, sz, d], dtype=float64
+    dataset : array-like, shape=(n_ts, sz, d), dtype=float64
     t0 : int32
 
     Returns
     -------
-    dataset_out : array-like, shape=[n_ts, d], dtype=float64
+    dataset_out : array-like, shape=(n_ts, d), dtype=float64
     """
     n_ts, sz, d = dataset.shape
     dataset_out = np.empty((n_ts, d))
@@ -135,9 +135,9 @@ def cydist_1d_sax(
 
     Parameters
     ----------
-    sax1 : array-like, shape=[sz, 2 * d], dtype=float64 (Linux and MacOS) or float32 (Windows)
+    sax1 : array-like, shape=(sz, 2 * d), dtype=float64 (Linux and MacOS) or float32 (Windows)
         1d-SAX representation of a time series.
-    sax2 : array-like, shape=[sz, 2 * d], dtype=float64 (Linux and MacOS) or float32 (Windows)
+    sax2 : array-like, shape=(sz, 2 * d), dtype=float64 (Linux and MacOS) or float32 (Windows)
         1d-SAX representation of another time series.
     breakpoints_avg_middle_ : array-like, ndim=1, dtype=float64
     breakpoints_slope_middle_ : array-like, ndim=1, dtype=float64
@@ -187,7 +187,7 @@ def inv_transform_1d_sax(
 
     Parameters
     ----------
-    dataset_sax : array-like, shape=[n_ts, sz, 2 * d], dtype=float64 (Linux and MacOS) or float32 (Windows)
+    dataset_sax : array-like, shape=(n_ts, sz, 2 * d), dtype=float64 (Linux and MacOS) or float32 (Windows)
         A dataset of SAX series.
     breakpoints_avg_middle_ : array-like, ndim=1, dtype=float64
     breakpoints_slope_middle_ : array-like, ndim=1, dtype=float64
@@ -195,7 +195,7 @@ def inv_transform_1d_sax(
 
     Returns
     -------
-    dataset_out : array-like, shape=[n_ts, original_size, d], dtype=float64
+    dataset_out : array-like, shape=(n_ts, original_size, d), dtype=float64
         A dataset of time series corresponding to the provided
             representation.
     """

--- a/tslearn/metrics/sax.py
+++ b/tslearn/metrics/sax.py
@@ -13,19 +13,23 @@ def cdist_sax(dataset1, breakpoints_avg, size_fitted, dataset2=None,
 
     Parameters
     ----------
-    dataset1 : array-like
-        A dataset of time series
+    dataset1 : array-like, shape=(n_ts1, sz1, d) or (n_ts1, sz1) or (sz1,)
+        A dataset of time series.
+        If shape is (n_ts1, sz1), the dataset is composed of univariate time series.
+        If shape is (sz1,), the dataset is a composed of a unique univariate time series.
 
-    breakpoints_avg : array-like
+    breakpoints_avg : array-like, ndim=1
         The breakpoints used to assign the alphabet symbols.
 
     size_fitted: int
         The original timesteps in the timeseries, before
         discretizing through SAX.
 
-    dataset2 : array-like (default: None)
-        Another dataset of time series. If `None`, self-similarity of
-        `dataset1` is returned.
+    dataset2 : None or array-like, shape=(n_ts2, sz2, d) or (n_ts2, sz2) or (sz2,) (default: None)
+        Another dataset of time series. 
+        If `None`, self-similarity of `dataset1` is returned.
+        If shape is (n_ts2, sz2), the dataset is composed of univariate time series.
+        If shape is (sz2,), the dataset is a composed of a unique univariate time series.
 
     n_jobs : int or None, optional (default=None)
         The number of jobs to run in parallel.
@@ -44,8 +48,8 @@ def cdist_sax(dataset1, breakpoints_avg, size_fitted, dataset2=None,
 
     Returns
     -------
-    cdist : numpy.ndarray
-        Cross-similarity matrix
+    cdist : array-like, shape=(n_ts1, n_ts2)
+        Cross-similarity matrix.
 
     References
     ----------

--- a/tslearn/metrics/soft_dtw_fast.py
+++ b/tslearn/metrics/soft_dtw_fast.py
@@ -13,18 +13,26 @@ DBL_MAX = np.finfo("double").max
 
 @njit(fastmath=True)
 def _njit_softmin3(a, b, c, gamma):
-    """Compute softmin of 3 input variables with parameter gamma.
+    r"""Compute softmin of 3 input variables with parameter gamma.
+
+    In the limit case :math:`\gamma = 0`, the softmin operator reduces to
+    a hard-min operator.
 
     Parameters
     ----------
     a : float64
+        First input variable.
     b : float64
+        Second input variable.
     c : float64
+        Third input variable.
     gamma : float64
+        Regularization parameter.
 
     Returns
     -------
     softmin_value : float64
+        Softmin value.
     """
     a /= -gamma
     b /= -gamma
@@ -41,20 +49,28 @@ def _njit_softmin3(a, b, c, gamma):
 
 
 def _softmin3(a, b, c, gamma, be=None):
-    """Compute softmin of 3 input variables with parameter gamma.
+    r"""Compute softmin of 3 input variables with parameter gamma.
+
+    In the limit case :math:`\gamma = 0`, the softmin operator reduces to
+    a hard-min operator.
 
     Parameters
     ----------
     a : float64
+        First input variable.
     b : float64
+        Second input variable.
     c : float64
+        Third input variable.
     gamma : float64
+        Regularization parameter.
     be : Backend object or string or None
         Backend.
 
     Returns
     -------
     softmin_value : float64
+        Softmin value.
     """
     be = instantiate_backend(be, a, b, c, gamma)
     a = be.array(a, dtype=be.float64)
@@ -82,9 +98,10 @@ def _njit_soft_dtw(D, R, gamma):
 
     Parameters
     ----------
-    D : array-like, shape=[m, n], dtype=float64
-    R : array-like, shape=[m+2, n+2], dtype=float64
+    D : array-like, shape=(m, n), dtype=float64
+    R : array-like, shape=(m+2, n+2), dtype=float64
     gamma : float64
+        Regularization parameter.
     """
     m = D.shape[0]
     n = D.shape[1]
@@ -108,9 +125,10 @@ def _soft_dtw(D, R, gamma, be=None):
 
     Parameters
     ----------
-    D : array-like, shape=[m, n], dtype=float64
-    R : array-like, shape=[m+2, n+2], dtype=float64
+    D : array-like, shape=(m, n), dtype=float64
+    R : array-like, shape=(m+2, n+2), dtype=float64
     gamma : float64
+        Regularization parameter.
     be : Backend object or string or None
         Backend.
     """
@@ -142,9 +160,10 @@ def _njit_soft_dtw_batch(D, R, gamma):
 
     Parameters
     ----------
-    D : array-like, shape=[b, m, n], dtype=float64
-    R : array-like, shape=[b, m+2, n+2], dtype=float64
+    D : array-like, shape=(b, m, n), dtype=float64
+    R : array-like, shape=(b, m+2, n+2), dtype=float64
     gamma : float64
+        Regularization parameter.
     """
     for i_sample in prange(D.shape[0]):
         _njit_soft_dtw(D[i_sample, :, :], R[i_sample, :, :], gamma)
@@ -155,9 +174,10 @@ def _soft_dtw_batch(D, R, gamma, be=None):
 
     Parameters
     ----------
-    D : array-like, shape=[b, m, n], dtype=float64
-    R : array-like, shape=[b, m+2, n+2], dtype=float64
+    D : array-like, shape=(b, m, n), dtype=float64
+    R : array-like, shape=(b, m+2, n+2), dtype=float64
     gamma : float64
+        Regularization parameter.
     be : Backend object or string or None
         Backend.
     """
@@ -172,10 +192,11 @@ def _njit_soft_dtw_grad(D, R, E, gamma):
 
     Parameters
     ----------
-    D : array-like, shape=[m, n], dtype=float64
-    R : array-like, shape=[m+2, n+2], dtype=float64
-    E : array-like, shape=[m+2, n+2], dtype=float64
+    D : array-like, shape=(m, n), dtype=float64
+    R : array-like, shape=(m+2, n+2), dtype=float64
+    E : array-like, shape=(m+2, n+2), dtype=float64
     gamma : float64
+        Regularization parameter.
     """
     m = D.shape[0] - 1
     n = D.shape[1] - 1
@@ -203,10 +224,11 @@ def _soft_dtw_grad(D, R, E, gamma, be=None):
 
     Parameters
     ----------
-    D : array-like, shape=[m, n], dtype=float64
-    R : array-like, shape=[m+2, n+2], dtype=float64
-    E : array-like, shape=[m+2, n+2], dtype=float64
+    D : array-like, shape=(m, n), dtype=float64
+    R : array-like, shape=(m+2, n+2), dtype=float64
+    E : array-like, shape=(m+2, n+2), dtype=float64
     gamma : float64
+        Regularization parameter.
     be : Backend object or string or None
         Backend.
     """
@@ -239,10 +261,11 @@ def _njit_soft_dtw_grad_batch(D, R, E, gamma):
 
     Parameters
     ----------
-    D : array-like, shape=[b, m, n], dtype=float64
-    R : array-like, shape=[b, m+2, n+2], dtype=float64
-    E : array-like, shape=[b, m+2, n+2], dtype=float64
+    D : array-like, shape=(b, m, n), dtype=float64
+    R : array-like, shape=(b, m+2, n+2), dtype=float64
+    E : array-like, shape=(b, m+2, n+2), dtype=float64
     gamma : float64
+        Regularization parameter.
     """
     for i_sample in prange(D.shape[0]):
         _njit_soft_dtw_grad(D[i_sample, :, :], R[i_sample, :, :], E[i_sample, :, :], gamma)
@@ -253,10 +276,11 @@ def _soft_dtw_grad_batch(D, R, E, gamma, be=None):
 
     Parameters
     ----------
-    D : array-like, shape=[b, m, n], dtype=float64
-    R : array-like, shape=[b, m+2, n+2], dtype=float64
-    E : array-like, shape=[b, m+2, n+2], dtype=float64
+    D : array-like, shape=(b, m, n), dtype=float64
+    R : array-like, shape=(b, m+2, n+2), dtype=float64
+    E : array-like, shape=(b, m+2, n+2), dtype=float64
     gamma : float64
+        Regularization parameter.
     be : Backend object or string or None
         Backend.
     """
@@ -272,13 +296,13 @@ def _njit_jacobian_product_sq_euc(X, Y, E, G):
 
     Parameters
     ----------
-    X: array, shape = [m, d], dtype=float64
+    X: array, shape=(m, d), dtype=float64
         First time series.
-    Y: array, shape = [n, d], dtype=float64
+    Y: array, shape=(n, d), dtype=float64
         Second time series.
-    E: array, shape = [m, n], dtype=float64
-    G: array, shape = [m, d], dtype=float64
-        Product with Jacobian
+    E: array, shape=(m, n), dtype=float64
+    G: array, shape=(m, d), dtype=float64
+        Product with Jacobian.
         ([m x d, m x n] * [m x n] = [m x d]).
     """
     m = X.shape[0]
@@ -297,13 +321,13 @@ def _jacobian_product_sq_euc(X, Y, E, G):
 
     Parameters
     ----------
-    X: array, shape = [m, d], dtype=float64
+    X: array, shape=(m, d), dtype=float64
         First time series.
-    Y: array, shape = [n, d], dtype=float64
+    Y: array, shape=(n, d), dtype=float64
         Second time series.
-    E: array, shape = [m, n], dtype=float64
-    G: array, shape = [m, d], dtype=float64
-        Product with Jacobian
+    E: array, shape=(m, n), dtype=float64
+    G: array, shape=(m, d), dtype=float64
+        Product with Jacobian.
         ([m x d, m x n] * [m x n] = [m x d]).
     """
     m = X.shape[0]

--- a/tslearn/metrics/softdtw_variants.py
+++ b/tslearn/metrics/softdtw_variants.py
@@ -398,7 +398,7 @@ def soft_dtw(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False):
     ts2
         Another time series
     gamma : float (default 1.)
-        Gamma parameter for Soft-DTW
+        Gamma parameter for Soft-DTW.
     be : Backend object or string or None
         Backend.
     compute_with_backend : bool, default=False
@@ -474,7 +474,7 @@ def soft_dtw_alignment(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False)
     ts2
         Another time series
     gamma : float (default 1.)
-        Gamma parameter for Soft-DTW
+        Gamma parameter for Soft-DTW.
     be : Backend object or string or None
         Backend.
     compute_with_backend : bool, default=False


### PR DESCRIPTION
Improve the docstrings in several metric functions, in particular the functions of the files `cycc.py`, `cysax.py`, `sax.py` and `soft_dtw_fast.py`.