### PR TITLE
Fix error in LearningShapelets when the input parameter n_shapelets_per_size equals None

### DIFF
--- a/tslearn/shapelets/shapelets.py
+++ b/tslearn/shapelets/shapelets.py
@@ -362,11 +362,15 @@ class LearningShapelets(ClassifierMixin, TransformerMixin,
 
     @property
     def shapelets_(self):
-        total_n_shp = sum(self.n_shapelets_per_size.values())
+        if self.n_shapelets_per_size is None:
+            n_shapelets_per_size = self.n_shapelets_per_size_
+        else:
+            n_shapelets_per_size = self.n_shapelets_per_size
+        total_n_shp = sum(n_shapelets_per_size.values())
         shapelets = numpy.empty((total_n_shp, ), dtype=object)
         idx = 0
-        for i, shp_sz in enumerate(sorted(self.n_shapelets_per_size.keys())):
-            n_shp = self.n_shapelets_per_size[shp_sz]
+        for i, shp_sz in enumerate(sorted(n_shapelets_per_size.keys())):
+            n_shp = n_shapelets_per_size[shp_sz]
             for idx_shp in range(idx, idx + n_shp):
                 shapelets[idx_shp] = numpy.zeros((shp_sz, self.d_))
             for di in range(self.d_):

--- a/tslearn/shapelets/shapelets.py
+++ b/tslearn/shapelets/shapelets.py
@@ -396,8 +396,12 @@ class LearningShapelets(ClassifierMixin, TransformerMixin,
         >>> model.shapelets_as_time_series_.shape
         (3, 4, 1)
         """
-        total_n_shp = sum(self.n_shapelets_per_size.values())
-        shp_sz = max(self.n_shapelets_per_size.keys())
+        if self.n_shapelets_per_size is None:
+            n_shapelets_per_size = self.n_shapelets_per_size_
+        else:
+            n_shapelets_per_size = self.n_shapelets_per_size
+        total_n_shp = sum(n_shapelets_per_size.values())
+        shp_sz = max(n_shapelets_per_size.keys())
         non_formatted_shapelets = self.shapelets_
         d = non_formatted_shapelets[0].shape[1]
         shapelets = numpy.zeros((total_n_shp, shp_sz, d)) + numpy.nan

--- a/tslearn/tests/test_shapelets.py
+++ b/tslearn/tests/test_shapelets.py
@@ -58,6 +58,7 @@ def test_shapelets():
                             random_state=0)
     clf.fit(time_series, y)
     assert clf.shapelets_.shape == (6,)
+    assert clf.shapelets_as_time_series_.shape == (6, 3, 2)
 
 
 def test_shapelet_lengths():

--- a/tslearn/tests/test_shapelets.py
+++ b/tslearn/tests/test_shapelets.py
@@ -53,6 +53,13 @@ def test_shapelets():
     np.testing.assert_allclose(preds_before,
                                clf.predict_proba(time_series))
 
+    clf = LearningShapelets(max_iter=1,
+                            verbose=0,
+                            random_state=0)
+    clf.fit(time_series, y)
+    assert clf.shapelets_.shape == (6,)
+
+
 def test_shapelet_lengths():
     pytest.importorskip('tensorflow')
     from tslearn.shapelets import LearningShapelets
@@ -86,6 +93,7 @@ def test_shapelet_lengths():
     tr = clf.transform(time_series)
     np.testing.assert_allclose(tr,
                                np.array([[0.], [8. / 3]]))
+
 
 def test_series_lengths():
     pytest.importorskip('tensorflow')


### PR DESCRIPTION
Fix error in `LearningShapelets` when the input parameter `n_shapelets_per_size` equals `None`.

The error related to this PR is detailed in the issue https://github.com/tslearn-team/tslearn/issues/495.