### PR TITLE
Clarify docstrings of backend parameters

### DIFF
--- a/docs/backend.rst
+++ b/docs/backend.rst
@@ -1,3 +1,5 @@
+.. _backend:
+
 Backend selection and use
 =========================
 

--- a/tslearn/metrics/ctw.py
+++ b/tslearn/metrics/ctw.py
@@ -101,7 +101,12 @@ def ctw_path(
     verbose : bool (default: True)
         If True, scores are printed at each iteration of the algorithm.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -249,7 +254,12 @@ def ctw(
     verbose : bool (default: True)
         If True, scores are printed at each iteration of the algorithm.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -363,7 +373,12 @@ def cdist_ctw(
         `Glossary <https://joblib.readthedocs.io/en/latest/parallel.html#parallel-reference-documentation>`__
         for more details.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------

--- a/tslearn/metrics/dtw_variants.py
+++ b/tslearn/metrics/dtw_variants.py
@@ -46,7 +46,12 @@ def _local_squared_dist(x, y, be=None):
     y : array-like, shape=(d,)
         Another vector.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -108,7 +113,12 @@ def accumulated_matrix(s1, s2, mask, be=None):
     mask : array-like, shape=(sz1, sz2)
         Mask. Unconsidered cells must have infinite values.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -168,7 +178,12 @@ def _dtw(s1, s2, mask, be=None):
     mask : array-like, shape=(sz1, sz2)
         Mask. Unconsidered cells must have infinite values.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -233,7 +248,12 @@ def _return_path(acc_cost_mat, be=None):
     acc_cost_mat : array-like, shape=(sz1, sz2)
         Accumulated cost matrix.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -319,7 +339,12 @@ def dtw_path(
         constraint, a `RuntimeWarning` is raised and no global constraint is
         used.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -424,7 +449,12 @@ def accumulated_matrix_from_dist_matrix(dist_matrix, mask, be=None):
     mask : array-like, shape=(sz1, sz2)
         Mask. Unconsidered cells must have infinite values.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -521,7 +551,12 @@ def dtw_path_from_metric(
         used.
 
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     **kwds
         Additional arguments to pass to sklearn pairwise_distances to compute
@@ -680,7 +715,12 @@ def dtw(
         used.
 
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -800,7 +840,12 @@ def _limited_warping_length_cost(s1, s2, max_length, be=None):
         Maximum allowed warping path length. Should be an integer between
         XXX and YYY.  # TODO
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -873,7 +918,12 @@ def dtw_limited_warping_length(s1, s2, max_length, be=None):
         If lower than max(len(s1), len(s2)), no path can be found and a
         ValueError is raised.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -934,7 +984,12 @@ def _return_path_limited_warping_length(
     optimal_length : int
         Optimal length.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -1005,7 +1060,12 @@ def dtw_path_limited_warping_length(s1, s2, max_length, be=None):
         If lower than max(len(s1), len(s2)), no path can be found and a
         ValueError is raised.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -1110,7 +1170,12 @@ def _subsequence_cost_matrix(subseq, longseq, be=None):
     longseq : array-like, shape=(sz2, d)
         Reference time series.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -1145,7 +1210,12 @@ def subsequence_cost_matrix(subseq, longseq, be=None):
     longseq : array-like, shape=(sz2, d) or (sz2,)
         Reference time series. If shape is (sz2,), the time series is assumed to be univariate.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -1219,7 +1289,12 @@ def _subsequence_path(acc_cost_mat, idx_path_end, be=None):
     idx_path_end: int
         The end position of the matched subsequence in the longer sequence.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -1268,7 +1343,12 @@ def subsequence_path(acc_cost_mat, idx_path_end, be=None):
     idx_path_end: int
         The end position of the matched subsequence in the longer sequence.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -1332,7 +1412,12 @@ def dtw_subsequence_path(subseq, longseq, be=None):
         A reference (supposed to be longer than `subseq`) time series.
         If shape is (sz2,), the time series is assumed to be univariate.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -1428,7 +1513,12 @@ def sakoe_chiba_mask(sz1, sz2, radius=1, be=None):
     radius : int
         The radius of the band.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -1528,7 +1618,12 @@ def _itakura_mask(sz1, sz2, max_slope=2.0, be=None):
     max_slope : float (default = 2)
         The maximum slope of the parallelogram.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -1580,7 +1675,12 @@ def itakura_mask(sz1, sz2, max_slope=2.0, be=None):
     max_slope : float (default = 2)
         The maximum slope of the parallelogram.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -1668,7 +1768,12 @@ def compute_mask(
         constraint, a `RuntimeWarning` is raised and no global constraint is
         used.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -1794,7 +1899,12 @@ def cdist_dtw(
         for more details.
 
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -1963,7 +2073,12 @@ def _lb_envelope(time_series, radius, be=None):
         index i will be generated based on all observations from the time series
         at indices comprised between i-radius and i+radius).
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -2007,7 +2122,12 @@ def lb_envelope(ts, radius=1, be=None):
         index i will be generated based on all observations from the time series
         at indices comprised between i-radius and i+radius).
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -2103,7 +2223,12 @@ def lcss_accumulated_matrix(s1, s2, eps, mask, be=None):
     mask : array-like, shape=(sz1, sz2)
         Mask. Unconsidered cells must have infinite values.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -2177,7 +2302,12 @@ def _lcss(s1, s2, eps, mask, be=None):
     mask : array-like, shape=(sz1, sz2)
         Mask. Unconsidered cells must have infinite values.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -2255,7 +2385,12 @@ def lcss(
         constraint, a `RuntimeWarning` is raised and no global constraint is
         used.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -2364,7 +2499,12 @@ def _return_lcss_path(s1, s2, eps, mask, acc_cost_mat, sz1, sz2, be=None):
     sz2 : int
         Length of the second time series.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -2460,7 +2600,12 @@ def _return_lcss_path_from_dist_matrix(
     sz2 : int
         Length of the second time series.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -2550,7 +2695,12 @@ def lcss_path(
        constraint, a `RuntimeWarning` is raised and no global constraint is
        used.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -2657,7 +2807,12 @@ def lcss_accumulated_matrix_from_dist_matrix(dist_matrix, eps, mask, be=None):
     mask : array-like, shape=(sz1, sz2)
         Mask. Unconsidered cells must have infinite values.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -2751,7 +2906,12 @@ def lcss_path_from_metric(
         constraint, a `RuntimeWarning` is raised and no global constraint is
         used.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
     **kwds
         Additional arguments to pass to sklearn pairwise_distances to compute
         the pairwise distances.

--- a/tslearn/metrics/soft_dtw_fast.py
+++ b/tslearn/metrics/soft_dtw_fast.py
@@ -65,7 +65,12 @@ def _softmin3(a, b, c, gamma, be=None):
     gamma : float64
         Regularization parameter.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -130,7 +135,12 @@ def _soft_dtw(D, R, gamma, be=None):
     gamma : float64
         Regularization parameter.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
     """
     be = instantiate_backend(be, D, R, gamma)
 
@@ -179,7 +189,12 @@ def _soft_dtw_batch(D, R, gamma, be=None):
     gamma : float64
         Regularization parameter.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
     """
     be = instantiate_backend(be, D, R)
     for i_sample in range(D.shape[0]):
@@ -230,7 +245,12 @@ def _soft_dtw_grad(D, R, E, gamma, be=None):
     gamma : float64
         Regularization parameter.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
     """
     be = instantiate_backend(be, D, R, E)
 
@@ -282,7 +302,12 @@ def _soft_dtw_grad_batch(D, R, E, gamma, be=None):
     gamma : float64
         Regularization parameter.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
     """
     be = instantiate_backend(be, D, R, E)
     for i_sample in prange(D.shape[0]):

--- a/tslearn/metrics/softdtw_variants.py
+++ b/tslearn/metrics/softdtw_variants.py
@@ -463,7 +463,7 @@ def soft_dtw(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False):
         If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
         the PyTorch backend is used.
         If `be` is `None`, the backend is determined by the input arrays.
-        See [:ref:`dedicated user-guide page <dtw>`] for more information.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
     compute_with_backend : bool, default=False
         This parameter has no influence when the NumPy backend is used.
         When a backend different from NumPy is used (cf parameter `be`):

--- a/tslearn/metrics/softdtw_variants.py
+++ b/tslearn/metrics/softdtw_variants.py
@@ -458,7 +458,12 @@ def soft_dtw(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False):
     gamma : float (default 1.)
         Gamma parameter for Soft-DTW.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See [:ref:`dedicated user-guide page <dtw>`] for more information.
     compute_with_backend : bool, default=False
         This parameter has no influence when the NumPy backend is used.
         When a backend different from NumPy is used (cf parameter `be`):

--- a/tslearn/metrics/softdtw_variants.py
+++ b/tslearn/metrics/softdtw_variants.py
@@ -461,7 +461,7 @@ def soft_dtw(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False):
         Backend.
     compute_with_backend : bool, default=False
         This parameter has no influence when the NumPy backend is used.
-        When a backend different from NumPy is used:
+        When a backend different from NumPy is used (cf parameter `be`):
         If `True`, the computation is done with the corresponding backend.
         If `False`, a conversion to the NumPy backend can be used to accelerate the computation.
 
@@ -564,7 +564,7 @@ def soft_dtw_alignment(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False)
         Backend.
     compute_with_backend : bool, default=False
         This parameter has no influence when the NumPy backend is used.
-        When a backend different from NumPy is used:
+        When a backend different from NumPy is used (cf parameter `be`):
         If `True`, the computation is done with the corresponding backend.
         If `False`, a conversion to the NumPy backend can be used to accelerate the computation.
 
@@ -681,7 +681,7 @@ def cdist_soft_dtw(dataset1, dataset2=None, gamma=1.0, be=None, compute_with_bac
         Backend.
     compute_with_backend : bool, default=False
         This parameter has no influence when the NumPy backend is used.
-        When a backend different from NumPy is used:
+        When a backend different from NumPy is used (cf parameter `be`):
         If `True`, the computation is done with the corresponding backend.
         If `False`, a conversion to the NumPy backend can be used to accelerate the computation.
 
@@ -817,7 +817,7 @@ def cdist_soft_dtw_normalized(dataset1, dataset2=None, gamma=1.0, be=None, compu
         Backend.
     compute_with_backend : bool, default=False
         This parameter has no influence when the NumPy backend is used.
-        When a backend different from NumPy is used:
+        When a backend different from NumPy is used (cf parameter `be`):
         If `True`, the computation is done with the corresponding backend.
         If `False`, a conversion to the NumPy backend can be used to accelerate the computation.
 
@@ -911,7 +911,7 @@ class SoftDTW:
             Backend.
         compute_with_backend : bool, default=False
             This parameter has no influence when the NumPy backend is used.
-            When a backend different from NumPy is used:
+            When a backend different from NumPy is used (cf parameter `be`):
             If `True`, the computation is done with the corresponding backend.
             If `False`, a conversion to the NumPy backend can be used to accelerate the computation.
 
@@ -1017,7 +1017,7 @@ class SquaredEuclidean:
             Backend.
         compute_with_backend : bool, default=False
             This parameter has no influence when the NumPy backend is used.
-            When a backend different from NumPy is used:
+            When a backend different from NumPy is used (cf parameter `be`):
             If `True`, the computation is done with the corresponding backend.
             If `False`, a conversion to the NumPy backend can be used to accelerate the computation.
 

--- a/tslearn/metrics/softdtw_variants.py
+++ b/tslearn/metrics/softdtw_variants.py
@@ -38,7 +38,12 @@ def _gak(gram, be=None):
     gram : array-like, shape=(sz1, sz2)
         Gram matrix.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -103,7 +108,12 @@ def _gak_gram(s1, s2, sigma=1.0, be=None):
     sigma : float (default 1.)
         Bandwidth of the internal gaussian kernel used for GAK.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -137,7 +147,12 @@ def unnormalized_gak(s1, s2, sigma=1.0, be=None):
     sigma : float (default 1.)
         Bandwidth of the internal gaussian kernel used for GAK.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -195,7 +210,12 @@ def gak(s1, s2, sigma=1.0, be=None):  # TODO: better doc (formula for the kernel
     sigma : float (default 1.)
         Bandwidth of the internal gaussian kernel used for GAK.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -259,7 +279,12 @@ def cdist_gak(dataset1, dataset2=None, sigma=1.0, n_jobs=None, verbose=0, be=Non
         `Glossary <https://joblib.readthedocs.io/en/latest/parallel.html#parallel-reference-documentation>`__
         for more details.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -333,7 +358,12 @@ def sigma_gak(dataset, n_samples=100, random_state=None, be=None):
         The generator used to draw the samples. If an integer is given, it
         fixes the seed. Defaults to the global numpy random number generator.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -393,7 +423,12 @@ def gamma_soft_dtw(dataset, n_samples=100, random_state=None, be=None):
         The generator used to draw the samples. If an integer is given, it
         fixes the seed. Defaults to the global numpy random number generator.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -566,7 +601,12 @@ def soft_dtw_alignment(ts1, ts2, gamma=1.0, be=None, compute_with_backend=False)
     gamma : float (default 1.)
         Gamma parameter for Soft-DTW.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
     compute_with_backend : bool, default=False
         This parameter has no influence when the NumPy backend is used.
         When a backend different from NumPy is used (cf parameter `be`):
@@ -683,7 +723,12 @@ def cdist_soft_dtw(dataset1, dataset2=None, gamma=1.0, be=None, compute_with_bac
     gamma : float (default 1.)
         Gamma parameter for Soft-DTW.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
     compute_with_backend : bool, default=False
         This parameter has no influence when the NumPy backend is used.
         When a backend different from NumPy is used (cf parameter `be`):
@@ -819,7 +864,12 @@ def cdist_soft_dtw_normalized(dataset1, dataset2=None, gamma=1.0, be=None, compu
     gamma : float (default 1.)
         Gamma parameter for Soft-DTW.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
     compute_with_backend : bool, default=False
         This parameter has no influence when the NumPy backend is used.
         When a backend different from NumPy is used (cf parameter `be`):

--- a/tslearn/metrics/utils.py
+++ b/tslearn/metrics/utils.py
@@ -53,7 +53,12 @@ def _cdist_generic(
         for more details.
 
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     compute_diagonal : bool (default: True)
         Whether diagonal terms should be computed or assumed to be 0 in the

--- a/tslearn/utils/utils.py
+++ b/tslearn/utils/utils.py
@@ -125,7 +125,12 @@ def to_time_series(ts, remove_nans=False, be=None):
         Whether trailing NaNs at the end of the time series should be removed
         or not
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------
@@ -408,7 +413,12 @@ def ts_size(ts, be=None):
     ts : array-like
         A time series.
     be : Backend object or string or None
-        Backend.
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
 
     Returns
     -------


### PR DESCRIPTION
Clarify the docstrings of optional input parameters `be` and `compute_with_backend`.