### PR TITLE
Fix error in function silhouette_score when metric is callable

### DIFF
--- a/tslearn/clustering/utils.py
+++ b/tslearn/clustering/utils.py
@@ -141,6 +141,7 @@ def silhouette_score(X, labels, metric=None, sample_size=None,
     --------
     >>> from tslearn.generators import random_walks
     >>> from tslearn.metrics import cdist_dtw
+    >>> from tslearn.metrics import dtw
     >>> numpy.random.seed(0)
     >>> X = random_walks(n_ts=20, sz=16, d=1)
     >>> labels = numpy.random.randint(2, size=20)
@@ -157,8 +158,10 @@ def silhouette_score(X, labels, metric=None, sample_size=None,
     >>> silhouette_score(cdist_dtw(X), labels,
     ...                  metric="precomputed")  # doctest: +ELLIPSIS
     0.13383800...
+    >>> silhouette_score(X, labels, metric=dtw)  # doctest: +ELLIPSIS
+    0.13383800...
     """
-    sklearn_metric = None
+    sklearn_metric = "precomputed"
     if metric_params is None:
         metric_params_ = {}
     else:
@@ -188,10 +191,9 @@ def silhouette_score(X, labels, metric=None, sample_size=None,
                                          remove_nans=True),
                           to_time_series(y.reshape((sz, d)),
                                          remove_nans=True))
-    metric = "precomputed" if sklearn_metric is None else sklearn_metric
     return sklearn_silhouette(X=sklearn_X,
                               labels=labels,
-                              metric=metric,
+                              metric=sklearn_metric,
                               sample_size=sample_size,
                               random_state=random_state,
                               **kwds)


### PR DESCRIPTION
Investigating on the issue https://github.com/tslearn-team/tslearn/issues/507, I found a recursion error in the function `silhouette_score` when the input parameter metric is callable.

The error can be reproduced running the following code:

```
import numpy as np
from tslearn.clustering.utils import silhouette_score
from tslearn.metrics import dtw

n_ts = 4
sz = 3
d = 2

X = np.random.randn(n_ts, sz, d)
labels = [0] * (n_ts // 2) + [1] * (n_ts // 2)

score = silhouette_score(
    X=X,
    labels=labels,
    metric=dtw)

print(score)
```

The following error is returned:
```
RecursionError: maximum recursion depth exceeded while calling a Python object
```

The error is related to the end of the function `silhouette_score`:
```
        def sklearn_metric(x, y):
            return metric(to_time_series(x.reshape((sz, d)),
                                         remove_nans=True),
                          to_time_series(y.reshape((sz, d)),
                                         remove_nans=True))
    metric = "precomputed" if sklearn_metric is None else sklearn_metric
```

Indeed, since `metric` is equal to `sklearn_metric` when `sklearn_metric` is callable, the function `sklearn_metric` is therefore calling itself.