### PR TITLE
Fix LCSS documentation

### DIFF
--- a/docs/user_guide/lcss.rst
+++ b/docs/user_guide/lcss.rst
@@ -28,8 +28,8 @@ This is the algorithm at stake when invoking
 Problem
 --------------------
 
-The similarity S between :math:`x` and :math:`y`, given an integer :math:`\epsilon` and
-a real number :math:`\delta`, is formulated as follows:
+The similarity :math:`S` between :math:`x` and :math:`y`, given a positive real number :math:`\epsilon` and
+an integer :math:`\delta`, is formulated as follows:
 
 .. math::
 

--- a/docs/user_guide/lcss.rst
+++ b/docs/user_guide/lcss.rst
@@ -21,10 +21,6 @@ shapes `(n, d)` and `(m, d)` and LCSS can be computed using the following code:
     path, lcss_score = lcss_path(x, y)
 
 
-This is the algorithm at stake when invoking
-:class:`tslearn.clustering.TimeSeriesKMeans` with
-``metric="lcss"``.
-
 Problem
 --------------------
 

--- a/docs/user_guide/lcss.rst
+++ b/docs/user_guide/lcss.rst
@@ -43,6 +43,9 @@ is the matching threshold.
 Here, a path can be seen as the parts of the time series where the Euclidean
 distance between them does not exceed a given threshold, i.e., they are close/similar.
 
+To retrieve a meaningful similarity value from the length of the longest common subsequence,
+the percentage of that value regarding the length of the shortest time series is returned.
+
 Algorithmic solution
 --------------------
 
@@ -89,12 +92,12 @@ Properties
 
 The Longest Common Subsequence holds the following properties:
 
-* :math:`\forall x, y, LCSS(x, y) \geq 0`
+* :math:`\forall x, y, LCSS(x, y) \in \left[0, 1\right]`
 * :math:`\forall x, y, LCSS(x, y) = LCSS(y, x)`
-* :math:`\forall x, LCSS(x, x) = 0`
+* :math:`\forall x, LCSS(x, x) = 1`
 
-However, mathematically speaking, LCSS is not a valid measure since it does
-not satisfy the triangular inequality.
+The values returned by LCSS range from 0 to 1,
+the value 1 being taken when the two time series completely match.
 
 Additional constraints
 ----------------------

--- a/docs/user_guide/lcss.rst
+++ b/docs/user_guide/lcss.rst
@@ -121,7 +121,7 @@ The corresponding code would be:
 
 The Sakoe-Chiba radius corresponds to the parameter :math:`\delta` mentioned in [1]_,
 it controls how far in time we can go in order to match a given
-point from one time-series to a point in another time-series.
+point from one time series to a point in another time series.
 
 Second, the Itakura parallelogram sets a maximum slope :math:`s` for alignment
 paths, which leads to a parallelogram-shaped constraint:

--- a/docs/user_guide/lcss.rst
+++ b/docs/user_guide/lcss.rst
@@ -67,7 +67,7 @@ simplicity):
                 else:
                     C[i, j] = max(C[i, j-1], C[i-1, j])
 
-       return C[n, m]
+       return C[n, m] / min(n, m)
 
 
 Using a different ground metric

--- a/docs/user_guide/lcss.rst
+++ b/docs/user_guide/lcss.rst
@@ -24,17 +24,15 @@ shapes `(n, d)` and `(m, d)` and LCSS can be computed using the following code:
 Problem
 --------------------
 
-The similarity :math:`S` between :math:`x` and :math:`y`, given a positive real number :math:`\epsilon` and
-an integer :math:`\delta`, is formulated as follows:
+The similarity :math:`S` between :math:`x` and :math:`y`,
+given a positive real number :math:`\epsilon`, is formulated as follows:
 
 .. math::
 
-    S(x, y, \epsilon, \delta) = \frac{LCSS_{(\epsilon, \delta) (x, y)}}{\min(n, m)}
+    S(x, y, \epsilon) = \frac{LCSS_{\epsilon} (x, y)}{\min(n, m)}
 
 
-The constant :math:`\delta` controls how far in time we can go in order to match a given
-point from one time-series to a point in another time-series. The constant :math:`\epsilon`
-is the matching threshold.
+The constant :math:`\epsilon` is the matching threshold.
 
 Here, a path can be seen as the parts of the time series where the Euclidean
 distance between them does not exceed a given threshold, i.e., they are close/similar.
@@ -61,7 +59,7 @@ simplicity):
        # Main loop
        for i = 1..n
             for j = 1..m
-                if dist(x_i, x_j) <= epsilon and abs(j - i) <= delta:
+                if dist(x_i, x_j) <= epsilon:
                     C[i, j] = C[i-1, j-1] + 1
                 else:
                     C[i, j] = max(C[i, j-1], C[i-1, j])
@@ -120,6 +118,10 @@ The corresponding code would be:
     from tslearn.metrics import lcss
     cost = lcss(x, y, global_constraint="sakoe_chiba", sakoe_chiba_radius=3)
 
+
+The Sakoe-Chiba band corresponds to the constant :math:`\delta` mentioned in [1]_,
+it controls how far in time we can go in order to match a given
+point from one time-series to a point in another time-series.
 
 Second, the Itakura parallelogram sets a maximum slope :math:`s` for alignment
 paths, which leads to a parallelogram-shaped constraint:

--- a/docs/user_guide/lcss.rst
+++ b/docs/user_guide/lcss.rst
@@ -28,8 +28,8 @@ This is the algorithm at stake when invoking
 Problem
 --------------------
 
-The similarity S between :math:`x` and :math:`y`, given an integer :math `\epsilon` and
-a real number :math `\delta`, is formulated as follows:
+The similarity S between :math:`x` and :math:`y`, given an integer :math:`\epsilon` and
+a real number :math:`\delta`, is formulated as follows:
 
 .. math::
 

--- a/docs/user_guide/lcss.rst
+++ b/docs/user_guide/lcss.rst
@@ -119,7 +119,7 @@ The corresponding code would be:
     cost = lcss(x, y, global_constraint="sakoe_chiba", sakoe_chiba_radius=3)
 
 
-The Sakoe-Chiba band corresponds to the constant :math:`\delta` mentioned in [1]_,
+The Sakoe-Chiba radius corresponds to the parameter :math:`\delta` mentioned in [1]_,
 it controls how far in time we can go in order to match a given
 point from one time-series to a point in another time-series.
 

--- a/tslearn/metrics/dtw_variants.py
+++ b/tslearn/metrics/dtw_variants.py
@@ -322,6 +322,9 @@ def dtw_path(
         Global constraint to restrict admissible paths for DTW.
     sakoe_chiba_radius : int or None (default: None)
         Radius to be used for Sakoe-Chiba band global constraint.
+        The Sakoe-Chiba radius corresponds to the parameter :math:`\delta` mentioned in [1]_,
+        it controls how far in time we can go in order to match a given
+        point from one time-series to a point in another time-series.
         If None and `global_constraint` is set to "sakoe_chiba", a radius of
         1 is used.
         If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
@@ -532,6 +535,9 @@ def dtw_path_from_metric(
 
     sakoe_chiba_radius : int or None (default: None)
         Radius to be used for Sakoe-Chiba band global constraint.
+        The Sakoe-Chiba radius corresponds to the parameter :math:`\delta` mentioned in [1]_,
+        it controls how far in time we can go in order to match a given
+        point from one time-series to a point in another time-series.
         If None and `global_constraint` is set to "sakoe_chiba", a radius of
         1 is used.
         If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
@@ -696,6 +702,9 @@ def dtw(
 
     sakoe_chiba_radius : int or None (default: None)
         Radius to be used for Sakoe-Chiba band global constraint.
+        The Sakoe-Chiba radius corresponds to the parameter :math:`\delta` mentioned in [1]_,
+        it controls how far in time we can go in order to match a given
+        point from one time-series to a point in another time-series.
         If None and `global_constraint` is set to "sakoe_chiba", a radius of
         1 is used.
         If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
@@ -1751,6 +1760,9 @@ def compute_mask(
         - no constraint otherwise
     sakoe_chiba_radius : int or None (default: None)
         Radius to be used for Sakoe-Chiba band global constraint.
+        The Sakoe-Chiba radius corresponds to the parameter :math:`\delta` mentioned in [1]_,
+        it controls how far in time we can go in order to match a given
+        point from one time-series to a point in another time-series.
         If None and `global_constraint` is set to 2 (sakoe-chiba), a radius of
         1 is used.
         If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
@@ -1865,6 +1877,9 @@ def cdist_dtw(
 
     sakoe_chiba_radius : int or None (default: None)
         Radius to be used for Sakoe-Chiba band global constraint.
+        The Sakoe-Chiba radius corresponds to the parameter :math:`\delta` mentioned in [1]_,
+        it controls how far in time we can go in order to match a given
+        point from one time-series to a point in another time-series.
         If None and `global_constraint` is set to "sakoe_chiba", a radius of
         1 is used.
         If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
@@ -2339,11 +2354,13 @@ def lcss(
     LCSS is computed by matching indexes that are met up until the eps
     threshold, so it leaves some points unmatched and focuses on the
     similar parts of two sequences. The matching can occur even if the
-    time indexes are different, regulated through the delta parameter
-    that defines how far it can go. To retrieve a meaningful similarity
-    value from the length of the longest common subsequence, the
-    percentage of that value regarding the length of the shortest time
-    series is returned.
+    time indexes are different. One can set additional constraints to the
+    set of acceptable paths: the Sakoe-Chiba band which is parametrized by a
+    radius or the Itakura parallelogram which is parametrized by a maximum slope.
+    Both these constraints consists in forcing paths to lie close
+    to the diagonal. To retrieve a meaningful similarity value from the
+    length of the longest common subsequence, the percentage of that value
+    regarding the length of the shortest time series is returned.
 
     According to this definition, the values returned by LCSS range from
     0 to 1, the highest value taken when two time series fully match,
@@ -2368,6 +2385,9 @@ def lcss(
         Global constraint to restrict admissible paths for LCSS.
     sakoe_chiba_radius : int or None (default: None)
         Radius to be used for Sakoe-Chiba band global constraint.
+        The Sakoe-Chiba radius corresponds to the parameter :math:`\delta` mentioned in [1]_,
+        it controls how far in time we can go in order to match a given
+        point from one time-series to a point in another time-series.
         If None and `global_constraint` is set to "sakoe_chiba", a radius of
         1 is used.
         If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
@@ -2675,25 +2695,28 @@ def lcss_path(
     eps : float (default: 1.)
         Maximum matching distance threshold.
     global_constraint : {"itakura", "sakoe_chiba"} or None (default: None)
-       Global constraint to restrict admissible paths for LCSS.
+        Global constraint to restrict admissible paths for LCSS.
     sakoe_chiba_radius : int or None (default: None)
-       Radius to be used for Sakoe-Chiba band global constraint.
-       If None and `global_constraint` is set to "sakoe_chiba", a radius of
-       1 is used.
-       If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
-       `global_constraint` is used to infer which constraint to use among the
-       two. In this case, if `global_constraint` corresponds to no global
-       constraint, a `RuntimeWarning` is raised and no global constraint is
-       used.
+        Radius to be used for Sakoe-Chiba band global constraint.
+        The Sakoe-Chiba radius corresponds to the parameter :math:`\delta` mentioned in [1]_,
+        it controls how far in time we can go in order to match a given
+        point from one time-series to a point in another time-series.
+        If None and `global_constraint` is set to "sakoe_chiba", a radius of
+        1 is used.
+        If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
+        `global_constraint` is used to infer which constraint to use among the
+        two. In this case, if `global_constraint` corresponds to no global
+        constraint, a `RuntimeWarning` is raised and no global constraint is
+        used.
     itakura_max_slope : float or None (default: None)
-       Maximum slope for the Itakura parallelogram constraint.
-       If None and `global_constraint` is set to "itakura", a maximum slope
-       of 2. is used.
-       If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
-       `global_constraint` is used to infer which constraint to use among the
-       two. In this case, if `global_constraint` corresponds to no global
-       constraint, a `RuntimeWarning` is raised and no global constraint is
-       used.
+        Maximum slope for the Itakura parallelogram constraint.
+        If None and `global_constraint` is set to "itakura", a maximum slope
+        of 2. is used.
+        If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
+        `global_constraint` is used to infer which constraint to use among the
+        two. In this case, if `global_constraint` corresponds to no global
+        constraint, a `RuntimeWarning` is raised and no global constraint is
+        used.
     be : Backend object or string or None
         Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
         the NumPy backend is used.
@@ -2889,6 +2912,9 @@ def lcss_path_from_metric(
         Global constraint to restrict admissible paths for LCSS.
     sakoe_chiba_radius : int or None (default: None)
         Radius to be used for Sakoe-Chiba band global constraint.
+        The Sakoe-Chiba radius corresponds to the parameter :math:`\delta` mentioned in [1]_,
+        it controls how far in time we can go in order to match a given
+        point from one time-series to a point in another time-series.
         If None and `global_constraint` is set to "sakoe_chiba", a radius of
         1 is used.
         If both `sakoe_chiba_radius` and `itakura_max_slope` are set,

--- a/tslearn/metrics/dtw_variants.py
+++ b/tslearn/metrics/dtw_variants.py
@@ -2668,8 +2668,11 @@ def lcss_path(
     LCSS is computed by matching indexes that are met up until the eps
     threshold, so it leaves some points unmatched and focuses on the
     similar parts of two sequences. The matching can occur even if the
-    time indexes are different, which can be regulated through the sakoe
-    chiba radius parameter that defines how far it can go.
+    time indexes are different. One can set additional constraints to
+    the set of acceptable paths: the Sakoe-Chiba band which is parametrized
+    by a radius or the Itakura parallelogram which is parametrized by a
+    maximum slope. Both these constraints consists in forcing paths to lie
+    close to the diagonal.
 
     To retrieve a meaningful similarity value from the length of the
     longest common subsequence, the percentage of that value regarding

--- a/tslearn/metrics/dtw_variants.py
+++ b/tslearn/metrics/dtw_variants.py
@@ -324,7 +324,7 @@ def dtw_path(
         Radius to be used for Sakoe-Chiba band global constraint.
         The Sakoe-Chiba radius corresponds to the parameter :math:`\delta` mentioned in [1]_,
         it controls how far in time we can go in order to match a given
-        point from one time-series to a point in another time-series.
+        point from one time series to a point in another time series.
         If None and `global_constraint` is set to "sakoe_chiba", a radius of
         1 is used.
         If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
@@ -537,7 +537,7 @@ def dtw_path_from_metric(
         Radius to be used for Sakoe-Chiba band global constraint.
         The Sakoe-Chiba radius corresponds to the parameter :math:`\delta` mentioned in [1]_,
         it controls how far in time we can go in order to match a given
-        point from one time-series to a point in another time-series.
+        point from one time series to a point in another time series.
         If None and `global_constraint` is set to "sakoe_chiba", a radius of
         1 is used.
         If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
@@ -704,7 +704,7 @@ def dtw(
         Radius to be used for Sakoe-Chiba band global constraint.
         The Sakoe-Chiba radius corresponds to the parameter :math:`\delta` mentioned in [1]_,
         it controls how far in time we can go in order to match a given
-        point from one time-series to a point in another time-series.
+        point from one time series to a point in another time series.
         If None and `global_constraint` is set to "sakoe_chiba", a radius of
         1 is used.
         If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
@@ -1762,7 +1762,7 @@ def compute_mask(
         Radius to be used for Sakoe-Chiba band global constraint.
         The Sakoe-Chiba radius corresponds to the parameter :math:`\delta` mentioned in [1]_,
         it controls how far in time we can go in order to match a given
-        point from one time-series to a point in another time-series.
+        point from one time series to a point in another time series.
         If None and `global_constraint` is set to 2 (sakoe-chiba), a radius of
         1 is used.
         If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
@@ -1879,7 +1879,7 @@ def cdist_dtw(
         Radius to be used for Sakoe-Chiba band global constraint.
         The Sakoe-Chiba radius corresponds to the parameter :math:`\delta` mentioned in [1]_,
         it controls how far in time we can go in order to match a given
-        point from one time-series to a point in another time-series.
+        point from one time series to a point in another time series.
         If None and `global_constraint` is set to "sakoe_chiba", a radius of
         1 is used.
         If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
@@ -1968,9 +1968,9 @@ def lb_keogh(ts_query, ts_candidate=None, radius=1, envelope_candidate=None):
     Parameters
     ----------
     ts_query : array-like, shape=(sz1, 1) or (sz1,)
-        Univariate query time-series to compare to the envelope of the candidate.
+        Univariate query time series to compare to the envelope of the candidate.
     ts_candidate : None or array-like, shape=(sz2, 1) or (sz2,) (default: None)
-        Univariate candidate time-series. None means the envelope is provided via
+        Univariate candidate time series. None means the envelope is provided via
         `envelope_candidate` parameter and hence does not
         need to be computed again.
     radius : int (default: 1)
@@ -2040,12 +2040,12 @@ def lb_keogh(ts_query, ts_candidate=None, radius=1, envelope_candidate=None):
 
 @njit()
 def _njit_lb_envelope(time_series, radius):
-    """Compute time-series envelope as required by LB_Keogh.
+    """Compute time series envelope as required by LB_Keogh.
 
     Parameters
     ----------
     time_series : array-like, shape=(sz, d)
-        Time-series for which the envelope should be computed.
+        Time series for which the envelope should be computed.
     radius : int
         Radius to be used for the envelope generation (the envelope at time
         index i will be generated based on all observations from the time series
@@ -2077,12 +2077,12 @@ def _njit_lb_envelope(time_series, radius):
 
 
 def _lb_envelope(time_series, radius, be=None):
-    """Compute time-series envelope as required by LB_Keogh.
+    """Compute time series envelope as required by LB_Keogh.
 
     Parameters
     ----------
     time_series : array-like, shape=(sz, d)
-        Time-series for which the envelope should be computed.
+        Time series for which the envelope should be computed.
     radius : int
         Radius to be used for the envelope generation (the envelope at time
         index i will be generated based on all observations from the time series
@@ -2123,14 +2123,14 @@ def _lb_envelope(time_series, radius, be=None):
 
 
 def lb_envelope(ts, radius=1, be=None):
-    r"""Compute time-series envelope as required by LB_Keogh.
+    r"""Compute time series envelope as required by LB_Keogh.
 
     LB_Keogh was originally presented in [1]_.
 
     Parameters
     ----------
     ts : array-like, shape=(sz, d) or (sz,)
-        Time-series for which the envelope should be computed.
+        Time series for which the envelope should be computed.
         If shape is (sz,), the time series is assumed to be univariate.
     radius : int (default: 1)
         Radius to be used for the envelope generation (the envelope at time
@@ -2387,7 +2387,7 @@ def lcss(
         Radius to be used for Sakoe-Chiba band global constraint.
         The Sakoe-Chiba radius corresponds to the parameter :math:`\delta` mentioned in [1]_,
         it controls how far in time we can go in order to match a given
-        point from one time-series to a point in another time-series.
+        point from one time series to a point in another time series.
         If None and `global_constraint` is set to "sakoe_chiba", a radius of
         1 is used.
         If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
@@ -2700,7 +2700,7 @@ def lcss_path(
         Radius to be used for Sakoe-Chiba band global constraint.
         The Sakoe-Chiba radius corresponds to the parameter :math:`\delta` mentioned in [1]_,
         it controls how far in time we can go in order to match a given
-        point from one time-series to a point in another time-series.
+        point from one time series to a point in another time series.
         If None and `global_constraint` is set to "sakoe_chiba", a radius of
         1 is used.
         If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
@@ -2875,7 +2875,7 @@ def lcss_path_from_metric(
     (possibly multidimensional) time series using a distance metric defined by
     the user and return both the path and the similarity.
 
-    Having the length of the longest commom subsequence between two time-series,
+    Having the length of the longest commom subsequence between two time series,
     the similarity is computed as the percentage of that value regarding the
     length of the shortest time series.
 
@@ -2914,7 +2914,7 @@ def lcss_path_from_metric(
         Radius to be used for Sakoe-Chiba band global constraint.
         The Sakoe-Chiba radius corresponds to the parameter :math:`\delta` mentioned in [1]_,
         it controls how far in time we can go in order to match a given
-        point from one time-series to a point in another time-series.
+        point from one time series to a point in another time series.
         If None and `global_constraint` is set to "sakoe_chiba", a radius of
         1 is used.
         If both `sakoe_chiba_radius` and `itakura_max_slope` are set,


### PR DESCRIPTION
Fix a few mistakes in the LCSS documentation:
- Fix a typo in `epsilon` and `delta` mathematical symbols
- Fix an error in `epsilon` and `delta` data types
- In the pseudocode of the function `lcss`, normalize the returned result by dividing by `min(n, m)` 
- Precise that the values returned by LCSS range from 0 to 1, the value 1 being taken when the two time series completely match. It was written that for all `x`, `lcss(x, x) = 0` instead of `lcss(x, x) = 1`. This mistake has been noticed in Issue https://github.com/tslearn-team/tslearn/issues/509
- Remove a wrong sentence saying that the clustering algorithm `TimeSeriesKMeans` can be used with the `lcss` metric

