### PR TITLE
Improve gak

### DIFF
--- a/tslearn/metrics/softdtw_variants.py
+++ b/tslearn/metrics/softdtw_variants.py
@@ -240,10 +240,8 @@ def gak(s1, s2, sigma=1.0, be=None):  # TODO: better doc (formula for the kernel
     be = instantiate_backend(be, s1, s2)
     s1 = be.array(s1)
     s2 = be.array(s2)
-    denom = be.sqrt(
-        unnormalized_gak(s1, s1, sigma=sigma, be=be)
-        * unnormalized_gak(s2, s2, sigma=sigma, be=be)
-    )
+    denom = be.sqrt(unnormalized_gak(s1, s1, sigma=sigma, be=be)) * be.sqrt(
+        unnormalized_gak(s2, s2, sigma=sigma, be=be))
     return unnormalized_gak(s1, s2, sigma=sigma, be=be) / denom
 
 


### PR DESCRIPTION
This pull request improves `gak` in which an overflow can occur when used on long almost constant time series.
This pull request is related to the issue https://github.com/tslearn-team/tslearn/issues/510 and the problem is detailed here: https://github.com/tslearn-team/tslearn/issues/510#issuecomment-2008557358.
The current `gak` function always works for time series of length `sz <= 204` and can fail for time series of length `sz >= 205`.
This pull request proposes a solution for `gak` to always work for time series of length `sz <= 405`.