### PR TITLE
Update tslearn's codes to be compatible with the version 0.16.0 and above of the package sphinx-gallery

### DIFF
--- a/docs/requirements_rtd.txt
+++ b/docs/requirements_rtd.txt
@@ -6,7 +6,7 @@ numba
 sphinx>=1.6.1
 ipykernel
 nbsphinx
-sphinx-gallery==0.15.0
+sphinx-gallery
 pillow
 tensorflow>=2
 Pygments


### PR DESCRIPTION
Update `tslearn`'s codes to be compatible with the version 0.16.0 and above of the package `sphinx-gallery`.