### PR TITLE
[MRG] Docs: fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The documentation is hosted at [readthedocs](http://tslearn.readthedocs.io/en/st
 
 ## Contributing<a id="contributing"></a>
 
-If you would like to contribute to `tslearn`, please have a look at [our contribution guidelines](https://github.com/tslearn-team/tslearn/CONTRIBUTING.md). A list of interesting TODO's can be found [here](https://github.com/tslearn-team/tslearn/issues?utf8=✓&q=is%3Aissue%20is%3Aopen%20label%3A%22new%20feature%22%20). **If you want other ML methods for time series to be added to this TODO list, do not hesitate to [open an issue](https://github.com/tslearn-team/tslearn/issues/new/choose)!**
+If you would like to contribute to `tslearn`, please have a look at [our contribution guidelines](https://github.com/tslearn-team/tslearn/blob/main/CONTRIBUTING.md). A list of interesting TODO's can be found [here](https://github.com/tslearn-team/tslearn/issues?utf8=✓&q=is%3Aissue%20is%3Aopen%20label%3A%22new%20feature%22%20). **If you want other ML methods for time series to be added to this TODO list, do not hesitate to [open an issue](https://github.com/tslearn-team/tslearn/issues/new/choose)!**
 
 ## Referencing tslearn<a id="referencing-tslearn"></a>
 


### PR DESCRIPTION
fix broken contributing link in the readme.  
I assume from the previous link that you wanted to have the link inside github - another option is to redirect to https://tslearn.readthedocs.io/en/stable/contributing.html. 