### PR TITLE
Add imputation capability

### DIFF
--- a/tslearn/preprocessing/__init__.py
+++ b/tslearn/preprocessing/__init__.py
@@ -6,11 +6,13 @@ resamplers.
 from .preprocessing import (
     TimeSeriesScalerMeanVariance,
     TimeSeriesScalerMinMax,
-    TimeSeriesResampler
+    TimeSeriesResampler,
+    TimeSeriesImputer
 )
 
 __all__ = [
     "TimeSeriesResampler",
     "TimeSeriesScalerMinMax",
-    "TimeSeriesScalerMeanVariance"
+    "TimeSeriesScalerMeanVariance",
+    "TimeSeriesImputer"
 ]

--- a/tslearn/tests/test_preprocessing.py
+++ b/tslearn/tests/test_preprocessing.py
@@ -1,12 +1,15 @@
 import math
+
 import numpy as np
+
+import pytest
 
 from tslearn.bases.bases import ALLOW_VARIABLE_LENGTH
 from tslearn.preprocessing import (TimeSeriesScalerMeanVariance,
                                    TimeSeriesScalerMinMax,
                                    TimeSeriesImputer)
-from tslearn.tests.sklearn_patches import assert_raises
-from tslearn.utils import to_time_series_dataset
+
+from tslearn.utils import to_time_series_dataset, to_time_series
 
 
 def test_single_value_ts_no_nan():
@@ -29,7 +32,7 @@ def test_scaler_allow_variable_length():
         assert ALLOW_VARIABLE_LENGTH in tags
         assert not tags[ALLOW_VARIABLE_LENGTH]
 
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             estimator.fit_transform(variable_length_dataset)
 
 
@@ -350,3 +353,14 @@ def test_imputer():
         [[value], [2], [value], [9], [6], [math.nan], [math.nan]],
     ])
     np.testing.assert_array_equal(transformed, expected)
+
+    imputer.set_params(method=lambda x: to_time_series([1, 2, 3]))
+    transformed = imputer.fit_transform([[1, math.nan, 3]])
+    expected = np.array([
+        [[1.], [2.], [3.]]
+    ])
+    np.testing.assert_array_equal(transformed, expected)
+
+    imputer.set_params(method="unknown")
+    with pytest.raises(ValueError):
+        imputer.fit_transform([[1, math.nan, 3]])

--- a/tslearn/tests/test_preprocessing.py
+++ b/tslearn/tests/test_preprocessing.py
@@ -1,8 +1,10 @@
+import math
 import numpy as np
 
 from tslearn.bases.bases import ALLOW_VARIABLE_LENGTH
 from tslearn.preprocessing import (TimeSeriesScalerMeanVariance,
-                                   TimeSeriesScalerMinMax)
+                                   TimeSeriesScalerMinMax,
+                                   TimeSeriesImputer)
 from tslearn.tests.sklearn_patches import assert_raises
 from tslearn.utils import to_time_series_dataset
 
@@ -205,3 +207,146 @@ def test_mean_variance_scaler_modes():
         ]),
         decimal=2
     )
+
+
+def test_imputer():
+    multivariate_dataset = [
+        [[1, 2], [2, 3], [2, math.nan]],
+        [[3, 4], [math.nan, 5]],
+    ]
+    univariate_dataset = [
+        [1, math.nan, 3],
+        [1, 2, math.nan, 9]
+    ]
+
+    # Test default params and equivalent mean method
+    imputer = TimeSeriesImputer()
+    transformed = imputer.fit_transform(multivariate_dataset)
+    expected = np.array([
+        [[1, 2], [2, 3], [2, 2.5]],
+        [[3, 4], [3, 5], [np.nan, np.nan]],
+    ])
+    np.testing.assert_array_equal(transformed, expected)
+    transformed = TimeSeriesImputer(method="mean").fit_transform(multivariate_dataset)
+    np.testing.assert_array_equal(transformed, expected)
+    transformed = imputer.fit_transform(univariate_dataset)
+    expected = np.array([
+        [[1], [2], [3], [np.nan]],
+        [[1], [2], [4], [9]],
+    ])
+    np.testing.assert_array_equal(transformed, expected)
+    transformed = TimeSeriesImputer(method="mean").fit_transform(univariate_dataset)
+    np.testing.assert_array_equal(transformed, expected)
+
+    # Test median method
+    imputer.set_params(method="median")
+    transformed = imputer.fit_transform(multivariate_dataset)
+    expected = np.array([
+        [[1, 2], [2, 3], [2, 2.5]],
+        [[3, 4], [3, 5], [np.nan, np.nan]],
+    ])
+    np.testing.assert_array_equal(transformed, expected)
+    transformed = imputer.fit_transform(univariate_dataset)
+    expected = np.array([
+        [[1], [2], [3], [np.nan]],
+        [[1], [2], [2], [9]],
+    ])
+    np.testing.assert_array_equal(transformed, expected)
+
+    # Test ffill method
+    multivariate_dataset = [
+        [[1, math.nan], [2, 3], [2, math.nan]],
+        [[3, 4], [math.nan, 5]],
+    ]
+    univariate_dataset = [
+        [1, math.nan, math.nan, 3, 6, math.nan, 9],
+        [1, 2, math.nan, 9],
+        [math.nan, 2, math.nan, 9, 6, math.nan],
+    ]
+    imputer.set_params(method="ffill")
+    transformed = imputer.fit_transform(multivariate_dataset)
+    expected = np.array([
+        [[1, math.nan], [2, 3], [2, 3]],
+        [[3, 4], [3, 5], [np.nan, np.nan]],
+    ])
+    np.testing.assert_array_equal(transformed, expected)
+    transformed = imputer.fit_transform(univariate_dataset)
+    expected = np.array([
+        [[1], [1], [1], [3], [6], [6], [9] ],
+        [[1], [2], [2], [9], [math.nan], [math.nan], [math.nan] ],
+        [[math.nan], [2], [2], [9], [6], [6], [math.nan]],
+    ])
+    np.testing.assert_array_equal(transformed, expected)
+
+    # Test bfill method
+    imputer.set_params(method="bfill")
+    transformed = imputer.fit_transform(multivariate_dataset)
+    expected = np.array([
+        [[1, 3], [2, 3], [2, np.nan]],
+        [[3, 4], [np.nan, 5], [np.nan, np.nan]],
+    ])
+    np.testing.assert_array_equal(transformed, expected)
+    transformed = imputer.fit_transform(univariate_dataset)
+    expected = np.array([
+        [[1], [3], [3], [3], [6], [9], [9]],
+        [[1], [2], [9], [9], [np.nan], [np.nan], [np.nan]],
+        [[2], [2], [9], [9], [6], [math.nan], [math.nan]],
+    ])
+    np.testing.assert_array_equal(transformed, expected)
+
+    # Constant:
+    # with default value: no changes except for NaN padding
+    # with value : non padded nans filled with value
+    imputer.set_params(method="constant")
+    transformed = imputer.fit_transform(multivariate_dataset)
+    expected = np.array([
+        [[1, math.nan], [2, 3], [2, math.nan]],
+        [[3, 4], [math.nan, 5], [math.nan, math.nan]],
+    ])
+    np.testing.assert_array_equal(transformed, expected)
+    transformed = imputer.fit_transform(univariate_dataset)
+    expected = np.array([
+        [[1], [math.nan], [math.nan], [3], [6], [math.nan], [9]],
+        [[1], [2], [math.nan], [9], [math.nan], [math.nan], [math.nan]],
+        [[math.nan], [2], [math.nan], [9], [6], [math.nan], [math.nan]],
+    ])
+    np.testing.assert_array_equal(transformed, expected)
+    value=42.42
+    imputer.set_params(value=value)
+    transformed = imputer.fit_transform(multivariate_dataset)
+    expected = np.array([
+        [[1, value], [2, 3], [2, value]],
+        [[3, 4], [value, 5], [math.nan, math.nan]],
+    ])
+    np.testing.assert_array_equal(transformed, expected)
+    transformed = imputer.fit_transform(univariate_dataset)
+    expected = np.array([
+        [[1], [value], [value], [3], [6], [value], [9]],
+        [[1], [2], [value], [9], [math.nan], [math.nan], [math.nan]],
+        [[value], [2], [value], [9], [6], [value], [math.nan]],
+    ])
+    np.testing.assert_array_equal(transformed, expected)
+
+    multivariate_dataset = [
+        [[1, math.nan], [2, 3], [2, math.nan]],
+        [[3, 4], [math.nan, 5], [math.nan, math.nan]],
+    ]
+    univariate_dataset = [
+        [1, math.nan, math.nan, 3, 6, math.nan, 9],
+        [1, 2, math.nan, 9],
+        [math.nan, 2, math.nan, 9, 6, math.nan],
+    ]
+    imputer.set_params(keep_trailing_nans=True)
+    transformed = imputer.fit_transform(multivariate_dataset)
+    expected = np.array([
+        [[1, value], [2, 3], [2, value]],
+        [[3, 4], [value, 5], [math.nan, math.nan]],
+    ])
+    np.testing.assert_array_equal(transformed, expected)
+    transformed = imputer.fit_transform(univariate_dataset)
+    expected = np.array([
+        [[1], [value], [value], [3], [6], [value], [9]],
+        [[1], [2], [value], [9], [math.nan], [math.nan], [math.nan]],
+        [[value], [2], [value], [9], [6], [math.nan], [math.nan]],
+    ])
+    np.testing.assert_array_equal(transformed, expected)

--- a/tslearn/utils/__init__.py
+++ b/tslearn/utils/__init__.py
@@ -22,7 +22,8 @@ from .utils import (
     check_dataset,
     LabelCategorizer,
     _load_txt_uea,
-    _load_arff_uea
+    _load_arff_uea,
+    check_variable_length_input
 )
 
 from .cast import (
@@ -55,5 +56,6 @@ __all__ = [
     "from_seglearn_dataset", "to_seglearn_dataset",
     "from_sktime_dataset", "to_sktime_dataset",
     "from_stumpy_dataset", "to_stumpy_dataset",
-    "from_tsfresh_dataset", "to_tsfresh_dataset"
+    "from_tsfresh_dataset", "to_tsfresh_dataset",
+    "check_variable_length_input"
 ]

--- a/tslearn/utils/utils.py
+++ b/tslearn/utils/utils.py
@@ -41,6 +41,29 @@ check_array = fix_force_all_finite_warning(sk_check_array)
 check_X_y = fix_force_all_finite_warning(sk_check_X_y)
 
 
+def check_variable_length_input(X):
+    """Input validation on a variable length dataset.
+
+    Parameters
+    ----------
+    X : object
+        Input object to check / convert.
+
+    Returns
+    -------
+        array_converted : object
+        The converted and validated array.
+    """
+    if getattr(X, "shape", None) is None:
+        # Check each time series when X can be of variable length before
+        # to_time_series_dataset processing
+        for ts in X:
+            check_array([ts], allow_nd=True, force_all_finite=False)
+    else:
+        X = check_array(X, allow_nd=True, force_all_finite=False)
+    return to_time_series_dataset(X)
+
+
 def check_dims(X, X_fit_dims=None, extend=True, check_n_features_only=False):
     """Reshapes X to a 3-dimensional array of X.shape[0] univariate
     timeseries of length X.shape[1] if X is 2-dimensional and extend
@@ -579,7 +602,7 @@ class LabelCategorizer(TransformerMixin, TimeSeriesBaseEstimator):
     single_column_if_binary : boolean (optional, default: False)
         If true, generate a single column for binary classification case.
         Otherwise, will generate 2.
-        If there are more than 2 labels, thie option will not change anything.
+        If there are more than 2 labels, this option will not change anything.
     forward_match : dict
         A dictionary that maps each element that occurs in the label vector
         on a index {y_i : i} with i in [0, C - 1], C the total number of


### PR DESCRIPTION
Fixes #564 Add an TimeSeriesImputer class to handle basic imputation. Imputation is done per time series, using one of the available method (mean, median, forwardfill , backward fill). When used with variable lenght time series, the keep_trailing_nans parameter controls whether the nans padding is to be processed by the imputer.

 