### PR TITLE
Random init and nan in subset of dimensions

### DIFF
--- a/tslearn/barycenters/dba.py
+++ b/tslearn/barycenters/dba.py
@@ -341,7 +341,7 @@ def _mm_update_barycenter(X, diag_sum_v_k, list_w_k):
     sum_w_x = numpy.zeros((barycenter_size, d))
     for k, (w_k, x_k) in enumerate(zip(list_w_k, X)):
         # because w_k is the matching bertween ts timestamps and centroid timestamps, and is the same across dimension, we gotta discount the diag_sum_v_k (which is how many timestamp from the ts have been assigned to that centroid timestamp) of the timestamps that have a nan in that specific dimension.
-        x_k_na0 = np.nan_to_num(x_k, nan=0)
+        x_k_na0 = numpy.nan_to_num(x_k, nan=0)
         sum_w_x += w_k.dot(x_k_na0[:ts_size(x_k)])
 
     # given we compute the average of the ts values for each timestamp (following the assignement from dtw: (1/D)(sum_w_x) 
@@ -350,8 +350,8 @@ def _mm_update_barycenter(X, diag_sum_v_k, list_w_k):
     # we need make D as a matrix for each dimension, intead of one for each dimension and remove  for every timestamp and  dimension i where there are k np.nans in the ts for which sum_w_x was computing replacing nans with 0., with a matrix x_nan. So that for every dimension i we will compute D_adj_i = D-k_i
     # where k_i is the vector with the number of missing values on the ts, assigned to the timestamps, for that dimension.
     # so diag_sum_w_na = (1/D_adj_i)*sum_w_x_i. * is pairwise product
-    diag_sum_w_na = np.tile(diag_sum_v_k, (X.shape[2], 1)).T
-    diag_sum_w_na = diag_sum_w_na - np.isnan(X).sum(axis=(0))
+    diag_sum_w_na = numpy.tile(diag_sum_v_k, (X.shape[2], 1)).T
+    diag_sum_w_na = diag_sum_w_na - numpy.isnan(X).sum(axis=(0))
     barycenter = (1/diag_sum_w_na) * sum_w_x
     #barycenter = numpy.diag(1. / diag_sum_v_k).dot(sum_w_x)
     return barycenter

--- a/tslearn/clustering/kmeans.py
+++ b/tslearn/clustering/kmeans.py
@@ -659,7 +659,7 @@ class TimeSeriesKMeans(
                     X, self.n_clusters, cdist_metric=metric_fun, random_state=rs
                 )
         elif self.init == "random":
-            indices = rs.choice(X.shape[0], self.n_clusters)
+            indices = rs.choice(X.shape[0], self.n_clusters, replace=False)
             self.cluster_centers_ = X[indices].copy()
         else:
             raise ValueError("Value %r for parameter 'init'" "is invalid" % self.init)

--- a/tslearn/metrics/dtw_variants.py
+++ b/tslearn/metrics/dtw_variants.py
@@ -31,7 +31,7 @@ def _njit_local_squared_dist(x, y):
     """
     dist = 0.0
     for di in range(x.shape[0]):
-        if np.isnan(x[di]) or  np.isnan(y[di]):
+        if numpy.isnan(x[di]) or  numpy.isnan(y[di]):
             continue
         diff = x[di] - y[di]
         dist += diff * diff
@@ -65,6 +65,8 @@ def _local_squared_dist(x, y, be=None):
     y = be.array(y)
     dist = 0.0
     for di in range(be.shape(x)[0]):
+        if numpy.isnan(x[di]) or  numpy.isnan(y[di]):
+            continue
         diff = x[di] - y[di]
         dist += diff * diff
     return dist

--- a/tslearn/utils/utils.py
+++ b/tslearn/utils/utils.py
@@ -247,7 +247,6 @@ def to_time_series_dataset(dataset, dtype=float, be=None):
     --------
     to_time_series : Transforms a single time series
     """
-    print('New')
     be = instantiate_backend(be, dataset)
 
     try:


### PR DESCRIPTION
The main problems that I found are:

1) when setting init='random', pick a random set of ts as cluster centroids; it may take the same ts multiple times (because  in np.random.choice,  replace is set to True). Therefore the "duplicated" clusters stays empty, no centroid is computed and then you get an error.
2) When computing the distance between two ts with multiple dimensions, if there is only a nan in one or more of the dimensions (but not all), the distance will be inf. It expects that if there are nans should be on all the dimensions observed in the time series. EX: a ts with 3 timepoints and 2 dimensions =[[1,2,3],[2,3,na]] is not supported. 
3) In the Barycenter computation again it is assumed that either a ts has all nans in all dimensions. 
These 3 problems should be addressed:
when init is random, we should make sure that each cluster is initialized on a different ts. Done
when we have a nan in a subset of the dimension of the ts, don't use the ts only for that dimension for the computation of the distance and the barycenter. Done