### PR TITLE
pytest 9.0 workaround 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,11 @@ changelog = "https://github.com/tslearn-team/tslearn/CHANGELOG.md"
 
 [project.optional-dependencies]
 pytorch = ['torch']
-tests = ["pytest", "h5py"]
+tests = [
+    # See https://github.com/pytest-dev/pytest/issues/13895
+    "pytest<9", 
+    "h5py"
+]
 docs = [
     "sphinx",
     "pydata_sphinx_theme",


### PR DESCRIPTION
Bug https://github.com/pytest-dev/pytest/issues/13895 pops up on test_all_estimators with KNeighborsTimeSeriesClassifier and TimeSeriesMLPClassifier with check_classifiers_multilabel_output_format_decision_function.