### PR TITLE
Fix deprecation warning in piecewise module

### DIFF
--- a/tslearn/metrics/cysax.py
+++ b/tslearn/metrics/cysax.py
@@ -124,7 +124,7 @@ def cyslopes(dataset, t0):
             with objmode(dataset_out_i_di="float64"):
                 dataset_out_i_di = (
                     LinearRegression()
-                    .fit(vec_t, dataset[i, :, di].reshape((-1, 1)))
+                    .fit(vec_t, dataset[i, :, di])
                     .coef_[0]
                 )
             dataset_out[i, di] = dataset_out_i_di


### PR DESCRIPTION
This warning occurred 72 times in the test suite:

```
  tslearn/piecewise/piecewise.py:685: DeprecationWarning: Conversion of an array with ndim > 0
  to a scalar is deprecated, and will error in future. Ensure you extract a single element from your 
  array before performing this operation. (Deprecated NumPy 1.25.)
  
    X_slopes[:, i_seg, :] = cyslopes(X[:, start:end, :], start)
```