### PR TITLE
Fix deprecation warnings in test_clustering.py

### DIFF
--- a/tslearn/barycenters/softdtw.py
+++ b/tslearn/barycenters/softdtw.py
@@ -107,7 +107,7 @@ def softdtw_barycenter(X, gamma=1.0, weights=None, method="L-BFGS-B", tol=1e-3,
 
         # The function works with vectors so we need to vectorize barycenter.
         res = minimize(f, barycenter.ravel(), method=method, jac=True, tol=tol,
-                       options=dict(maxiter=max_iter, disp=False))
+                       options=dict(maxiter=max_iter))
         return res.x.reshape(barycenter.shape)
     else:
         return barycenter

--- a/tslearn/clustering/kmeans.py
+++ b/tslearn/clustering/kmeans.py
@@ -7,7 +7,6 @@ from sklearn.base import ClusterMixin, TransformerMixin, BaseEstimator
 from sklearn.cluster._kmeans import _kmeans_plusplus
 from sklearn.metrics.pairwise import pairwise_kernels
 from sklearn.utils import check_random_state
-from sklearn.utils.extmath import stable_cumsum
 from sklearn.utils.validation import _check_sample_weight
 from sklearn.utils.validation import check_is_fitted
 
@@ -98,7 +97,7 @@ def _k_init_metric(X, n_clusters, cdist_metric, random_state, n_local_trials=Non
         # Choose center candidates by sampling with probability proportional
         # to the squared distance to the closest existing center
         rand_vals = random_state.random_sample(n_local_trials) * current_pot
-        candidate_ids = numpy.searchsorted(stable_cumsum(closest_dist_sq), rand_vals)
+        candidate_ids = numpy.searchsorted(numpy.cumsum(closest_dist_sq, dtype=numpy.float64), rand_vals)
         # XXX: numerical imprecision can result in a candidate_id out of range
         numpy.clip(candidate_ids, None, closest_dist_sq.size - 1, out=candidate_ids)
 


### PR DESCRIPTION
This occurred several (7) times in tests/test_clustering.py:

```
tests/test_clustering.py::test_kmeans:
  .venv/lib/python3.14/site-packages/sklearn/utils/deprecation.py:95: FutureWarning: Function
  stable_cumsum is deprecated; `sklearn.utils.extmath.stable_cumsum` is deprecated in version
  1.8 and will be removed in 1.10. Use `np.cumulative_sum` with the desired dtype directly instead.
    warnings.warn(msg, category=FutureWarning)
```

---

Previously, `disp=False` was set. This had no effect anyways.

This showed up quite a few times when testing, for instance, tests/test_clustering.py::test_kmeans:
```
tests/test_clustering.py: 25 warnings
  tslearn/barycenters/softdtw.py:109: DeprecationWarning: scipy.optimize: The `disp` and `iprint`
  options of the L-BFGS-B solver are deprecated and will be removed in SciPy 1.18.0.
    res = minimize(f, barycenter.ravel(), method=method, jac=True, tol=tol,
```
