### PR TITLE
[MRG] DTW related performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Changelogs for this project are recorded in this file since v0.2.0.
 
 ### Changed
 
+* Rework `cdist_dtw` and underlying Numba jited DTW computation to speed things up for numpy Backends. 
+* Masks as returned by `compute_mask`, `sakoe_chiba_mask` and `itakura_mask` now have boolean values.
 * Fixed centroids computations in K-shape for multivariate timeseries ([#288](https://github.com/tslearn-team/tslearn/issues/288))
 * Fixed json and pickle serialization for LearningShapelet ([#387](https://github.com/tslearn-team/tslearn/issues/387))([#403](https://github.com/tslearn-team/tslearn/issues/403)) 
 

--- a/conftest.py
+++ b/conftest.py
@@ -37,6 +37,7 @@ def pytest_collection_modifyitems(config, items):
         skip_marker = pytest.mark.skip(reason="torch not installed!")
         for item in items:
             if item.name in [
+                "tslearn.metrics._dtw.dtw",
                 "tslearn.metrics.dtw_variants.dtw",
                 "tslearn.metrics.softdtw_variants.cdist_soft_dtw_normalized",
                 "tslearn.metrics.softdtw_variants.soft_dtw",

--- a/docs/gen_modules/tslearn.metrics.rst
+++ b/docs/gen_modules/tslearn.metrics.rst
@@ -11,8 +11,15 @@ tslearn.metrics
       :toctree: metrics
       :template: function.rst
 
+      compute_mask
+      sakoe_chiba_mask
+      itakura_mask
+      accumulated_matrix
       cdist_dtw
       cdist_gak
+      cdist_soft_dtw
+      cdist_soft_dtw_normalized
+      cdist_frechet
       ctw
       ctw_path
       dtw
@@ -29,8 +36,6 @@ tslearn.metrics
       gak
       soft_dtw
       soft_dtw_alignment
-      cdist_soft_dtw
-      cdist_soft_dtw_normalized
       lb_envelope
       lb_keogh
       sigma_gak
@@ -39,4 +44,3 @@ tslearn.metrics
       frechet
       frechet_path
       frechet_path_from_metric
-      cdist_frechet

--- a/tests/test_barycenters.py
+++ b/tests/test_barycenters.py
@@ -1,8 +1,11 @@
 import numpy as np
 
 import tslearn.barycenters
+from tslearn.utils import to_time_series
+
 
 __author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
+
 
 
 def test_set_weights():
@@ -112,7 +115,7 @@ def test_dba():
             init_barycenter=init_barycenter,
             max_iter=0
         ),
-        np.array(init_barycenter)
+        to_time_series(init_barycenter)
     )
 
 

--- a/tests/test_barycenters.py
+++ b/tests/test_barycenters.py
@@ -104,6 +104,17 @@ def test_dba():
     np.testing.assert_allclose(dba_bar, ref, atol=1e-6)
     np.testing.assert_allclose(dba_bar_mm, ref, atol=1e-6)
 
+    # Subgradient averaging, 0 iter -> init
+    init_barycenter = [0]
+    np.testing.assert_array_equal(
+        tslearn.barycenters.dtw_barycenter_averaging_subgradient(
+            time_series,
+            init_barycenter=init_barycenter,
+            max_iter=0
+        ),
+        np.array(init_barycenter)
+    )
+
 
 def test_softdtw_barycenter():
     n, sz, d = 15, 10, 3

--- a/tests/test_barycenters.py
+++ b/tests/test_barycenters.py
@@ -78,6 +78,32 @@ def test_dba():
         max_iter=5)
     np.testing.assert_allclose(dba_bar, dba_bar_mm)
 
+    # With an init of different size
+    init_barycenter = rng.randn(sz-1, d)
+    ref = np.array([[0.421127, 0.054492, -0.124027],
+                    [-0.498396, -0.200649, 0.029864],
+                    [0.431492, -0.397721, -0.585897],
+                    [-0.906793, 0.021529, -0.514742],
+                    [0.629140, -0.152363, -0.434802],
+                    [0.609915, 0.348230, 0.447403],
+                    [-0.041696, 0.760246, -0.361783],
+                    [-0.042272, -0.642698, -0.662480],
+                    [0.261962, 0.111322, 0.389292]])
+    dba_bar = tslearn.barycenters.dtw_barycenter_averaging_petitjean(
+        time_series,
+        init_barycenter=init_barycenter,
+        max_iter=5,
+        verbose=1
+    )
+    dba_bar_mm = tslearn.barycenters.dtw_barycenter_averaging(
+        time_series,
+        init_barycenter=init_barycenter,
+        max_iter=5,
+        verbose=1
+    )
+    np.testing.assert_allclose(dba_bar, ref, atol=1e-6)
+    np.testing.assert_allclose(dba_bar_mm, ref, atol=1e-6)
+
 
 def test_softdtw_barycenter():
     n, sz, d = 15, 10, 3

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -514,11 +514,11 @@ def test_gak():
             assert backend.belongs_to_backend(sqeuc_compute)
 
 
-@pytest.mark.skipif(
-    (sys.version_info.major, sys.version_info.minor) == (3, 9)
-    and "mac" in platform.platform().lower(),
-    reason="Test failing for MacOS with python3.9 (Segmentation fault)",
-)
+# @pytest.mark.skipif(
+#     (sys.version_info.major, sys.version_info.minor) == (3, 9)
+#     and "mac" in platform.platform().lower(),
+#     reason="Test failing for MacOS with python3.9 (Segmentation fault)",
+# )
 def test_gamma_soft_dtw():
     for be in backends:
         for array_type in array_types:
@@ -685,12 +685,9 @@ def test_dtw_path_with_empty_or_nan_inputs():
             )
 
 
-@pytest.mark.skipif(
-    len(backends) == 1,
-    reason="Skipping test that requires pytorch backend",
-)
 def test_soft_dtw_loss_pytorch():
     """Tests for the class SoftDTWLossPyTorch."""
+    pytest.importorskip('torch')
     from tslearn.metrics.soft_dtw_loss_pytorch import _SoftDTWLossPyTorch
 
     b = 5

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -470,46 +470,48 @@ def test_masks():
             np.testing.assert_allclose(i_mask, reference_mask)
             assert backend.belongs_to_backend(i_mask)
 
-            # Test masks for different combinations of global_constraints /
-            # sakoe_chiba_radius / itakura_max_slope
-            sz = 10
-            ts0 = cast(np.empty((sz, 1)), array_type)
-            ts1 = cast(np.empty((sz, 1)), array_type)
-            mask_no_constraint = tslearn.metrics.dtw_variants.compute_mask(
-                ts0, ts1, global_constraint=0, be=be
-            )
-            np.testing.assert_array_equal(mask_no_constraint, np.full((sz, sz), True))
-            backend = instantiate_backend(be, array_type)
-            assert backend.belongs_to_backend(mask_no_constraint)
+            for compute_mask in [tslearn.metrics.compute_mask,
+                                 tslearn.metrics.dtw_variants.compute_mask]:
+                # Test masks for different combinations of global_constraints /
+                # sakoe_chiba_radius / itakura_max_slope
+                sz = 10
+                ts0 = cast(np.empty((sz, 1)), array_type)
+                ts1 = cast(np.empty((sz, 1)), array_type)
+                mask_no_constraint = compute_mask(
+                    ts0, ts1, global_constraint=0, be=be
+                )
+                np.testing.assert_array_equal(mask_no_constraint, np.full((sz, sz), True))
+                backend = instantiate_backend(be, array_type)
+                assert backend.belongs_to_backend(mask_no_constraint)
 
-            mask_itakura = tslearn.metrics.dtw_variants.compute_mask(
-                ts0, ts1, global_constraint=1, be=be
-            )
-            mask_itakura_bis = tslearn.metrics.dtw_variants.compute_mask(
-                ts0, ts1, itakura_max_slope=2.0, be=be
-            )
-            np.testing.assert_allclose(mask_itakura, mask_itakura_bis)
-            assert backend.belongs_to_backend(mask_itakura)
+                mask_itakura = compute_mask(
+                    ts0, ts1, global_constraint=1, be=be
+                )
+                mask_itakura_bis = compute_mask(
+                    ts0, ts1, itakura_max_slope=2.0, be=be
+                )
+                np.testing.assert_allclose(mask_itakura, mask_itakura_bis)
+                assert backend.belongs_to_backend(mask_itakura)
 
-            mask_sakoe = tslearn.metrics.dtw_variants.compute_mask(
-                ts0, ts1, global_constraint=2, be=be
-            )
+                mask_sakoe = compute_mask(
+                    ts0, ts1, global_constraint=2, be=be
+                )
 
-            mask_sakoe_bis = tslearn.metrics.dtw_variants.compute_mask(
-                ts0, ts1, sakoe_chiba_radius=1, be=be
-            )
-            np.testing.assert_allclose(mask_sakoe, mask_sakoe_bis)
-            assert backend.belongs_to_backend(mask_sakoe)
+                mask_sakoe_bis = compute_mask(
+                    ts0, ts1, sakoe_chiba_radius=1, be=be
+                )
+                np.testing.assert_allclose(mask_sakoe, mask_sakoe_bis)
+                assert backend.belongs_to_backend(mask_sakoe)
 
-            np.testing.assert_raises(
-                RuntimeWarning,
-                tslearn.metrics.dtw_variants.compute_mask,
-                ts0,
-                ts1,
-                sakoe_chiba_radius=1,
-                itakura_max_slope=2.0,
-                be=be,
-            )
+                np.testing.assert_raises(
+                    RuntimeWarning,
+                    compute_mask,
+                    ts0,
+                    ts1,
+                    sakoe_chiba_radius=1,
+                    itakura_max_slope=2.0,
+                    be=be,
+                )
 
             # Tests for estimators that can set masks through metric_params
             n, sz, d = 15, 10, 3

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -429,59 +429,69 @@ def test_masks():
     for be in backends:
         for array_type in array_types:
             backend = instantiate_backend(be)
-            sk_mask = tslearn.metrics.sakoe_chiba_mask(4, 4, 1, be=be)
-            reference_mask = np.array(
-                [
-                    [True, True, False, False],
-                    [True, True, True, False],
-                    [False, True, True, True],
-                    [False, False, True, True],
-                ]
-            )
-            np.testing.assert_allclose(sk_mask, reference_mask)
-            assert backend.belongs_to_backend(sk_mask)
 
-            sk_mask = tslearn.metrics.sakoe_chiba_mask(7, 3, 1, be=be)
-            reference_mask = np.array(
-                [
-                    [True, True, False],
-                    [True, True, True],
-                    [True, True, True],
-                    [True, True, True],
-                    [True, True, True],
-                    [True, True, True],
-                    [False, True, True],
-                ]
-            )
-            np.testing.assert_allclose(sk_mask, reference_mask)
-            assert backend.belongs_to_backend(sk_mask)
+            for sakoe_chiba_mask in [tslearn.metrics.sakoe_chiba_mask,
+                                     tslearn.metrics.dtw_variants.sakoe_chiba_mask]:
 
-            i_mask = tslearn.metrics.itakura_mask(6, 6, be=be)
-            reference_mask = np.array(
-                [
-                    [True, False, False, False, False, False],
-                    [False, True, True, False, False, False],
-                    [False, True, True, True, False, False],
-                    [False, False, True, True, True, False],
-                    [False, False, False, True, True, False],
-                    [False, False, False, False, False, True],
-                ]
-            )
-            np.testing.assert_allclose(i_mask, reference_mask)
-            assert backend.belongs_to_backend(i_mask)
+                sk_mask = sakoe_chiba_mask(4, 4, 1, be=be)
+                reference_mask = np.array(
+                    [
+                        [True, True, False, False],
+                        [True, True, True, False],
+                        [False, True, True, True],
+                        [False, False, True, True],
+                    ]
+                )
+                np.testing.assert_allclose(sk_mask, reference_mask)
+                assert backend.belongs_to_backend(sk_mask)
+
+                sk_mask = sakoe_chiba_mask(7, 3, 1, be=be)
+                reference_mask = np.array(
+                    [
+                        [True, True, False],
+                        [True, True, True],
+                        [True, True, True],
+                        [True, True, True],
+                        [True, True, True],
+                        [True, True, True],
+                        [False, True, True],
+                    ]
+                )
+                np.testing.assert_allclose(sk_mask, reference_mask)
+                assert backend.belongs_to_backend(sk_mask)
+
+            for itakura_mask in [tslearn.metrics.itakura_mask,
+                                 tslearn.metrics.dtw_variants.itakura_mask]:
+                i_mask = itakura_mask(6, 6, be=be)
+                reference_mask = np.array(
+                    [
+                        [True, False, False, False, False, False],
+                        [False, True, True, False, False, False],
+                        [False, True, True, True, False, False],
+                        [False, False, True, True, True, False],
+                        [False, False, False, True, True, False],
+                        [False, False, False, False, False, True],
+                    ]
+                )
+                np.testing.assert_allclose(i_mask, reference_mask)
+                assert backend.belongs_to_backend(i_mask)
 
             for compute_mask in [tslearn.metrics.compute_mask,
                                  tslearn.metrics.dtw_variants.compute_mask]:
+                backend = instantiate_backend(be, array_type)
+
                 # Test masks for different combinations of global_constraints /
                 # sakoe_chiba_radius / itakura_max_slope
                 sz = 10
+                mask_no_constraint = compute_mask(sz, sz, be=be)
+                np.testing.assert_array_equal(mask_no_constraint, np.full((sz, sz), True))
+
                 ts0 = cast(np.empty((sz, 1)), array_type)
                 ts1 = cast(np.empty((sz, 1)), array_type)
                 mask_no_constraint = compute_mask(
                     ts0, ts1, global_constraint=0, be=be
                 )
                 np.testing.assert_array_equal(mask_no_constraint, np.full((sz, sz), True))
-                backend = instantiate_backend(be, array_type)
                 assert backend.belongs_to_backend(mask_no_constraint)
 
                 mask_itakura = compute_mask(
@@ -496,7 +506,6 @@ def test_masks():
                 mask_sakoe = compute_mask(
                     ts0, ts1, global_constraint=2, be=be
                 )
-
                 mask_sakoe_bis = compute_mask(
                     ts0, ts1, sakoe_chiba_radius=1, be=be
                 )

--- a/tslearn/barycenters/__init__.py
+++ b/tslearn/barycenters/__init__.py
@@ -27,10 +27,9 @@ from .softdtw import softdtw_barycenter
 __author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
 
 __all__ = [
-        "euclidean_barycenter",
-
-        "dtw_barycenter_averaging", "dtw_barycenter_averaging_subgradient",
-        "dtw_barycenter_averaging_petitjean",
-
-        "softdtw_barycenter"
+    "euclidean_barycenter",
+    "dtw_barycenter_averaging",
+    "dtw_barycenter_averaging_subgradient",
+    "dtw_barycenter_averaging_petitjean",
+    "softdtw_barycenter"
 ]

--- a/tslearn/barycenters/dba.py
+++ b/tslearn/barycenters/dba.py
@@ -742,7 +742,7 @@ def dtw_barycenter_averaging_subgradient(
         barycenter = _init_avg(X_, barycenter_size)
     else:
         barycenter = to_time_series(init_barycenter, be=backend)
-        barycenter_size = init_barycenter.shape[0]
+        barycenter_size = barycenter.shape[0]
     cost_prev, cost = numpy.inf, numpy.inf
     eta = initial_step_size
     n = X_.shape[0]

--- a/tslearn/barycenters/dba.py
+++ b/tslearn/barycenters/dba.py
@@ -61,14 +61,14 @@ def _petitjean_update_barycenter(X, assign, barycenter_size, weights):
 
 
 def dtw_barycenter_averaging_petitjean(
-        X,
-        barycenter_size=None,
-        init_barycenter=None,
-        max_iter=30,
-        tol=1e-5,
-        weights=None,
-        metric_params=None,
-        verbose=False
+    X,
+    barycenter_size=None,
+    init_barycenter=None,
+    max_iter=30,
+    tol=1e-5,
+    weights=None,
+    metric_params=None,
+    verbose=False
 ):
     """DTW Barycenter Averaging (DBA) method.
 
@@ -407,15 +407,15 @@ def _subgradient_update_barycenter(X, list_diag_v_k, list_w_k, weights_sum,
 
 
 def dtw_barycenter_averaging(
-        X,
-        barycenter_size=None,
-        init_barycenter=None,
-        max_iter=30,
-        tol=1e-5,
-        weights=None,
-        metric_params=None,
-        verbose=False,
-        n_init=1
+    X,
+    barycenter_size=None,
+    init_barycenter=None,
+    max_iter=30,
+    tol=1e-5,
+    weights=None,
+    metric_params=None,
+    verbose=False,
+    n_init=1
 ):
     """DTW Barycenter Averaging (DBA) method estimated through
     Expectation-Maximization algorithm.
@@ -633,13 +633,19 @@ def dtw_barycenter_averaging_one_init(
     return barycenter, cost
 
 
-def dtw_barycenter_averaging_subgradient(X, barycenter_size=None,
-                                         init_barycenter=None, max_iter=30,
-                                         initial_step_size=.05,
-                                         final_step_size=.005,
-                                         tol=1e-5, random_state=None,
-                                         weights=None,
-                                         metric_params=None, verbose=False):
+def dtw_barycenter_averaging_subgradient(
+    X,
+    barycenter_size=None,
+    init_barycenter=None,
+    max_iter=30,
+    initial_step_size=.05,
+    final_step_size=.005,
+    tol=1e-5,
+    random_state=None,
+    weights=None,
+    metric_params=None,
+    verbose=False
+):
     """DTW Barycenter Averaging (DBA) method estimated through subgradient
     descent algorithm.
 
@@ -735,8 +741,8 @@ def dtw_barycenter_averaging_subgradient(X, barycenter_size=None,
     if init_barycenter is None:
         barycenter = _init_avg(X_, barycenter_size)
     else:
+        barycenter = to_time_series(init_barycenter, be=backend)
         barycenter_size = init_barycenter.shape[0]
-        barycenter = init_barycenter
     cost_prev, cost = numpy.inf, numpy.inf
     eta = initial_step_size
     n = X_.shape[0]

--- a/tslearn/clustering/kmeans.py
+++ b/tslearn/clustering/kmeans.py
@@ -12,7 +12,7 @@ from sklearn.utils.validation import _check_sample_weight
 from sklearn.utils.validation import check_is_fitted
 
 from tslearn.barycenters import (
-    dtw_barycenter_averaging,
+    dtw_barycenter_averaging_petitjean,
     euclidean_barycenter,
     softdtw_barycenter,
 )
@@ -744,7 +744,7 @@ class TimeSeriesKMeans(
         metric_params = self._get_metric_params()
         for k in range(self.n_clusters):
             if self.metric == "dtw":
-                self.cluster_centers_[k] = dtw_barycenter_averaging(
+                self.cluster_centers_[k] = dtw_barycenter_averaging_petitjean(
                     X=X[self.labels_ == k],
                     barycenter_size=None,
                     init_barycenter=self.cluster_centers_[k],

--- a/tslearn/clustering/kmeans.py
+++ b/tslearn/clustering/kmeans.py
@@ -11,7 +11,7 @@ from sklearn.utils.validation import _check_sample_weight
 from sklearn.utils.validation import check_is_fitted
 
 from tslearn.barycenters import (
-    dtw_barycenter_averaging,
+    dtw_barycenter_averaging_petitjean,
     euclidean_barycenter,
     softdtw_barycenter,
 )
@@ -743,7 +743,7 @@ class TimeSeriesKMeans(
         metric_params = self._get_metric_params()
         for k in range(self.n_clusters):
             if self.metric == "dtw":
-                self.cluster_centers_[k] = dtw_barycenter_averaging(
+                self.cluster_centers_[k] = dtw_barycenter_averaging_petitjean(
                     X=X[self.labels_ == k],
                     barycenter_size=None,
                     init_barycenter=self.cluster_centers_[k],

--- a/tslearn/metrics/__init__.py
+++ b/tslearn/metrics/__init__.py
@@ -46,6 +46,7 @@ from .softdtw_variants import (
 from .soft_dtw_loss_pytorch import SoftDTWLossPyTorch
 from .cycc import cdist_normalized_cc, y_shifted_sbd_vec
 from .frechet import frechet, frechet_path, frechet_path_from_metric, cdist_frechet
+from .utils import accumulated_matrix
 
 __author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
 
@@ -70,6 +71,7 @@ __all__ = [
     "TSLEARN_VALID_METRICS",
     "VARIABLE_LENGTH_METRICS",
     "GLOBAL_CONSTRAINT_CODE",
+    "accumulated_matrix",
     "compute_mask",
     "itakura_mask",
     "sakoe_chiba_mask",

--- a/tslearn/metrics/__init__.py
+++ b/tslearn/metrics/__init__.py
@@ -5,22 +5,44 @@ used at the core of machine learning algorithms.
 **User guide:** See the :ref:`Dynamic Time Warping (DTW) <dtw>` section for 
 further details.
 """
-from .dtw_variants import (dtw, dtw_limited_warping_length,
-                           dtw_path_limited_warping_length, subsequence_path,
-                           subsequence_cost_matrix,
-                           dtw_path, dtw_path_from_metric,
-                           dtw_subsequence_path, cdist_dtw,
-                           GLOBAL_CONSTRAINT_CODE,
-                           lb_envelope, lb_keogh,
-                           sakoe_chiba_mask, itakura_mask,
-                           lcss, lcss_path, lcss_path_from_metric)
+from ._masks import (
+    GLOBAL_CONSTRAINT_CODE,
+    compute_mask,
+    itakura_mask,
+    sakoe_chiba_mask
+)
+from ._dtw import(
+    dtw,
+    dtw_path,
+    cdist_dtw
+)
+from .dtw_variants import (
+   dtw_limited_warping_length,
+   dtw_path_limited_warping_length,
+   subsequence_path,
+   subsequence_cost_matrix,
+   dtw_path_from_metric,
+   dtw_subsequence_path,
+   lb_envelope,
+   lb_keogh,
+   lcss,
+   lcss_path,
+   lcss_path_from_metric
+)
 from .ctw import ctw_path, ctw, cdist_ctw
 from .sax import cdist_sax
-from .softdtw_variants import (cdist_soft_dtw, cdist_gak,
-                               cdist_soft_dtw_normalized, gak, soft_dtw,
-                               soft_dtw_alignment,
-                               sigma_gak, gamma_soft_dtw, SquaredEuclidean,
-                               SoftDTW)
+from .softdtw_variants import (
+    cdist_soft_dtw,
+    cdist_gak,
+    cdist_soft_dtw_normalized,
+    gak,
+    soft_dtw,
+    soft_dtw_alignment,
+    sigma_gak,
+    gamma_soft_dtw,
+    SquaredEuclidean,
+    SoftDTW
+)
 from .soft_dtw_loss_pytorch import SoftDTWLossPyTorch
 from .cycc import cdist_normalized_cc, y_shifted_sbd_vec
 from .frechet import frechet, frechet_path, frechet_path_from_metric, cdist_frechet
@@ -48,19 +70,22 @@ __all__ = [
     "TSLEARN_VALID_METRICS",
     "VARIABLE_LENGTH_METRICS",
     "GLOBAL_CONSTRAINT_CODE",
+    "compute_mask",
+    "itakura_mask",
+    "sakoe_chiba_mask",
     "dtw",
+    "dtw_path",
+    "cdist_dtw",
     "dtw_limited_warping_length",
     "dtw_path_limited_warping_length",
     "subsequence_path",
     "subsequence_cost_matrix",
-    "dtw_path",
+    "dtw_limited_warping_length",
+    "dtw_path_limited_warping_length",
     "dtw_path_from_metric",
     "dtw_subsequence_path",
-    "cdist_dtw",
     "lb_envelope",
     "lb_keogh",
-    "sakoe_chiba_mask",
-    "itakura_mask",
     "lcss",
     "lcss_path",
     "lcss_path_from_metric",

--- a/tslearn/metrics/_dtw.py
+++ b/tslearn/metrics/_dtw.py
@@ -539,47 +539,67 @@ def cdist_dtw(
     """  # noqa: E501
     be = instantiate_backend(be, dataset1, dataset2)
     dataset1 = to_time_series_dataset(dataset1, be=be)
+    n_ts_1 = dataset1.shape[0]
 
-    global_constraint_ = GLOBAL_CONSTRAINT_CODE[global_constraint]
-
-    if be.is_numpy:
-        dtw_ = _njit_dtw
-    else:
-        dtw_ = _dtw
+    mask_args = {
+        "global_constraint": GLOBAL_CONSTRAINT_CODE[global_constraint],
+        "sakoe_chiba_radius": sakoe_chiba_radius,
+        "itakura_max_slope": itakura_max_slope,
+    }
+    dtw_ = _njit_dtw if be.is_numpy else _dtw
+    use_parallel = n_jobs not in [None, 1]
 
     if dataset2 is None:
-        matrix = be.zeros((len(dataset1), len(dataset1)))
-        indices = be.triu_indices(
-            len(dataset1), k=1, m=len(dataset1)
-        )
-        matrix[indices] = be.array(
-            Parallel(n_jobs=n_jobs, prefer="threads", verbose=verbose)(
-                delayed(dtw_)(
+        matrix = be.zeros((n_ts_1, n_ts_1))
+        indices = be.triu_indices(n_ts_1, k=1, m=n_ts_1)
+        if use_parallel:
+            matrix[indices] = be.array(
+                Parallel(n_jobs=n_jobs, prefer="threads", verbose=verbose)(
+                    delayed(dtw_)(
+                        to_time_series(dataset1[i], remove_nans=True, be=be),
+                        to_time_series(dataset1[j], remove_nans=True, be=be),
+                        **mask_args
+                    )
+                    for i in range(n_ts_1)
+                    for j in range(i + 1, n_ts_1)
+                )
+            )
+        else:
+            matrix[indices] = be.array([
+                dtw_(
                     to_time_series(dataset1[i], remove_nans=True, be=be),
                     to_time_series(dataset1[j], remove_nans=True, be=be),
-                    global_constraint=global_constraint_,
-                    sakoe_chiba_radius=sakoe_chiba_radius,
-                    itakura_max_slope=itakura_max_slope,
+                    **mask_args
                 )
-                for i in range(len(dataset1))
-                for j in range(i + 1, len(dataset1))
-            )
-        )
-        indices = be.tril_indices(len(dataset1), k=-1, m=len(dataset1))
+                for i in range(n_ts_1)
+                for j in range(i + 1, n_ts_1)
+            ])
+        indices = be.tril_indices(n_ts_1, k=-1, m=n_ts_1)
         matrix[indices] = matrix.T[indices]
-
         return matrix
     else:
         dataset2 = to_time_series_dataset(dataset2, be=be)
-        matrix = Parallel(n_jobs=n_jobs, prefer="threads", verbose=verbose)(
-            delayed(dtw_)(
-                to_time_series(dataset1[i], remove_nans=True, be=be),
-                to_time_series(dataset2[j], remove_nans=True, be=be),
-                global_constraint=global_constraint_,
-                sakoe_chiba_radius=sakoe_chiba_radius,
-                itakura_max_slope=itakura_max_slope,
+        n_ts_2 = dataset2.shape[0]
+        if use_parallel:
+            matrix = be.array(
+                Parallel(n_jobs=n_jobs, prefer="threads", verbose=verbose)(
+                    delayed(dtw_)(
+                        to_time_series(dataset1[i], remove_nans=True, be=be),
+                        to_time_series(dataset2[j], remove_nans=True, be=be),
+                        **mask_args
+                    )
+                    for i in range(n_ts_1)
+                    for j in range(n_ts_2)
+                )
             )
-            for i in range(len(dataset1))
-            for j in range(len(dataset2))
-        )
-        return be.reshape(be.array(matrix), (len(dataset1), -1),)
+        else:
+            matrix = be.array([
+                dtw_(
+                    to_time_series(dataset1[i], remove_nans=True, be=be),
+                    to_time_series(dataset2[j], remove_nans=True, be=be),
+                    **mask_args
+                )
+                for i in range(n_ts_1)
+                for j in range(n_ts_2)
+            ])
+        return matrix.reshape((n_ts_1, n_ts_2))

--- a/tslearn/metrics/_dtw.py
+++ b/tslearn/metrics/_dtw.py
@@ -5,6 +5,7 @@ from numba import njit
 import numpy
 
 from tslearn.backend import instantiate_backend
+from tslearn.backend.pytorch_backend import HAS_TORCH
 from tslearn.metrics._masks import GLOBAL_CONSTRAINT_CODE, _compute_mask, _njit_compute_mask
 from tslearn.utils import to_time_series, to_time_series_dataset
 
@@ -73,7 +74,10 @@ def __make_accumulated_matrix(backend):
         return _accumulated_matrix_generic
 
 _njit_accumulated_matrix = __make_accumulated_matrix(numpy)
-_accumulated_matrix = __make_accumulated_matrix(instantiate_backend("TorchBackend"))
+if HAS_TORCH:
+    _accumulated_matrix = __make_accumulated_matrix(instantiate_backend("TorchBackend"))
+else:
+    _accumulated_matrix = _njit_accumulated_matrix
 
 
 def dtw(
@@ -359,7 +363,10 @@ def __make_compute_path(backend):
         return _compute_path_generic
 
 _njit_compute_path = __make_compute_path(numpy)
-_compute_path = __make_compute_path(instantiate_backend("torch"))
+if HAS_TORCH:
+    _compute_path = __make_compute_path(instantiate_backend("torch"))
+else:
+    _compute_path = _njit_compute_path
 
 
 def __make_dtw(backend):
@@ -387,7 +394,10 @@ def __make_dtw(backend):
         return _dtw_generic
 
 _njit_dtw = __make_dtw(numpy)
-_dtw = __make_dtw(instantiate_backend("torch"))
+if HAS_TORCH:
+    _dtw = __make_dtw(instantiate_backend("torch"))
+else:
+    _dtw = _njit_dtw
 
 
 def __make_dtw_path(backend):
@@ -419,7 +429,10 @@ def __make_dtw_path(backend):
 
 
 _njit_dtw_path = __make_dtw_path(numpy)
-_dtw_path = __make_dtw_path(instantiate_backend("torch"))
+if HAS_TORCH:
+    _dtw_path = __make_dtw_path(instantiate_backend("torch"))
+else:
+    _dtw_path = _njit_dtw_path
 
 
 def cdist_dtw(

--- a/tslearn/metrics/_dtw.py
+++ b/tslearn/metrics/_dtw.py
@@ -1,0 +1,585 @@
+from joblib import Parallel, delayed
+
+from numba import njit
+
+import numpy
+
+from tslearn.backend import instantiate_backend
+from tslearn.metrics._masks import GLOBAL_CONSTRAINT_CODE, _compute_mask, _njit_compute_mask
+from tslearn.utils import to_time_series, to_time_series_dataset
+
+
+def accumulated_matrix(s1, s2, mask, be=None):
+    """Compute the accumulated cost matrix score between two time series.
+
+    Parameters
+    ----------
+    s1 : array-like, shape=(sz1, d)
+        First time series.
+    s2 : array-like, shape=(sz2, d)
+        Second time series.
+    mask : array-like, shape=(sz1, sz2)
+        Mask. Unconsidered cells must have infinite values.
+    be : Backend object or string or None
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
+
+    Returns
+    -------
+    mat : array-like, shape=(sz1, sz2)
+        Accumulated cost matrix.
+    """
+    be = instantiate_backend(be, s1, s2)
+    s1 = be.array(s1)
+    s2 = be.array(s2)
+
+    if be.is_numpy:
+        compute_accumulated_matrix = _njit_accumulated_matrix
+    else:
+        compute_accumulated_matrix = _accumulated_matrix
+    return compute_accumulated_matrix(s1, s2, mask)
+
+
+def __make_accumulated_matrix(backend):
+
+    def _accumulated_matrix_generic(s1, s2, mask):
+        l1 = s1.shape[0]
+        l2 = s2.shape[0]
+        cum_sum = backend.full((l1 + 1, l2 + 1), backend.inf)
+        cum_sum[0, 0] = 0.0
+
+        for i in range(l1):
+            for j in range(l2):
+                if mask[i, j]:
+                    dist = 0.0
+                    for di in range(s1[i].shape[0]):
+                        diff = s1[i][di] - s2[j][di]
+                        dist += diff * diff
+                    cum_sum[i + 1, j + 1] = dist
+                    cum_sum[i + 1, j + 1] += min(
+                        cum_sum[i, j + 1],
+                        cum_sum[i + 1, j],
+                        cum_sum[i, j]
+                    )
+        return cum_sum[1:, 1:]
+
+    if backend is numpy:
+        return njit(nogil=True)(_accumulated_matrix_generic)
+    else:
+        return _accumulated_matrix_generic
+
+_njit_accumulated_matrix = __make_accumulated_matrix(numpy)
+_accumulated_matrix = __make_accumulated_matrix(instantiate_backend("TorchBackend"))
+
+
+def dtw(
+    s1,
+    s2,
+    global_constraint=None,
+    sakoe_chiba_radius=None,
+    itakura_max_slope=None,
+    be=None,
+):
+    r"""Compute Dynamic Time Warping (DTW) similarity measure between
+    (possibly multidimensional) time series and return it.
+
+    DTW is computed as the Euclidean distance between aligned time series,
+    i.e., if :math:`\pi` is the optimal alignment path:
+
+    .. math::
+
+        DTW(X, Y) = \sqrt{\sum_{(i, j) \in \pi} \|X_{i} - Y_{j}\|^2}
+
+    Note that this formula is still valid for the multivariate case.
+
+    It is not required that both time series share the same size, but they must
+    be the same dimension. DTW was originally presented in [1]_ and is
+    discussed in more details in our :ref:`dedicated user-guide page <dtw>`.
+
+    Parameters
+    ----------
+    s1 : array-like, shape=(sz1, d) or (sz1,)
+        A time series. If shape is (sz1,), the time series is assumed to be univariate.
+
+    s2 : array-like, shape=(sz2, d) or (sz2,)
+        Another time series. If shape is (sz2,), the time series is assumed to be univariate.
+
+    global_constraint : {"itakura", "sakoe_chiba"} or None (default: None)
+        Global constraint to restrict admissible paths for DTW.
+
+    sakoe_chiba_radius : int or None (default: None)
+        Radius to be used for Sakoe-Chiba band global constraint.
+        The Sakoe-Chiba radius corresponds to the parameter :math:`\delta` mentioned in [1]_,
+        it controls how far in time we can go in order to match a given
+        point from one time series to a point in another time series.
+        If None and `global_constraint` is set to "sakoe_chiba", a radius of
+        1 is used.
+        If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
+        `global_constraint` is used to infer which constraint to use among the
+        two. In this case, if `global_constraint` corresponds to no global
+        constraint, a `RuntimeWarning` is raised and no global constraint is
+        used.
+
+    itakura_max_slope : float or None (default: None)
+        Maximum slope for the Itakura parallelogram constraint.
+        If None and `global_constraint` is set to "itakura", a maximum slope
+        of 2. is used.
+        If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
+        `global_constraint` is used to infer which constraint to use among the
+        two. In this case, if `global_constraint` corresponds to no global
+        constraint, a `RuntimeWarning` is raised and no global constraint is
+        used.
+
+    be : Backend object or string or None
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
+
+    Returns
+    -------
+    float
+        Similarity score
+
+    Examples
+    --------
+    >>> dtw([1, 2, 3], [1., 2., 2., 3.])
+    0.0
+    >>> dtw([1, 2, 3], [1., 2., 2., 3., 4.])
+    1.0
+
+    The PyTorch backend can be used to compute gradients:
+
+    >>> import torch
+    >>> s1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)
+    >>> s2 = torch.tensor([[3.0], [4.0], [-3.0]])
+    >>> sim = dtw(s1, s2, be="pytorch")
+    >>> print(sim)
+    tensor(6.4807, grad_fn=<SqrtBackward0>)
+    >>> sim.backward()
+    >>> print(s1.grad)
+    tensor([[-0.3086],
+            [-0.1543],
+            [ 0.7715]])
+
+    >>> s1_2d = torch.tensor([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]], requires_grad=True)
+    >>> s2_2d = torch.tensor([[3.0, 3.0], [4.0, 4.0], [-3.0, -3.0]])
+    >>> sim = dtw(s1_2d, s2_2d, be="pytorch")
+    >>> print(sim)
+    tensor(9.1652, grad_fn=<SqrtBackward0>)
+    >>> sim.backward()
+    >>> print(s1_2d.grad)
+    tensor([[-0.2182, -0.2182],
+            [-0.1091, -0.1091],
+            [ 0.5455,  0.5455]])
+
+    See Also
+    --------
+    dtw_path : Get both the matching path and the similarity score for DTW
+    cdist_dtw : Cross similarity matrix between time series datasets
+
+    References
+    ----------
+    .. [1] H. Sakoe, S. Chiba, "Dynamic programming algorithm optimization for
+           spoken word recognition," IEEE Transactions on Acoustics, Speech and
+           Signal Processing, vol. 26(1), pp. 43--49, 1978.
+
+    """  # noqa: E501
+    be = instantiate_backend(be, s1, s2)
+    s1 = to_time_series(s1, remove_nans=True, be=be)
+    s2 = to_time_series(s2, remove_nans=True, be=be)
+
+    if len(s1) == 0 or len(s2) == 0:
+        raise ValueError(
+            "One of the input time series contains only nans or has zero length."
+        )
+
+    if be.shape(s1)[1] != be.shape(s2)[1]:
+        raise ValueError("All input time series must have the same feature size.")
+
+    global_constraint_ = GLOBAL_CONSTRAINT_CODE[global_constraint]
+
+    if be.is_numpy:
+        dtw_ = _njit_dtw
+    else:
+        dtw_ = _dtw
+    return dtw_(s1, s2, global_constraint_, sakoe_chiba_radius, itakura_max_slope)
+
+
+def dtw_path(
+    s1,
+    s2,
+    global_constraint=None,
+    sakoe_chiba_radius=None,
+    itakura_max_slope=None,
+    be=None,
+):
+    r"""Compute Dynamic Time Warping (DTW) similarity measure between
+    (possibly multidimensional) time series and return both the path and the
+    similarity.
+
+    DTW is computed as the Euclidean distance between aligned time series,
+    i.e., if :math:`\pi` is the alignment path:
+
+    .. math::
+
+        DTW(X, Y) = \sqrt{\sum_{(i, j) \in \pi} (X_{i} - Y_{j})^2}
+
+    It is not required that both time series share the same size, but they must
+    be the same dimension. DTW was originally presented in [1]_ and is
+    discussed in more details in our :ref:`dedicated user-guide page <dtw>`.
+
+    Parameters
+    ----------
+    s1 : array-like, shape=(sz1, d) or (sz1,)
+        A time series. If shape is (sz1,), the time series is assumed to be univariate.
+    s2 : array-like, shape=(sz2, d) or (sz2,)
+        Another time series. If shape is (sz2,), the time series is assumed to be univariate.
+    global_constraint : {"itakura", "sakoe_chiba"} or None (default: None)
+        Global constraint to restrict admissible paths for DTW.
+    sakoe_chiba_radius : int or None (default: None)
+        Radius to be used for Sakoe-Chiba band global constraint.
+        The Sakoe-Chiba radius corresponds to the parameter :math:`\delta` mentioned in [1]_,
+        it controls how far in time we can go in order to match a given
+        point from one time series to a point in another time series.
+        If None and `global_constraint` is set to "sakoe_chiba", a radius of
+        1 is used.
+        If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
+        `global_constraint` is used to infer which constraint to use among the
+        two. In this case, if `global_constraint` corresponds to no global
+        constraint, a `RuntimeWarning` is raised and no global constraint is
+        used.
+    itakura_max_slope : float or None (default: None)
+        Maximum slope for the Itakura parallelogram constraint.
+        If None and `global_constraint` is set to "itakura", a maximum slope
+        of 2. is used.
+        If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
+        `global_constraint` is used to infer which constraint to use among the
+        two. In this case, if `global_constraint` corresponds to no global
+        constraint, a `RuntimeWarning` is raised and no global constraint is
+        used.
+    be : Backend object or string or None
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
+
+    Returns
+    -------
+    list of integer pairs
+        Matching path represented as a list of index pairs. In each pair, the
+        first index corresponds to s1 and the second one corresponds to s2.
+
+    float
+        Similarity score
+
+    Examples
+    --------
+    >>> path, dist = dtw_path([1, 2, 3], [1., 2., 2., 3.])
+    >>> path
+    [(0, 0), (1, 1), (1, 2), (2, 3)]
+    >>> float(dist)
+    0.0
+    >>> float(dtw_path([1, 2, 3], [1., 2., 2., 3., 4.])[1])
+    1.0
+
+    See Also
+    --------
+    dtw : Get only the similarity score for DTW
+    cdist_dtw : Cross similarity matrix between time series datasets
+    dtw_path_from_metric : Compute a DTW using a user-defined distance metric
+
+    References
+    ----------
+    .. [1] H. Sakoe, S. Chiba, "Dynamic programming algorithm optimization for
+           spoken word recognition," IEEE Transactions on Acoustics, Speech and
+           Signal Processing, vol. 26(1), pp. 43--49, 1978.
+
+    """
+    be = instantiate_backend(be, s1, s2)
+    s1 = to_time_series(s1, remove_nans=True, be=be)
+    s2 = to_time_series(s2, remove_nans=True, be=be)
+
+    if len(s1) == 0 or len(s2) == 0:
+        raise ValueError(
+            "One of the input time series contains only nans or has zero length."
+        )
+
+    if be.shape(s1)[1] != be.shape(s2)[1]:
+        raise ValueError("All input time series must have the same feature size.")
+
+    global_constraint_ = GLOBAL_CONSTRAINT_CODE[global_constraint]
+
+    if be.is_numpy:
+        dtw_path_ = _njit_dtw_path
+    else:
+        dtw_path_ = _dtw_path
+    dist, path = dtw_path_(s1, s2, global_constraint_, sakoe_chiba_radius, itakura_max_slope)
+    return path, dist
+
+
+def __make_compute_path(backend):
+
+    def _compute_path_generic(acc_cost_mat):
+        sz1, sz2 = acc_cost_mat.shape
+        path = [(sz1 - 1, sz2 - 1)]
+        while path[-1] != (0, 0):
+            i, j = path[-1]
+            if i == 0:
+                path.append((0, j - 1))
+            elif j == 0:
+                path.append((i - 1, 0))
+            else:
+                arr = backend.array(
+                    [
+                        acc_cost_mat[i - 1][j - 1],
+                        acc_cost_mat[i - 1][j],
+                        acc_cost_mat[i][j - 1],
+                    ]
+                )
+                argmin = backend.argmin(arr)
+                if argmin == 0:
+                    path.append((i - 1, j - 1))
+                elif argmin == 1:
+                    path.append((i - 1, j))
+                else:
+                    path.append((i, j - 1))
+        return path[::-1]
+    if backend is numpy:
+        return njit(nogil=True)(_compute_path_generic)
+    else:
+        return _compute_path_generic
+
+_njit_compute_path = __make_compute_path(numpy)
+_compute_path = __make_compute_path(instantiate_backend("torch"))
+
+
+def __make_dtw(backend):
+    if backend is numpy:
+        compute_mask_ = _njit_compute_mask
+        accumulated_matrix_ = _njit_accumulated_matrix
+    else:
+        compute_mask_ = _compute_mask
+        accumulated_matrix_ = _accumulated_matrix
+
+    def _dtw_generic(
+        s1,
+        s2,
+        global_constraint=0,
+        sakoe_chiba_radius=None,
+        itakura_max_slope=None,
+    ):
+        mask = compute_mask_(s1.shape[0], s2.shape[0], global_constraint, sakoe_chiba_radius, itakura_max_slope)
+        cum_sum = accumulated_matrix_(s1, s2, mask)
+        return backend.sqrt(cum_sum[-1, -1])
+
+    if backend is numpy:
+        return njit(nogil=True)(_dtw_generic)
+    else:
+        return _dtw_generic
+
+_njit_dtw = __make_dtw(numpy)
+_dtw = __make_dtw(instantiate_backend("torch"))
+
+
+def __make_dtw_path(backend):
+    if backend is numpy:
+        compute_mask_ = _njit_compute_mask
+        accumulated_matrix_ = _njit_accumulated_matrix
+        compute_path_ = _njit_compute_path
+    else:
+        compute_mask_ = _compute_mask
+        accumulated_matrix_ = _accumulated_matrix
+        compute_path_ = _compute_path
+
+    def _dtw_path_generic(
+        s1,
+        s2,
+        global_constraint=0,
+        sakoe_chiba_radius=None,
+        itakura_max_slope=None,
+    ):
+        mask = compute_mask_(s1.shape[0], s2.shape[0], global_constraint, sakoe_chiba_radius, itakura_max_slope)
+        cum_sum = accumulated_matrix_(s1, s2, mask)
+        path = compute_path_(cum_sum)
+        return backend.sqrt(cum_sum[-1, -1]), path
+
+    if backend is numpy:
+        return njit(nogil=True)(_dtw_path_generic)
+    else:
+        return _dtw_path_generic
+
+
+_njit_dtw_path = __make_dtw_path(numpy)
+_dtw_path = __make_dtw_path(instantiate_backend("torch"))
+
+
+def cdist_dtw(
+    dataset1,
+    dataset2=None,
+    global_constraint=None,
+    sakoe_chiba_radius=None,
+    itakura_max_slope=None,
+    n_jobs=None,
+    verbose=0,
+    be=None,
+):
+    r"""Compute cross-similarity matrix using Dynamic Time Warping (DTW)
+    similarity measure.
+
+    DTW is computed as the Euclidean distance between aligned time series,
+    i.e., if :math:`\pi` is the alignment path:
+
+    .. math::
+
+        DTW(X, Y) = \sqrt{\sum_{(i, j) \in \pi} \|X_{i} - Y_{j}\|^2}
+
+    Note that this formula is still valid for the multivariate case.
+
+    It is not required that time series share the same size, but they
+    must be the same dimension.
+    DTW was originally presented in [1]_ and is
+    discussed in more details in our :ref:`dedicated user-guide page <dtw>`.
+
+    Parameters
+    ----------
+    dataset1 : array-like, shape=(n_ts1, sz1, d) or (n_ts1, sz1) or (sz1,)
+        A dataset of time series.
+        If shape is (n_ts1, sz1), the dataset is composed of univariate time series.
+        If shape is (sz1,), the dataset is composed of a unique univariate time series.
+
+    dataset2 : None or array-like, shape=(n_ts2, sz2, d) or (n_ts2, sz2) or (sz2,) (default: None)
+        Another dataset of time series. If `None`, self-similarity of
+        `dataset1` is returned.
+        If shape is (n_ts2, sz2), the dataset is composed of univariate time series.
+        If shape is (sz2,), the dataset is composed of a unique univariate time series.
+
+    global_constraint : {"itakura", "sakoe_chiba"} or None (default: None)
+        Global constraint to restrict admissible paths for DTW.
+
+    sakoe_chiba_radius : int or None (default: None)
+        Radius to be used for Sakoe-Chiba band global constraint.
+        The Sakoe-Chiba radius corresponds to the parameter :math:`\delta` mentioned in [1]_,
+        it controls how far in time we can go in order to match a given
+        point from one time series to a point in another time series.
+        If None and `global_constraint` is set to "sakoe_chiba", a radius of
+        1 is used.
+        If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
+        `global_constraint` is used to infer which constraint to use among the
+        two. In this case, if `global_constraint` corresponds to no global
+        constraint, a `RuntimeWarning` is raised and no global constraint is
+        used.
+
+    itakura_max_slope : float or None (default: None)
+        Maximum slope for the Itakura parallelogram constraint.
+        If None and `global_constraint` is set to "itakura", a maximum slope
+        of 2. is used.
+        If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
+        `global_constraint` is used to infer which constraint to use among the
+        two. In this case, if `global_constraint` corresponds to no global
+        constraint, a `RuntimeWarning` is raised and no global constraint is
+        used.
+
+    n_jobs : int or None, optional (default=None)
+        The number of jobs to run in parallel.
+        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        ``-1`` means using all processors. See scikit-learns'
+        `Glossary <https://scikit-learn.org/stable/glossary.html#term-n_jobs>`__
+        for more details.
+
+    dtype
+
+    verbose : int, optional (default=0)
+        The verbosity level: if non zero, progress messages are printed.
+        Above 50, the output is sent to stdout.
+        The frequency of the messages increases with the verbosity level.
+        If it more than 10, all iterations are reported.
+        `Glossary <https://joblib.readthedocs.io/en/latest/parallel.html#parallel-reference-documentation>`__
+        for more details.
+
+    be : Backend object or string or None
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
+
+    Returns
+    -------
+    cdist : array-like, shape=(n_ts1, n_ts2)
+        Cross-similarity matrix.
+
+    Examples
+    --------
+    >>> cdist_dtw([[1, 2, 2, 3], [1., 2., 3., 4.]])
+    array([[0., 1.],
+           [1., 0.]])
+    >>> cdist_dtw([[1, 2, 2, 3], [1., 2., 3., 4.]], [[1, 2, 3], [2, 3, 4, 5]])
+    array([[0.        , 2.44948974],
+           [1.        , 1.41421356]])
+
+    See Also
+    --------
+    dtw : Get DTW similarity score
+
+    References
+    ----------
+    .. [1] H. Sakoe, S. Chiba, "Dynamic programming algorithm optimization for
+           spoken word recognition," IEEE Transactions on Acoustics, Speech and
+           Signal Processing, vol. 26(1), pp. 43--49, 1978.
+    """  # noqa: E501
+    be = instantiate_backend(be, dataset1, dataset2)
+    dataset1 = to_time_series_dataset(dataset1, be=be)
+
+    global_constraint_ = GLOBAL_CONSTRAINT_CODE[global_constraint]
+
+    if be.is_numpy:
+        dtw_ = _njit_dtw
+    else:
+        dtw_ = _dtw
+
+    if dataset2 is None:
+        matrix = be.zeros((len(dataset1), len(dataset1)))
+        indices = be.triu_indices(
+            len(dataset1), k=1, m=len(dataset1)
+        )
+        matrix[indices] = be.array(
+            Parallel(n_jobs=n_jobs, prefer="threads", verbose=verbose)(
+                delayed(dtw_)(
+                    to_time_series(dataset1[i], remove_nans=True, be=be),
+                    to_time_series(dataset1[j], remove_nans=True, be=be),
+                    global_constraint=global_constraint_,
+                    sakoe_chiba_radius=sakoe_chiba_radius,
+                    itakura_max_slope=itakura_max_slope,
+                )
+                for i in range(len(dataset1))
+                for j in range(i + 1, len(dataset1))
+            )
+        )
+        indices = be.tril_indices(len(dataset1), k=-1, m=len(dataset1))
+        matrix[indices] = matrix.T[indices]
+
+        return matrix
+    else:
+        dataset2 = to_time_series_dataset(dataset2, be=be)
+        matrix = Parallel(n_jobs=n_jobs, prefer="threads", verbose=verbose)(
+            delayed(dtw_)(
+                to_time_series(dataset1[i], remove_nans=True, be=be),
+                to_time_series(dataset2[j], remove_nans=True, be=be),
+                global_constraint=global_constraint_,
+                sakoe_chiba_radius=sakoe_chiba_radius,
+                itakura_max_slope=itakura_max_slope,
+            )
+            for i in range(len(dataset1))
+            for j in range(len(dataset2))
+        )
+        return be.reshape(be.array(matrix), (len(dataset1), -1),)

--- a/tslearn/metrics/_masks.py
+++ b/tslearn/metrics/_masks.py
@@ -1,0 +1,358 @@
+""" Masks """
+from numba import njit, prange
+
+import numpy
+
+from tslearn.backend import instantiate_backend
+
+try:
+    from sklearn.externals.array_api_compat import is_numpy_array
+except ImportError:
+    def is_numpy_array(array):
+        return instantiate_backend(array).is_numpy
+
+GLOBAL_CONSTRAINT_CODE = {None: 0, "": 0, "itakura": 1, "sakoe_chiba": 2}
+
+
+def __make_sakoe_chiba_mask(backend):
+    if backend is numpy:
+        range_ = prange
+    else:
+        range_ = range
+
+    def _sakoe_chiba_mask_generic(sz1, sz2, radius=1):
+        mask = backend.full((sz1, sz2), False)
+        if sz1 > sz2:
+            width = sz1 - sz2 + radius
+            for i in range_(sz2):
+                lower = max(0, i - radius)
+                upper = min(sz1, i + width) + 1
+                mask[lower:upper, i] = True
+        else:
+            width = sz2 - sz1 + radius
+            for i in range_(sz1):
+                lower = max(0, i - radius)
+                upper = min(sz2, i + width) + 1
+                mask[i, lower:upper] = True
+        return mask
+    if backend is numpy:
+        return njit(nogil=True, parallel=True)(_sakoe_chiba_mask_generic)
+    else:
+        return _sakoe_chiba_mask_generic
+
+_sakoe_chiba_mask = __make_sakoe_chiba_mask(instantiate_backend("torch"))
+_njit_sakoe_chiba_mask = __make_sakoe_chiba_mask(numpy)
+
+
+def sakoe_chiba_mask(sz1, sz2, radius=1, be=None):
+    """Compute the Sakoe-Chiba mask.
+
+    Parameters
+    ----------
+    sz1 : int
+        The size of the first time series
+    sz2 : int
+        The size of the second time series.
+    radius : int
+        The radius of the band.
+    be : Backend object or string or None
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
+
+    Returns
+    -------
+    mask : array-like, shape=(sz1, sz2)
+        Sakoe-Chiba mask.
+
+    Examples
+    --------
+    >>> sakoe_chiba_mask(4, 4, radius=2)
+    array([[ True,  True,  True, False],
+           [ True,  True,  True,  True],
+           [ True,  True,  True,  True],
+           [False,  True,  True,  True]])
+    """
+    be = instantiate_backend(be)
+    if be.is_numpy:
+        return _njit_sakoe_chiba_mask(
+            sz1,
+            sz2,
+            radius,
+        )
+    else:
+        return _sakoe_chiba_mask(
+            sz1,
+            sz2,
+            radius,
+        )
+
+
+def __make_itakura_mask(backend):
+    if backend is numpy:
+        range_ = prange
+    else:
+        range_ = range
+
+    def _itakura_mask_generic(sz1, sz2, max_slope=2.0):
+        min_slope = 1 / float(max_slope)
+        max_slope *= float(sz1) / float(sz2)
+        min_slope *= float(sz1) / float(sz2)
+
+        lower_bound = backend.empty((2, sz2))
+        lower_bound[0] = min_slope * backend.arange(sz2)
+        lower_bound[1] = (sz1 - 1) - max_slope * (sz2 - 1) + max_slope * backend.arange(sz2)
+        lower_bound_ = backend.empty(sz2)
+        for i in range_(sz2):
+            lower_bound_[i] = max(
+                backend.round(lower_bound[0, i], decimals=2),
+                backend.round(lower_bound[1, i], decimals=2)
+            )
+        lower_bound_ = backend.ceil(lower_bound_)
+
+        upper_bound = backend.empty((2, sz2))
+        upper_bound[0] = max_slope * backend.arange(sz2)
+        upper_bound[1] = (sz1 - 1) - min_slope * (sz2 - 1) + min_slope * backend.arange(sz2)
+        upper_bound_ = backend.empty(sz2)
+        for i in range_(sz2):
+            upper_bound_[i] = min(
+                backend.round(upper_bound[0, i], decimals=2),
+                backend.round(upper_bound[1, i], decimals=2)
+            )
+        upper_bound_ = backend.floor(upper_bound_ + 1)
+
+        mask = backend.full((sz1, sz2), False)
+        for i in range_(sz2):
+            mask[int(lower_bound_[i]): int(upper_bound_[i]), i] = True
+
+        # Post-check
+        raise_warning = False
+        for i in range(sz1):
+            if not backend.any(mask[i]):
+                raise_warning = True
+                break
+        if not raise_warning:
+            for j in range(sz2):
+                if not backend.any(mask[:, j]):
+                    raise_warning = True
+                    break
+        if raise_warning:
+            raise RuntimeWarning(
+                "'itakura_max_slope' constraint is unfeasible "
+                "(ie. leads to no admissible path) for the "
+                "provided time series sizes",
+            )
+
+        return mask
+
+    if backend is numpy:
+        return njit(nogil=True, parallel=True)(_itakura_mask_generic)
+    else:
+        return _itakura_mask_generic
+
+_itakura_mask = __make_itakura_mask(instantiate_backend("torch"))
+_njit_itakura_mask = __make_itakura_mask(numpy)
+
+
+def itakura_mask(sz1, sz2, max_slope=2.0, be=None):
+    """Compute the Itakura mask.
+
+    Parameters
+    ----------
+    sz1 : int
+        The size of the first time series
+    sz2 : int
+        The size of the second time series.
+    max_slope : float (default = 2)
+        The maximum slope of the parallelogram.
+    be : Backend object or string or None
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
+
+    Returns
+    -------
+    mask : array-like, shape=(sz1, sz2)
+        Itakura mask.
+
+    Examples
+    --------
+    >>> itakura_mask(6, 6, max_slope=3)
+    array([[ True, False, False, False, False, False],
+           [False,  True,  True,  True, False, False],
+           [False,  True,  True,  True,  True, False],
+           [False,  True,  True,  True,  True, False],
+           [False, False,  True,  True,  True, False],
+           [False, False, False, False, False,  True]])
+
+    """
+    be = instantiate_backend(be)
+
+    if be.is_numpy:
+        mask = _njit_itakura_mask(sz1, sz2, max_slope=max_slope)
+    else:
+        mask = _itakura_mask(sz1, sz2, max_slope=max_slope)
+
+    return mask
+
+
+def compute_mask(
+    s1,
+    s2,
+    global_constraint=0,
+    sakoe_chiba_radius=None,
+    itakura_max_slope=None,
+    be=None,
+):
+    r"""Compute the mask (region constraint).
+
+    Parameters
+    ----------
+    s1 : array-like, shape=(sz1, d) or (sz1,) or int
+        A time series or integer.
+        If shape is (sz1,), the time series is assumed to be univariate.
+        If int, size sz1 used to dimension the mask.
+    s2 : array-like, shape=(sz2, d) or (sz2,) or int
+        Another time series or integer.
+        If shape is (sz2,), the time series is assumed to be univariate.
+        If int, size sz2 used to dimension the mask.
+    global_constraint : {0, 1, 2} (default: 0)
+        Global constraint to restrict admissible paths for DTW:
+        - "itakura" if 1
+        - "sakoe_chiba" if 2
+        - no constraint otherwise
+    sakoe_chiba_radius : int or None (default: None)
+        Radius to be used for Sakoe-Chiba band global constraint.
+        The Sakoe-Chiba radius corresponds to the parameter :math:`\delta` mentioned in [1]_,
+        it controls how far in time we can go in order to match a given
+        point from one time series to a point in another time series.
+        If None and `global_constraint` is set to 2 (sakoe-chiba), a radius of
+        1 is used.
+        If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
+        `global_constraint` is used to infer which constraint to use among the
+        two. In this case, if `global_constraint` corresponds to no global
+        constraint, a `RuntimeWarning` is raised and no global constraint is
+        used.
+    itakura_max_slope : float or None (default: None)
+        Maximum slope for the Itakura parallelogram constraint.
+        If None and `global_constraint` is set to 1 (itakura), a maximum slope
+        of 2. is used.
+        If both `sakoe_chiba_radius` and `itakura_max_slope` are set,
+        `global_constraint` is used to infer which constraint to use among the
+        two. In this case, if `global_constraint` corresponds to no global
+        constraint, a `RuntimeWarning` is raised and no global constraint is
+        used.
+    be : Backend object or string or None
+        Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
+        the NumPy backend is used.
+        If `be` is an instance of the class `PyTorchBackend` or the string `"pytorch"`,
+        the PyTorch backend is used.
+        If `be` is `None`, the backend is determined by the input arrays.
+        See our :ref:`dedicated user-guide page <backend>` for more information.
+
+    Returns
+    -------
+    mask : array-like, shape=(sz1, sz2)
+        Constraint region.
+
+    Examples
+    --------
+    >>> compute_mask(4, 4)
+    array([[ True,  True,  True,  True],
+           [ True,  True,  True,  True],
+           [ True,  True,  True,  True],
+           [ True,  True,  True,  True]])
+    >>> compute_mask(4, 4, sakoe_chiba_radius=1)
+    array([[ True,  True, False, False],
+           [ True,  True,  True, False],
+           [False,  True,  True,  True],
+           [False, False,  True,  True]])
+    >>> compute_mask(4, 4, itakura_max_slope=2)
+    array([[ True, False, False, False],
+           [False,  True,  True, False],
+           [False,  True,  True, False],
+           [False, False, False,  True]])
+    """
+    be = instantiate_backend(be, s1, s2)
+
+    # The output mask will be of shape (sz1, sz2)
+    if isinstance(s1, int) and isinstance(s2, int):
+        sz1, sz2 = s1, s2
+    else:
+        sz1 = be.array(s1).shape[0]
+        sz2 = be.array(s2).shape[0]
+
+    if be.is_numpy:
+        x = _njit_compute_mask(
+            sz1,
+            sz2,
+            global_constraint,
+            sakoe_chiba_radius,
+            itakura_max_slope,
+        )
+        return x
+    else:
+        return _compute_mask(
+            sz1,
+            sz2,
+            global_constraint,
+            sakoe_chiba_radius,
+            itakura_max_slope,
+        )
+
+
+def __make_compute_mask(backend):
+    if backend is numpy:
+        sakoe_chiba_mask_ = _njit_sakoe_chiba_mask
+        itakura_mask_ = _njit_itakura_mask
+    else:
+        sakoe_chiba_mask_ = _sakoe_chiba_mask
+        itakura_mask_ = _itakura_mask
+
+    def _compute_mask_generic(
+            sz1,
+            sz2,
+            global_constraint=0,
+            sakoe_chiba_radius=None,
+            itakura_max_slope=None,
+    ):
+        if (
+                global_constraint == 0
+                and sakoe_chiba_radius is not None
+                and itakura_max_slope is not None
+        ):
+            raise RuntimeWarning(
+                "global_constraint is not set for DTW, but both "
+                "sakoe_chiba_radius and itakura_max_slope are "
+                "set, hence global_constraint cannot be inferred "
+                "and no global constraint will be used."
+            )
+        if global_constraint == 2 or (
+                global_constraint == 0 and sakoe_chiba_radius is not None
+        ):
+            if sakoe_chiba_radius is None:
+                sakoe_chiba_radius = 1
+            mask = sakoe_chiba_mask_(sz1, sz2, radius=sakoe_chiba_radius)
+
+        elif global_constraint == 1 or (
+                global_constraint == 0 and itakura_max_slope is not None
+        ):
+            if itakura_max_slope is None:
+                itakura_max_slope = 2.0
+            mask = itakura_mask_(sz1, sz2, max_slope=itakura_max_slope)
+        else:
+            mask = backend.full((sz1, sz2), True)
+        return mask
+    if backend is numpy:
+        return njit(nogil=True)(_compute_mask_generic)
+    else:
+        return _compute_mask_generic
+
+_njit_compute_mask = __make_compute_mask(numpy)
+_compute_mask = __make_compute_mask(instantiate_backend("torch"))

--- a/tslearn/metrics/_masks.py
+++ b/tslearn/metrics/_masks.py
@@ -4,12 +4,8 @@ from numba import njit, prange
 import numpy
 
 from tslearn.backend import instantiate_backend
+from tslearn.backend.pytorch_backend import HAS_TORCH
 
-try:
-    from sklearn.externals.array_api_compat import is_numpy_array
-except ImportError:
-    def is_numpy_array(array):
-        return instantiate_backend(array).is_numpy
 
 GLOBAL_CONSTRAINT_CODE = {None: 0, "": 0, "itakura": 1, "sakoe_chiba": 2}
 
@@ -40,8 +36,11 @@ def __make_sakoe_chiba_mask(backend):
     else:
         return _sakoe_chiba_mask_generic
 
-_sakoe_chiba_mask = __make_sakoe_chiba_mask(instantiate_backend("torch"))
 _njit_sakoe_chiba_mask = __make_sakoe_chiba_mask(numpy)
+if HAS_TORCH:
+    _sakoe_chiba_mask = __make_sakoe_chiba_mask(instantiate_backend("torch"))
+else:
+    _sakoe_chiba_mask = _njit_sakoe_chiba_mask
 
 
 def sakoe_chiba_mask(sz1, sz2, radius=1, be=None):
@@ -153,8 +152,11 @@ def __make_itakura_mask(backend):
     else:
         return _itakura_mask_generic
 
-_itakura_mask = __make_itakura_mask(instantiate_backend("torch"))
 _njit_itakura_mask = __make_itakura_mask(numpy)
+if HAS_TORCH:
+    _itakura_mask = __make_itakura_mask(instantiate_backend("torch"))
+else:
+    _itakura_mask = _njit_itakura_mask
 
 
 def itakura_mask(sz1, sz2, max_slope=2.0, be=None):
@@ -355,4 +357,7 @@ def __make_compute_mask(backend):
         return _compute_mask_generic
 
 _njit_compute_mask = __make_compute_mask(numpy)
-_compute_mask = __make_compute_mask(instantiate_backend("torch"))
+if HAS_TORCH:
+    _compute_mask = __make_compute_mask(instantiate_backend("torch"))
+else:
+    _compute_mask = _njit_compute_mask

--- a/tslearn/metrics/ctw.py
+++ b/tslearn/metrics/ctw.py
@@ -3,10 +3,9 @@ from sklearn.cross_decomposition import CCA
 
 from tslearn.backend import instantiate_backend
 
-from ..utils import to_time_series
-from .dtw_variants import dtw_path
+from ._dtw import dtw_path
 from .utils import _cdist_generic
-
+from ..utils import to_time_series
 
 def _get_warp_matrices(warp_path, be):
     """Convert warping path sequence to matrices.

--- a/tslearn/metrics/dtw_variants.py
+++ b/tslearn/metrics/dtw_variants.py
@@ -1,6 +1,7 @@
 import warnings
 
 import numpy
+
 from numba import njit, prange
 
 from tslearn.backend import instantiate_backend
@@ -93,7 +94,7 @@ def njit_accumulated_matrix(s1, s2, mask):
 
     for i in range(l1):
         for j in range(l2):
-            if numpy.isfinite(mask[i, j]):
+            if mask[i, j]:
                 cum_sum[i + 1, j + 1] = _njit_local_squared_dist(s1[i], s2[j])
                 cum_sum[i + 1, j + 1] += min(
                     cum_sum[i, j + 1], cum_sum[i + 1, j], cum_sum[i, j]
@@ -125,6 +126,8 @@ def accumulated_matrix(s1, s2, mask, be=None):
     mat : array-like, shape=(sz1, sz2)
         Accumulated cost matrix.
     """
+    warnings.warn("This method is deprecated, use tslearn.metrics._dtw.accumulated_matrix instead.", DeprecationWarning)
+
     be = instantiate_backend(be, s1, s2)
     s1 = be.array(s1)
     s2 = be.array(s2)
@@ -135,7 +138,7 @@ def accumulated_matrix(s1, s2, mask, be=None):
 
     for i in range(l1):
         for j in range(l2):
-            if be.isfinite(mask[i, j]):
+            if mask[i, j]:
                 cum_sum[i + 1, j + 1] = _local_squared_dist(s1[i], s2[j], be=be)
                 cum_sum[i + 1, j + 1] += min(
                     cum_sum[i, j + 1], cum_sum[i + 1, j], cum_sum[i, j]
@@ -381,6 +384,8 @@ def dtw_path(
            Signal Processing, vol. 26(1), pp. 43--49, 1978.
 
     """
+    warnings.warn("This method is deprecated, use tslearn.metrics._dtw.dtw_path instead.", DeprecationWarning)
+
     be = instantiate_backend(be, s1, s2)
     s1 = to_time_series(s1, remove_nans=True, be=be)
     s2 = to_time_series(s2, remove_nans=True, be=be)
@@ -472,7 +477,7 @@ def accumulated_matrix_from_dist_matrix(dist_matrix, mask, be=None):
 
     for i in range(l1):
         for j in range(l2):
-            if be.isfinite(mask[i, j]):
+            if mask[i, j]:
                 cum_sum[i + 1, j + 1] = dist_matrix[i, j]
                 cum_sum[i + 1, j + 1] += min(
                     cum_sum[i, j + 1], cum_sum[i + 1, j], cum_sum[i, j]
@@ -747,7 +752,7 @@ def dtw(
     1.0
 
     The PyTorch backend can be used to compute gradients:
-    
+
     >>> import torch
     >>> s1 = torch.tensor([[1.0], [2.0], [3.0]], requires_grad=True)
     >>> s2 = torch.tensor([[3.0], [4.0], [-3.0]])
@@ -1484,32 +1489,32 @@ def njit_sakoe_chiba_mask(sz1, sz2, radius=1):
     Examples
     --------
     >>> njit_sakoe_chiba_mask(4, 4, 1)
-    array([[ 0.,  0., inf, inf],
-           [ 0.,  0.,  0., inf],
-           [inf,  0.,  0.,  0.],
-           [inf, inf,  0.,  0.]])
+    array([[ True,  True, False, False],
+           [ True,  True,  True, False],
+           [False,  True,  True,  True],
+           [False, False,  True,  True]])
     >>> njit_sakoe_chiba_mask(7, 3, 1)
-    array([[ 0.,  0., inf],
-           [ 0.,  0.,  0.],
-           [ 0.,  0.,  0.],
-           [ 0.,  0.,  0.],
-           [ 0.,  0.,  0.],
-           [ 0.,  0.,  0.],
-           [inf,  0.,  0.]])
+    array([[ True,  True, False],
+           [ True,  True,  True],
+           [ True,  True,  True],
+           [ True,  True,  True],
+           [ True,  True,  True],
+           [ True,  True,  True],
+           [False,  True,  True]])
     """
-    mask = numpy.full((sz1, sz2), numpy.inf)
+    mask = numpy.full((sz1, sz2), False)
     if sz1 > sz2:
         width = sz1 - sz2 + radius
         for i in prange(sz2):
             lower = max(0, i - radius)
             upper = min(sz1, i + width) + 1
-            mask[lower:upper, i] = 0.0
+            mask[lower:upper, i] = True
     else:
         width = sz2 - sz1 + radius
         for i in prange(sz1):
             lower = max(0, i - radius)
             upper = min(sz2, i + width) + 1
-            mask[i, lower:upper] = 0.0
+            mask[i, lower:upper] = True
     return mask
 
 
@@ -1540,33 +1545,35 @@ def sakoe_chiba_mask(sz1, sz2, radius=1, be=None):
     Examples
     --------
     >>> sakoe_chiba_mask(4, 4, 1)
-    array([[ 0.,  0., inf, inf],
-           [ 0.,  0.,  0., inf],
-           [inf,  0.,  0.,  0.],
-           [inf, inf,  0.,  0.]])
+    array([[ True,  True, False, False],
+           [ True,  True,  True, False],
+           [False,  True,  True,  True],
+           [False, False,  True,  True]])
     >>> sakoe_chiba_mask(7, 3, 1)
-    array([[ 0.,  0., inf],
-           [ 0.,  0.,  0.],
-           [ 0.,  0.,  0.],
-           [ 0.,  0.,  0.],
-           [ 0.,  0.,  0.],
-           [ 0.,  0.,  0.],
-           [inf,  0.,  0.]])
+    array([[ True,  True, False],
+           [ True,  True,  True],
+           [ True,  True,  True],
+           [ True,  True,  True],
+           [ True,  True,  True],
+           [ True,  True,  True],
+           [False,  True,  True]])
     """
+    warnings.warn("This method is deprecated, use tslearn.metrics._masks.sakoe_chiba_mask instead.", DeprecationWarning)
+
     be = instantiate_backend(be)
-    mask = be.full((sz1, sz2), be.inf)
+    mask = be.full((sz1, sz2), False)
     if sz1 > sz2:
         width = sz1 - sz2 + radius
         for i in range(sz2):
             lower = max(0, i - radius)
             upper = min(sz1, i + width) + 1
-            mask[lower:upper, i] = 0.0
+            mask[lower:upper, i] = True
     else:
         width = sz2 - sz1 + radius
         for i in range(sz1):
             lower = max(0, i - radius)
             upper = min(sz2, i + width) + 1
-            mask[i, lower:upper] = 0.0
+            mask[i, lower:upper] = True
     return mask
 
 
@@ -1611,9 +1618,28 @@ def _njit_itakura_mask(sz1, sz2, max_slope=2.0):
         upper_bound_[i] = min(round(upper_bound[0, i], 2), round(upper_bound[1, i], 2))
     upper_bound_ = numpy.floor(upper_bound_ + 1)
 
-    mask = numpy.full((sz1, sz2), numpy.inf)
+    mask = numpy.full((sz1, sz2), False)
     for i in prange(sz2):
-        mask[int(lower_bound_[i]) : int(upper_bound_[i]), i] = 0.0
+        mask[int(lower_bound_[i]) : int(upper_bound_[i]), i] = True
+
+    # Post-check
+    raise_warning = False
+    for i in range(sz1):
+        if not numpy.any(mask[i]):
+            raise_warning = True
+            break
+    if not raise_warning:
+        for j in range(sz2):
+            if not numpy.any(mask[:, j]):
+                raise_warning = True
+                break
+    if raise_warning:
+        raise RuntimeWarning(
+            "'itakura_max_slope' constraint is unfeasible "
+            "(ie. leads to no admissible path) for the "
+            "provided time series sizes",
+        )
+
     return mask
 
 
@@ -1642,7 +1668,6 @@ def _itakura_mask(sz1, sz2, max_slope=2.0, be=None):
     mask : array-like, shape=(sz1, sz2)
         Itakura mask.
     """
-    be = instantiate_backend(be)
     min_slope = 1 / float(max_slope)
     max_slope *= float(sz1) / float(sz2)
     min_slope *= float(sz1) / float(sz2)
@@ -1669,9 +1694,26 @@ def _itakura_mask(sz1, sz2, max_slope=2.0, be=None):
         )
     upper_bound_ = be.floor(upper_bound_ + 1)
 
-    mask = be.full((sz1, sz2), be.inf)
+    mask = be.full((sz1, sz2), False)
     for i in range(sz2):
-        mask[int(lower_bound_[i]) : int(upper_bound_[i]), i] = 0.0
+        mask[int(lower_bound_[i]) : int(upper_bound_[i]), i] = True
+    # Post-check
+    raise_warning = False
+    for i in range(sz1):
+        if not be.any(mask[i]):
+            raise_warning = True
+            break
+    if not raise_warning:
+        for j in range(sz2):
+            if not be.any(mask[:, j]):
+                raise_warning = True
+                break
+    if raise_warning:
+        raise RuntimeWarning(
+            "'itakura_max_slope' constraint is unfeasible "
+            "(ie. leads to no admissible path) for the "
+            "provided time series sizes",
+        )
     return mask
 
 
@@ -1702,38 +1744,21 @@ def itakura_mask(sz1, sz2, max_slope=2.0, be=None):
     Examples
     --------
     >>> itakura_mask(6, 6)
-    array([[ 0., inf, inf, inf, inf, inf],
-           [inf,  0.,  0., inf, inf, inf],
-           [inf,  0.,  0.,  0., inf, inf],
-           [inf, inf,  0.,  0.,  0., inf],
-           [inf, inf, inf,  0.,  0., inf],
-           [inf, inf, inf, inf, inf,  0.]])
+    array([[ True, False, False, False, False, False],
+           [False,  True,  True, False, False, False],
+           [False,  True,  True,  True, False, False],
+           [False, False,  True,  True,  True, False],
+           [False, False, False,  True,  True, False],
+           [False, False, False, False, False,  True]])
     """
+    warnings.warn("This method is deprecated, use tslearn.metrics._masks.itakura_mask instead.", DeprecationWarning)
+
     be = instantiate_backend(be)
 
     if be.is_numpy:
         mask = _njit_itakura_mask(sz1, sz2, max_slope=max_slope)
     else:
         mask = _itakura_mask(sz1, sz2, max_slope=max_slope, be=be)
-
-    # Post-check
-    raise_warning = False
-    for i in range(sz1):
-        if not be.any(be.isfinite(mask[i])):
-            raise_warning = True
-            break
-    if not raise_warning:
-        for j in range(sz2):
-            if not be.any(be.isfinite(mask[:, j])):
-                raise_warning = True
-                break
-    if raise_warning:
-        warnings.warn(
-            "'itakura_max_slope' constraint is unfeasible "
-            "(ie. leads to no admissible path) for the "
-            "provided time series sizes",
-            RuntimeWarning,
-        )
 
     return mask
 
@@ -1795,6 +1820,8 @@ def compute_mask(
     mask : array-like, shape=(sz1, sz2)
         Constraint region.
     """
+    warnings.warn("This method is deprecated, use tslearn.metrics._masks.compute_mask instead.", DeprecationWarning)
+
     be = instantiate_backend(be, s1, s2)
     # The output mask will be of shape (sz1, sz2)
     if isinstance(s1, int) and isinstance(s2, int):
@@ -1831,7 +1858,7 @@ def compute_mask(
             itakura_max_slope = 2.0
         mask = itakura_mask(sz1, sz2, max_slope=itakura_max_slope, be=be)
     else:
-        mask = be.zeros((sz1, sz2))
+        mask = be.full((sz1, sz2), True)
     return mask
 
 
@@ -1948,6 +1975,8 @@ def cdist_dtw(
            spoken word recognition," IEEE Transactions on Acoustics, Speech and
            Signal Processing, vol. 26(1), pp. 43--49, 1978.
     """  # noqa: E501
+    warnings.warn("This method is deprecated, use tslearn.metrics._dtw.cdist_dtw instead.", DeprecationWarning)
+
     be = instantiate_backend(be, dataset1, dataset2)
     return _cdist_generic(
         dist_fun=dtw,
@@ -2264,7 +2293,7 @@ def lcss_accumulated_matrix(s1, s2, eps, mask, be=None):
 
     for i in range(1, l1 + 1):
         for j in range(1, l2 + 1):
-            if be.isfinite(mask[i - 1, j - 1]):
+            if mask[i - 1, j - 1]:
                 if be.is_numpy:
                     squared_dist = _njit_local_squared_dist(s1[i - 1], s2[j - 1])
                 else:
@@ -2543,7 +2572,7 @@ def _return_lcss_path(s1, s2, eps, mask, acc_cost_mat, sz1, sz2, be=None):
     path = []
 
     while i > 0 and j > 0:
-        if be.isfinite(mask[i - 1, j - 1]):
+        if mask[i - 1, j - 1]:
             if be.is_numpy:
                 squared_dist = _njit_local_squared_dist(s1[i - 1], s2[j - 1])
             else:
@@ -2644,7 +2673,7 @@ def _return_lcss_path_from_dist_matrix(
     path = []
 
     while i > 0 and j > 0:
-        if be.isfinite(mask[i - 1, j - 1]):
+        if mask[i - 1, j - 1]:
             if dist_matrix[i - 1, j - 1] <= eps:
                 path.append((i - 1, j - 1))
                 i, j = (i - 1, j - 1)
@@ -2855,7 +2884,7 @@ def lcss_accumulated_matrix_from_dist_matrix(dist_matrix, eps, mask, be=None):
 
     for i in range(1, l1 + 1):
         for j in range(1, l2 + 1):
-            if be.isfinite(mask[i - 1, j - 1]):
+            if mask[i - 1, j - 1]:
                 if dist_matrix[i - 1, j - 1] <= eps:
                     acc_cost_mat[i][j] = 1 + acc_cost_mat[i - 1][j - 1]
                 else:

--- a/tslearn/metrics/dtw_variants.py
+++ b/tslearn/metrics/dtw_variants.py
@@ -126,7 +126,10 @@ def accumulated_matrix(s1, s2, mask, be=None):
     mat : array-like, shape=(sz1, sz2)
         Accumulated cost matrix.
     """
-    warnings.warn("This method is deprecated, use tslearn.metrics._dtw.accumulated_matrix instead.", DeprecationWarning)
+    warnings.warn(
+        "This method is deprecated, use tslearn.metrics.accumulated_matrix instead.",
+        DeprecationWarning
+    )
 
     be = instantiate_backend(be, s1, s2)
     s1 = be.array(s1)
@@ -384,7 +387,10 @@ def dtw_path(
            Signal Processing, vol. 26(1), pp. 43--49, 1978.
 
     """
-    warnings.warn("This method is deprecated, use tslearn.metrics._dtw.dtw_path instead.", DeprecationWarning)
+    warnings.warn(
+        "This method is deprecated, use tslearn.metrics.dtw_path instead.",
+        DeprecationWarning
+    )
 
     be = instantiate_backend(be, s1, s2)
     s1 = to_time_series(s1, remove_nans=True, be=be)
@@ -1558,7 +1564,10 @@ def sakoe_chiba_mask(sz1, sz2, radius=1, be=None):
            [ True,  True,  True],
            [False,  True,  True]])
     """
-    warnings.warn("This method is deprecated, use tslearn.metrics._masks.sakoe_chiba_mask instead.", DeprecationWarning)
+    warnings.warn(
+        "This method is deprecated, use tslearn.metrics.sakoe_chiba_mask instead.",
+        DeprecationWarning
+    )
 
     be = instantiate_backend(be)
     mask = be.full((sz1, sz2), False)
@@ -1751,7 +1760,10 @@ def itakura_mask(sz1, sz2, max_slope=2.0, be=None):
            [False, False, False,  True,  True, False],
            [False, False, False, False, False,  True]])
     """
-    warnings.warn("This method is deprecated, use tslearn.metrics._masks.itakura_mask instead.", DeprecationWarning)
+    warnings.warn(
+        "This method is deprecated, use tslearn.metrics.itakura_mask instead.",
+        DeprecationWarning
+    )
 
     be = instantiate_backend(be)
 
@@ -1820,7 +1832,10 @@ def compute_mask(
     mask : array-like, shape=(sz1, sz2)
         Constraint region.
     """
-    warnings.warn("This method is deprecated, use tslearn.metrics._masks.compute_mask instead.", DeprecationWarning)
+    warnings.warn(
+        "This method is deprecated, use tslearn.metrics.compute_mask instead.",
+        DeprecationWarning
+    )
 
     be = instantiate_backend(be, s1, s2)
     # The output mask will be of shape (sz1, sz2)
@@ -1975,7 +1990,10 @@ def cdist_dtw(
            spoken word recognition," IEEE Transactions on Acoustics, Speech and
            Signal Processing, vol. 26(1), pp. 43--49, 1978.
     """  # noqa: E501
-    warnings.warn("This method is deprecated, use tslearn.metrics._dtw.cdist_dtw instead.", DeprecationWarning)
+    warnings.warn(
+        "This method is deprecated, use tslearn.metrics.cdist_dtw instead.",
+        DeprecationWarning
+    )
 
     be = instantiate_backend(be, dataset1, dataset2)
     return _cdist_generic(

--- a/tslearn/metrics/dtw_variants.py
+++ b/tslearn/metrics/dtw_variants.py
@@ -1630,25 +1630,6 @@ def _njit_itakura_mask(sz1, sz2, max_slope=2.0):
     mask = numpy.full((sz1, sz2), False)
     for i in prange(sz2):
         mask[int(lower_bound_[i]) : int(upper_bound_[i]), i] = True
-
-    # Post-check
-    raise_warning = False
-    for i in range(sz1):
-        if not numpy.any(mask[i]):
-            raise_warning = True
-            break
-    if not raise_warning:
-        for j in range(sz2):
-            if not numpy.any(mask[:, j]):
-                raise_warning = True
-                break
-    if raise_warning:
-        raise RuntimeWarning(
-            "'itakura_max_slope' constraint is unfeasible "
-            "(ie. leads to no admissible path) for the "
-            "provided time series sizes",
-        )
-
     return mask
 
 
@@ -1706,23 +1687,6 @@ def _itakura_mask(sz1, sz2, max_slope=2.0, be=None):
     mask = be.full((sz1, sz2), False)
     for i in range(sz2):
         mask[int(lower_bound_[i]) : int(upper_bound_[i]), i] = True
-    # Post-check
-    raise_warning = False
-    for i in range(sz1):
-        if not be.any(mask[i]):
-            raise_warning = True
-            break
-    if not raise_warning:
-        for j in range(sz2):
-            if not be.any(mask[:, j]):
-                raise_warning = True
-                break
-    if raise_warning:
-        raise RuntimeWarning(
-            "'itakura_max_slope' constraint is unfeasible "
-            "(ie. leads to no admissible path) for the "
-            "provided time series sizes",
-        )
     return mask
 
 
@@ -1771,6 +1735,25 @@ def itakura_mask(sz1, sz2, max_slope=2.0, be=None):
         mask = _njit_itakura_mask(sz1, sz2, max_slope=max_slope)
     else:
         mask = _itakura_mask(sz1, sz2, max_slope=max_slope, be=be)
+
+    # Post-check
+    raise_warning = False
+    for i in range(sz1):
+        if not be.any(be.isfinite(mask[i])):
+            raise_warning = True
+            break
+    if not raise_warning:
+        for j in range(sz2):
+            if not be.any(be.isfinite(mask[:, j])):
+                raise_warning = True
+                break
+    if raise_warning:
+        warnings.warn(
+            "'itakura_max_slope' constraint is unfeasible "
+            "(ie. leads to no admissible path) for the "
+            "provided time series sizes",
+            RuntimeWarning,
+        )
 
     return mask
 

--- a/tslearn/metrics/dtw_variants.py
+++ b/tslearn/metrics/dtw_variants.py
@@ -80,7 +80,7 @@ def njit_accumulated_matrix(s1, s2, mask):
     s2 : array-like, shape=(sz2, d)
         Second time series.
     mask : array-like, shape=(sz1, sz2)
-        Mask. Unconsidered cells must have infinite values.
+        Mask. Unconsidered cells must have False values.
 
     Returns
     -------
@@ -112,7 +112,7 @@ def accumulated_matrix(s1, s2, mask, be=None):
     s2 : array-like, shape=(sz2, d)
         Second time series.
     mask : array-like, shape=(sz1, sz2)
-        Mask. Unconsidered cells must have infinite values.
+        Mask. Unconsidered cells must have False values.
     be : Backend object or string or None
         Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
         the NumPy backend is used.
@@ -157,7 +157,7 @@ def _njit_dtw(s1, s2, mask):
     s2 : array-like, shape=(sz2, d)
         Second time series.
     mask : array-like, shape=(sz1, sz2)
-        Mask. Unconsidered cells must have infinite values.
+        Mask. Unconsidered cells must have False values.
 
     Returns
     -------
@@ -179,7 +179,7 @@ def _dtw(s1, s2, mask, be=None):
     s2 : array-like, shape=(sz2, d)
         Second time series.
     mask : array-like, shape=(sz1, sz2)
-        Mask. Unconsidered cells must have infinite values.
+        Mask. Unconsidered cells must have False values.
     be : Backend object or string or None
         Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
         the NumPy backend is used.
@@ -425,7 +425,7 @@ def njit_accumulated_matrix_from_dist_matrix(dist_matrix, mask):
     dist_matrix : array-like, shape=(sz1, sz2)
         Array containing the pairwise distances.
     mask : array-like, shape=(sz1, sz2)
-        Mask. Unconsidered cells must have infinite values.
+        Mask. Unconsidered cells must have False values.
 
     Returns
     -------
@@ -455,7 +455,7 @@ def accumulated_matrix_from_dist_matrix(dist_matrix, mask, be=None):
     dist_matrix : array-like, shape=(sz1, sz2)
         Array containing the pairwise distances.
     mask : array-like, shape=(sz1, sz2)
-        Mask. Unconsidered cells must have infinite values.
+        Mask. Unconsidered cells must have False values.
     be : Backend object or string or None
         Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
         the NumPy backend is used.
@@ -2231,7 +2231,7 @@ def njit_lcss_accumulated_matrix(s1, s2, eps, mask):
     eps : float
         Matching threshold.
     mask : array-like, shape=(sz1, sz2)
-        Mask. Unconsidered cells must have infinite values.
+        Mask. Unconsidered cells must have False values.
         
     Returns
     -------
@@ -2268,7 +2268,7 @@ def lcss_accumulated_matrix(s1, s2, eps, mask, be=None):
     eps : float
         Matching threshold.
     mask : array-like, shape=(sz1, sz2)
-        Mask. Unconsidered cells must have infinite values.
+        Mask. Unconsidered cells must have False values.
     be : Backend object or string or None
         Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
         the NumPy backend is used.
@@ -2321,7 +2321,7 @@ def _njit_lcss(s1, s2, eps, mask):
     eps : float (default: 1.)
         Maximum matching distance threshold.
     mask : array-like, shape=(sz1, sz2)
-        Mask. Unconsidered cells must have infinite values.
+        Mask. Unconsidered cells must have False values.
 
     Returns
     -------
@@ -2347,7 +2347,7 @@ def _lcss(s1, s2, eps, mask, be=None):
     eps : float (default: 1.)
         Maximum matching distance threshold.
     mask : array-like, shape=(sz1, sz2)
-        Mask. Unconsidered cells must have infinite values.
+        Mask. Unconsidered cells must have False values.
     be : Backend object or string or None
         Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
         the NumPy backend is used.
@@ -2502,7 +2502,7 @@ def _njit_return_lcss_path(s1, s2, eps, mask, acc_cost_mat, sz1, sz2):
     eps : float
         Maximum matching distance threshold.
     mask : array-like, shape=(sz1, sz2)
-        Mask. Unconsidered cells must have infinite values.
+        Mask. Unconsidered cells must have False values.
     acc_cost_mat : array-like, shape=(sz1 + 1, sz2 + 1)
         Accumulated cost matrix.
     sz1 : int
@@ -2543,7 +2543,7 @@ def _return_lcss_path(s1, s2, eps, mask, acc_cost_mat, sz1, sz2, be=None):
     eps : float
         Maximum matching distance threshold.
     mask : array-like, shape=(sz1, sz2)
-        Mask. Unconsidered cells must have infinite values.
+        Mask. Unconsidered cells must have False values.
     acc_cost_mat : array-like, shape=(sz1 + 1, sz2 + 1)
         Accumulated cost matrix.
     sz1 : int
@@ -2601,7 +2601,7 @@ def _njit_return_lcss_path_from_dist_matrix(
     eps : float
         Maximum matching distance threshold.
     mask : array-like, shape=(sz1, sz2)
-        Mask. Unconsidered cells must have infinite values.
+        Mask. Unconsidered cells must have False values.
     acc_cost_mat : array-like, shape=(sz1 + 1, sz2 + 1)
         Accumulated cost matrix.
     sz1 : int
@@ -2644,7 +2644,7 @@ def _return_lcss_path_from_dist_matrix(
     eps : float
         Maximum matching distance threshold.
     mask : array-like, shape=(sz1, sz2)
-        Mask. Unconsidered cells must have infinite values.
+        Mask. Unconsidered cells must have False values.
     acc_cost_mat : array-like, shape=(sz1 + 1, sz2 + 1)
         Accumulated cost matrix.
     sz1 : int
@@ -2829,7 +2829,7 @@ def njit_lcss_accumulated_matrix_from_dist_matrix(dist_matrix, eps, mask):
     eps : float (default: 1.)
         Maximum matching distance threshold.
     mask : array-like, shape=(sz1, sz2)
-        Mask. Unconsidered cells must have infinite values.
+        Mask. Unconsidered cells must have False values.
 
     Returns
     -------
@@ -2863,7 +2863,7 @@ def lcss_accumulated_matrix_from_dist_matrix(dist_matrix, eps, mask, be=None):
     eps : float (default: 1.)
         Maximum matching distance threshold.
     mask : array-like, shape=(sz1, sz2)
-        Mask. Unconsidered cells must have infinite values.
+        Mask. Unconsidered cells must have False values.
     be : Backend object or string or None
         Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
         the NumPy backend is used.

--- a/tslearn/metrics/frechet.py
+++ b/tslearn/metrics/frechet.py
@@ -170,7 +170,7 @@ def _frechet(
 
     else:
         s1 = backend.array(s1)
-        s2 = s1
+        s2 = s1.T
 
     mask = compute_mask(
         s1,

--- a/tslearn/metrics/softdtw_variants.py
+++ b/tslearn/metrics/softdtw_variants.py
@@ -14,7 +14,7 @@ from tslearn.utils import (
     ts_size,
 )
 
-from .dtw_variants import dtw, dtw_path
+from ._dtw import dtw, dtw_path
 from .soft_dtw_fast import (
     _jacobian_product_sq_euc,
     _njit_jacobian_product_sq_euc,

--- a/tslearn/metrics/utils.py
+++ b/tslearn/metrics/utils.py
@@ -19,12 +19,12 @@ def accumulated_matrix(s1, s2, mask, be=None):
 
     Parameters
     ----------
-    s1 : array-like, shape=(sz1, d)
+    s1 : array-like, shape=(sz1,) or (sz1, d)
         First time series.
-    s2 : array-like, shape=(sz2, d)
+    s2 : array-like, shape=(sz2,) or (sz2, d)
         Second time series.
     mask : array-like, shape=(sz1, sz2)
-        Mask. Unconsidered cells must have infinite values.
+        Mask used to constrain the region of computation. Unconsidered cells must have False values.
     be : Backend object or string or None
         Backend. If `be` is an instance of the class `NumPyBackend` or the string `"numpy"`,
         the NumPy backend is used.
@@ -36,7 +36,7 @@ def accumulated_matrix(s1, s2, mask, be=None):
     Returns
     -------
     mat : array-like, shape=(sz1, sz2)
-        Accumulated cost matrix.
+        Accumulated cost matrix. Non computed cells due to masking have infinite value.
     """
     be = instantiate_backend(be, s1, s2)
     s1 = to_time_series(s1, be=be)


### PR DESCRIPTION
Masks use boolean values for memory performance. 
Refactor DTW cross distance computation to ensure full NUMBA jitted code for DTW computation with numpy backend.
Refactor DBA Petitjean computation to benefit from njited DTW path computation.
Switch to DBA Petitjean for barycenter computation in TimeSeriesKMeans because it is generally faster.
Rearrange code base and deprecate rewritten code.
Tests
Docs
