### PR TITLE
Bump numba min version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "scikit-learn>=1.4",
     "numpy>=1.24.3",
     "scipy>=1.10.1",
-    "numba>=0.58.1",
+    "numba>=0.61",
     "joblib>=1.2"
 ]
 


### PR DESCRIPTION
Seems like version 0.60.0 is not compatible with tslearn code anymore, notably on mask computation.