### PR TITLE
Support variable-lenght time series in scalers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ Changelogs for this project are recorded in this file since v0.2.0.
 
 ## [Towards v0.9.0]
 
-# Nothing yet
+### Changed
+
+* `TimeSeriesScalerMinMax` and `TimeSeriesScalerMeanVariance` now support variable length timeseries. 
 
 ## [v0.8.0]
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -2,7 +2,6 @@ import numpy as np
 
 import pytest
 
-from tslearn.bases.bases import ALLOW_VARIABLE_LENGTH
 from tslearn.preprocessing import (TimeSeriesScalerMeanVariance,
                                    TimeSeriesScalerMinMax,
                                    TimeSeriesImputer)
@@ -20,27 +19,26 @@ def test_single_value_ts_no_nan():
     assert np.sum(np.isnan(minmax_scaler.fit_transform(X))) == 0
 
 
-def test_scaler_allow_variable_length():
-    variable_length_dataset = [[1, 2], [1, 2, 3]]
+def test_min_max_scaler_variable_length():
+    X = [
+        [1, np.nan],
+        [3, 4]
+    ]
 
-    for estimator_cls in [TimeSeriesScalerMeanVariance, TimeSeriesScalerMinMax]:
-        estimator = estimator_cls()
-
-        try:
-            # slearn >= 1.6
-            from sklearn.utils import get_tags
-            tags = get_tags(estimator)
-            assert not tags.allow_variable_length
-
-        except ImportError:
-            # slearn < 1.6
-            tags = estimator._get_tags()
-            assert ALLOW_VARIABLE_LENGTH in tags
-            assert not tags[ALLOW_VARIABLE_LENGTH]
-
-        with pytest.raises(ValueError):
-            estimator.fit_transform(variable_length_dataset)
-
+    estimator = TimeSeriesScalerMinMax(per_timeseries=True)
+    transformed = estimator.fit_transform(X)
+    np.testing.assert_array_equal(
+        transformed,
+        np.array([
+            [[0], [np.nan]],
+            [[0], [1]],
+        ])
+    )
+    transformed = estimator.transform([[1, 2, 3]])
+    np.testing.assert_array_equal(
+        transformed,
+        np.array([[[0], [0.5], [1]]])
+    )
 
 def test_min_max_scaler_modes():
     univariate_dataset = [
@@ -124,6 +122,28 @@ def test_min_max_scaler_modes():
             [[0], [0.25], [0.5]],
             [[0.5], [0.75], [1]],
         ])
+    )
+
+
+def test_mean_variance_scaler_variable_length():
+    X = [
+        [1, np.nan],
+        [3, 4]
+    ]
+
+    estimator = TimeSeriesScalerMeanVariance(per_timeseries=True)
+    transformed = estimator.fit_transform(X)
+    np.testing.assert_array_equal(
+        transformed,
+        np.array([
+            [[0], [np.nan]],
+            [[-1], [1]],
+        ])
+    )
+    transformed = estimator.transform([[1, 2, 3]])
+    np.testing.assert_array_equal(
+        transformed,
+        np.array([[[-np.sqrt(3/2)], [0], [np.sqrt(3/2)]]])
     )
 
 

--- a/tests/test_variablelength.py
+++ b/tests/test_variablelength.py
@@ -2,10 +2,15 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_array_less
 from sklearn.model_selection import cross_val_score, KFold
 
-from tslearn.neighbors import KNeighborsTimeSeriesClassifier
-from tslearn.preprocessing import TimeSeriesScalerMeanVariance
-from tslearn.svm import TimeSeriesSVC, TimeSeriesSVR
 from tslearn.clustering import KernelKMeans, TimeSeriesKMeans
+from tslearn.neighbors import KNeighborsTimeSeriesClassifier
+from tslearn.preprocessing import (
+    TimeSeriesImputer,
+    TimeSeriesResampler,
+    TimeSeriesScalerMeanVariance,
+    TimeSeriesScalerMinMax
+)
+from tslearn.svm import TimeSeriesSVC, TimeSeriesSVR
 from tslearn.utils import to_time_series_dataset
 
 __author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
@@ -33,6 +38,7 @@ def test_variable_length_knn():
     clf.fit(X_transf, y)
     assert_allclose(clf.predict(X_transf), [0, 0, 1, 1])
 
+
 def test_variable_length_svm():
     X = to_time_series_dataset([[1, 2, 3, 4],
                                 [1, 2, 3],
@@ -49,6 +55,7 @@ def test_variable_length_svm():
     clf.fit(X, y_reg)
     assert_array_less(clf.predict(X[:2]), 0.)
     assert_array_less(-clf.predict(X[2:]), 0.)
+
 
 def test_variable_length_clustering():
     # TODO: here we just check that they can accept variable-length TS, not
@@ -92,3 +99,25 @@ def test_variable_cross_val():
         # TODO: cannot test for clustering methods since they don't have a
         # score method yet
         cross_val_score(estimator, X=X, y=y, cv=cv)
+
+
+def test_variable_length_preprocessing():
+    # Just check that they can accept variable-length TS
+    X = to_time_series_dataset([
+        [1, 2, 3, 4],
+        [1, 2, 3],
+        [2, 5, 6, 7, 8, 9],
+        [3, 5, 6, 7, 8]]
+    )
+    other_X = to_time_series_dataset([
+        [1, 2, 3],
+        [3, 5, 6, 7, 8]
+    ])
+    estimators = [
+        TimeSeriesResampler(),
+        TimeSeriesImputer(),
+        TimeSeriesScalerMeanVariance(),
+        TimeSeriesScalerMinMax()
+    ]
+    for estimator in estimators:
+        estimator.fit(X).transform(other_X)

--- a/tslearn/preprocessing/preprocessing.py
+++ b/tslearn/preprocessing/preprocessing.py
@@ -155,8 +155,6 @@ class TimeSeriesScalerMinMax(TimeSeriesMixin, TransformerMixin, BaseEstimator):
 
     Notes
     -----
-        This method requires a dataset of equal-sized time series.
-
         NaNs within a time series are ignored when calculating min and max.
 
     Examples
@@ -242,7 +240,7 @@ class TimeSeriesScalerMinMax(TimeSeriesMixin, TransformerMixin, BaseEstimator):
         check_is_fitted(self, '_X_fit_dims')
         X_ = check_array(X, allow_nd=True, force_all_finite=False)
         X_ = to_time_series_dataset(X_)
-        X_ = check_dims(X_, X_fit_dims=self._X_fit_dims, extend=False)
+        X_ = check_dims(X_, X_fit_dims=self._X_fit_dims, check_n_features_only=True, extend=False)
 
         axis = (1,)
         if not self.per_feature:
@@ -261,12 +259,13 @@ class TimeSeriesScalerMinMax(TimeSeriesMixin, TransformerMixin, BaseEstimator):
 
     def _more_tags(self):
         tags = super()._more_tags()
-        tags.update({'allow_nan': True})
+        tags.update({'allow_nan': True, ALLOW_VARIABLE_LENGTH: True})
         return tags
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = True
+        tags.allow_variable_length = True
         return tags
 
 
@@ -288,8 +287,6 @@ class TimeSeriesScalerMeanVariance(TimeSeriesMixin, TransformerMixin, BaseEstima
 
     Notes
     -----
-        This method requires a dataset of equal-sized time series.
-
         NaNs within a time series are ignored when calculating mu and std.
 
     Examples
@@ -369,7 +366,7 @@ class TimeSeriesScalerMeanVariance(TimeSeriesMixin, TransformerMixin, BaseEstima
         check_is_fitted(self, '_X_fit_dims')
         X_ = check_array(X, allow_nd=True, force_all_finite=False)
         X_ = to_time_series_dataset(X_)
-        X_ = check_dims(X_, X_fit_dims=self._X_fit_dims, extend=False)
+        X_ = check_dims(X_, X_fit_dims=self._X_fit_dims, check_n_features_only=True, extend=False)
 
         axis = (1,)
         if not self.per_timeseries:
@@ -386,12 +383,13 @@ class TimeSeriesScalerMeanVariance(TimeSeriesMixin, TransformerMixin, BaseEstima
 
     def _more_tags(self):
         tags = super()._more_tags()
-        tags.update({'allow_nan': True})
+        tags.update({'allow_nan': True, ALLOW_VARIABLE_LENGTH: True})
         return tags
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = True
+        tags.allow_variable_length = True
         return tags
 
 


### PR DESCRIPTION
`TimeSeriesScalerMinMax` and `TimeSeriesScalerMeanVariance` now support variable length timeseries. Previously `fit` and `transform` required inputs with the same effective (after to_time_series_dataset is applied to the inputs) second dimension (number of sample per time series) even though nan values were properly handled. This PR just removes the check done on second dimension on `transform`.