### PR TITLE
Fixes LearningShapelets masking issue with Keras 3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ Changelogs for this project are recorded in this file since v0.2.0.
 
 ## [Towards v0.9.0]
 
-### Nothing yet
+### Changed
+
+* Fix masking issue in `LearningShapelets` with Keras 3.14
 
 ## [v0.8.1]
 

--- a/tslearn/shapelets/shapelets.py
+++ b/tslearn/shapelets/shapelets.py
@@ -9,8 +9,7 @@ from keras.layers import (
     Dense,
     Layer,
     Input,
-    concatenate,
-    Masking
+    concatenate
 )
 from keras.metrics import (
     categorical_accuracy,
@@ -64,7 +63,7 @@ def _kmeans_init_shapelets(X, n_shapelets, shp_len, n_draw=10000):
 
 
 @register_keras_serializable()
-class GlobalMinPooling1D(Masking):
+class GlobalMinPooling1D(Layer):
     """Global min pooling operation for temporal data.
     # Input shape
         3D tensor with shape: `(batch_size, steps, features)`.
@@ -95,7 +94,7 @@ class GlobalMinPooling1D(Masking):
 
 
 @register_keras_serializable()
-class GlobalArgminPooling1D(Masking):
+class GlobalArgminPooling1D(Layer):
     """Global argmin pooling operation for temporal data.
     # Input shape
         3D tensor with shape: `(batch_size, steps, features)`.


### PR DESCRIPTION
After https://github.com/keras-team/keras/pull/21946, mask is unproperly propagated to dense layer. No need to propagate the mask, as it is handled in GlobalMinPooling1D and GlobalArgminPooling1D