### PR TITLE
docs: add MacOS SSL certificate note to datasets module

### DIFF
--- a/tslearn/datasets/__init__.py
+++ b/tslearn/datasets/__init__.py
@@ -1,6 +1,17 @@
 """
 The :mod:`tslearn.datasets` module provides simplified access to standard time
 series datasets.
+
+.. note::
+    **MacOS users:** If you encounter SSL certificate errors when downloading
+    datasets, you may need to install certificates for your Python
+    installation. Run the following command::
+
+        /Applications/Python<VERSION>/Install\ Certificates.command
+
+    Alternatively, install the ``certifi`` package::
+
+        pip install certifi
 """
 
 from .datasets import extract_from_zip_url, in_file_string_replace


### PR DESCRIPTION
## Summary

Adds a note to the `tslearn.datasets` module docstring about SSL certificate errors on MacOS. Users who encounter download failures can fix it by running the Install Certificates command or installing `certifi`.

## Changes

- `tslearn/datasets/__init__.py`: Added a Sphinx `.. note::` directive to the module docstring with the MacOS workaround.

Fixes #396

This contribution was developed with AI assistance (Claude Code).