### PR TITLE
Fixes #659:  TimeSeriesImputer keep_trailing_nans = False crashes if there are trailing NANs in all TS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Changelogs for this project are recorded in this file since v0.2.0.
 ### Changed
 
 * Fix masking issue in `LearningShapelets` with Keras 3.14
+* Fix imputer crash ([#659](https://github.com/tslearn-team/tslearn/issues/659))
 
 ## [v0.8.1]
 

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -184,8 +184,7 @@ try:
             "check_sample_weight_equivalence_on_dense_data": "zero sample_weight is not equivalent to removing samples",
         },
         'SymbolicAggregateApproximation': {"check_transformer_preserve_dtypes": "Forces int transform"},
-        'OneD_SymbolicAggregateApproximation': {"check_transformer_preserve_dtypes": "Forces int transform"},
-        'TimeSeriesImputer': {"check_transformer_data_not_an_array": "Uses X"}
+        'OneD_SymbolicAggregateApproximation': {"check_transformer_preserve_dtypes": "Forces int transform"}
     }
 
     def get_expected_fails(estimator):

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -248,15 +248,18 @@ def test_imputer():
         [1, 2, np.nan, 9]
     ]
 
-    # Test default params and equivalent mean method
-    imputer = TimeSeriesImputer()
+    # Default method is mean
+    imputer = TimeSeriesImputer(keep_trailing_nans=True)
     transformed = imputer.fit_transform(multivariate_dataset)
     expected = np.array([
         [[1, 2], [2, 3], [2, 2.5]],
         [[3, 4], [3, 5], [np.nan, np.nan]],
     ])
     np.testing.assert_array_equal(transformed, expected)
-    transformed = TimeSeriesImputer(method="mean").fit_transform(multivariate_dataset)
+    transformed = TimeSeriesImputer(
+        method="mean",
+        keep_trailing_nans=True
+    ).fit_transform(multivariate_dataset)
     np.testing.assert_array_equal(transformed, expected)
     transformed = imputer.fit_transform(univariate_dataset)
     expected = np.array([
@@ -264,7 +267,10 @@ def test_imputer():
         [[1], [2], [4], [9]],
     ])
     np.testing.assert_array_equal(transformed, expected)
-    transformed = TimeSeriesImputer(method="mean").fit_transform(univariate_dataset)
+    transformed = TimeSeriesImputer(
+        method="mean",
+        keep_trailing_nans=True
+    ).fit_transform(univariate_dataset)
     np.testing.assert_array_equal(transformed, expected)
 
     # Test median method
@@ -300,11 +306,13 @@ def test_imputer():
     ])
     np.testing.assert_array_equal(transformed, expected)
     transformed = imputer.fit_transform(univariate_dataset)
-    expected = np.array([
-        [[1], [1], [1], [3], [6], [6], [9] ],
-        [[1], [2], [2], [9], [np.nan], [np.nan], [np.nan] ],
-        [[np.nan], [2], [2], [9], [6], [6], [np.nan]],
-    ])
+    expected = np.array(
+        [
+            [[1], [1], [1], [3], [6], [6], [9]],
+            [[1], [2], [2], [9], [np.nan], [np.nan], [np.nan]],
+            [[np.nan], [2], [2], [9], [6], [np.nan], [np.nan]],
+        ]
+    )
     np.testing.assert_array_equal(transformed, expected)
 
     # Test bfill method
@@ -340,7 +348,7 @@ def test_imputer():
         [[np.nan], [2], [np.nan], [9], [6], [np.nan], [np.nan]],
     ])
     np.testing.assert_array_equal(transformed, expected)
-    value=42.42
+    value = 42.42
     imputer.set_params(value=value)
     transformed = imputer.fit_transform(multivariate_dataset)
     expected = np.array([
@@ -349,11 +357,13 @@ def test_imputer():
     ])
     np.testing.assert_array_equal(transformed, expected)
     transformed = imputer.fit_transform(univariate_dataset)
-    expected = np.array([
-        [[1], [value], [value], [3], [6], [value], [9]],
-        [[1], [2], [value], [9], [np.nan], [np.nan], [np.nan]],
-        [[value], [2], [value], [9], [6], [value], [np.nan]],
-    ])
+    expected = np.array(
+        [
+            [[1], [value], [value], [3], [6], [value], [9]],
+            [[1], [2], [value], [9], [np.nan], [np.nan], [np.nan]],
+            [[value], [2], [value], [9], [6], [np.nan], [np.nan]],
+        ]
+    )
     np.testing.assert_array_equal(transformed, expected)
 
     imputer.set_params(method="linear")
@@ -367,11 +377,13 @@ def test_imputer():
         [np.nan, 2, np.nan, 9, 6, np.nan],
     ]
     transformed = imputer.fit_transform(univariate_dataset)
-    expected = np.array([
-        [[1], [5/3], [7/3], [3], [6], [7.5], [9]],
-        [[1], [2], [5.5], [9], [np.nan], [np.nan], [np.nan]],
-        [[2], [2], [5.5], [9], [6], [6], [np.nan]],
-    ])
+    expected = np.array(
+        [
+            [[1], [5 / 3], [7 / 3], [3], [6], [7.5], [9]],
+            [[1], [2], [5.5], [9], [np.nan], [np.nan], [np.nan]],
+            [[2], [2], [5.5], [9], [6], [np.nan], [np.nan]],
+        ]
+    )
     np.testing.assert_array_almost_equal(transformed, expected)
     transformed = imputer.fit_transform(multivariate_dataset)
     expected = np.array([
@@ -389,19 +401,30 @@ def test_imputer():
         [1, 2, np.nan, 9],
         [np.nan, 2, np.nan, 9, 6, np.nan],
     ]
-    imputer.set_params(method="constant", keep_trailing_nans=True)
+    imputer.set_params(method="constant", keep_trailing_nans=False)
     transformed = imputer.fit_transform(multivariate_dataset)
-    expected = np.array([
-        [[1, value], [2, 3], [2, value]],
-        [[3, 4], [value, 5], [np.nan, np.nan]],
-    ])
+    expected = np.array(
+        [
+            [[1, value], [2, 3], [2, value]],
+            [[3, 4], [value, 5], [value, value]],
+        ]
+    )
     np.testing.assert_array_equal(transformed, expected)
     transformed = imputer.fit_transform(univariate_dataset)
-    expected = np.array([
-        [[1], [value], [value], [3], [6], [value], [9]],
-        [[1], [2], [value], [9], [np.nan], [np.nan], [np.nan]],
-        [[value], [2], [value], [9], [6], [np.nan], [np.nan]],
-    ])
+    expected = np.array(
+        [
+            [[1], [value], [value], [3], [6], [value], [9]],
+            [[1], [2], [value], [9], [value], [value], [value]],
+            [[value], [2], [value], [9], [6], [value], [value]],
+        ]
+    )
+    np.testing.assert_array_equal(transformed, expected)
+
+    transformed = imputer.fit_transform([[1, np.nan]])
+    expected = np.array([[[1.0]]])
+    np.testing.assert_array_equal(transformed, expected)
+    imputer.set_params(keep_trailing_nans=True)
+    transformed = imputer.fit_transform([[1, np.nan]])
     np.testing.assert_array_equal(transformed, expected)
 
     imputer.set_params(method=lambda x: to_time_series([1, 2, 3]))

--- a/tslearn/preprocessing/preprocessing.py
+++ b/tslearn/preprocessing/preprocessing.py
@@ -11,7 +11,6 @@ from tslearn.bases.bases import ALLOW_VARIABLE_LENGTH
 from tslearn.utils import (
     check_variable_length_input,
     to_time_series_dataset,
-    to_time_series,
     check_array,
     check_dims
 )
@@ -611,11 +610,13 @@ class TimeSeriesImputer(TimeSeriesMixin, TransformerMixin, BaseEstimator):
             raise ValueError("Imputer {} not implemented.".format(self.method))
 
         for ts_index in range(X_.shape[0]):
-            ts = to_time_series(X[ts_index])
-            stop_index = ts.shape[0]
+            ts = X_[ts_index]
             if self.keep_trailing_nans:
                 stop_index = _ts_size(ts)
-            X_[ts_index, :stop_index] = imputer(ts[:stop_index])
+                X_[ts_index, :stop_index] = imputer(ts[:stop_index])
+            else:
+                X_[ts_index] = imputer(ts)
+
         return to_time_series_dataset(X_)
 
     def _more_tags(self):
@@ -623,9 +624,6 @@ class TimeSeriesImputer(TimeSeriesMixin, TransformerMixin, BaseEstimator):
         tags.update({
             'allow_nan': True,
             ALLOW_VARIABLE_LENGTH: True,
-        })
-        tags['_xfail_checks'].update({
-            "check_transformer_data_not_an_array": "Uses X"
         })
         return tags
 

--- a/tslearn/preprocessing/preprocessing.py
+++ b/tslearn/preprocessing/preprocessing.py
@@ -429,10 +429,10 @@ class TimeSeriesImputer(TimeSeriesMixin, TransformerMixin, BaseEstimator):
     value: float (default: nan)
         The value to replace missing values with. Only used when method is
         `constant`.
-    keep_trailing_nans: bool (default: False)
+    keep_trailing_nans: bool (default: True)
         Whether trailing samples with nans on all dimensions should be considered
         padding for variable length time series and kept unprocessed. When set to
-        `True`, trailing 'empty' samples  will not be imputed.
+        `False` , trailing 'empty' samples  will be imputed.
 
     Notes
     -----
@@ -474,7 +474,7 @@ class TimeSeriesImputer(TimeSeriesMixin, TransformerMixin, BaseEstimator):
     def __init__(self,
                  method: Union[str, Callable]="mean",
                  value:  Optional[float]=nan,
-                 keep_trailing_nans: bool = False):
+                 keep_trailing_nans: bool = True):
         self.method = method
         self.value = value
         self.keep_trailing_nans = keep_trailing_nans

--- a/tslearn/preprocessing/preprocessing.py
+++ b/tslearn/preprocessing/preprocessing.py
@@ -456,15 +456,15 @@ class TimeSeriesImputer(TimeSeriesMixin, TransformerMixin, BaseEstimator):
            [[3. ],
             [3. ],
             [nan]]])
-    >>> # Trailing empty samples are preserved with `keep_trailing_nans`
-    >>> TimeSeriesImputer('ffill', keep_trailing_nans=True).fit_transform(
+    >>> # Process trailing empty samples
+    >>> TimeSeriesImputer('ffill', keep_trailing_nans=False).fit_transform(
     ... [[[1, 2], [2, numpy.nan]], [[3, 4], [numpy.nan, numpy.nan]]]
     ... )
-    array([[[ 1.,  2.],
-            [ 2.,  2.]],
+    array([[[1., 2.],
+            [2., 2.]],
     <BLANKLINE>
-           [[ 3.,  4.],
-            [nan, nan]]])
+           [[3., 4.],
+            [3., 4.]]])
     >>> # Uncomputable values are left unchanged
     >>> TimeSeriesImputer('ffill').fit_transform([[numpy.nan, 3, 6]])
     array([[[nan],


### PR DESCRIPTION
Uses formatted dataset for TS size computation rather than the inputted data.