### PR TITLE
[MRG] Early classif streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelogs for this project are recorded in this file since v0.2.0.
 ### Added
 
 * Allow parallel computation of DTW barycenters and plug it in `TimeSeriesKMeans`.
+* NonMyopicEarlyClassifier can now be used with yet incomplete series to retrieve optimal classification timing.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Changelogs for this project are recorded in this file since v0.2.0.
 ### Added
 
 * Allow parallel computation of DTW barycenters and plug it in `TimeSeriesKMeans`.
-* NonMyopicEarlyClassifier can now be used with yet incomplete series to retrieve optimal classification timing.
+* `NonMyopicEarlyClassifier` can now be used with yet incomplete series or streamed inputs 
+to retrieve optimal classification timing.
 
 ### Changed
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,6 +83,7 @@ sphinx_gallery_conf = {
                          "examples/autodiff", "examples/misc"].index,
     'within_subsection_order': "FileNameSortKey",
     'image_scrapers': (matplotlib_svg_scraper,),
+    'matplotlib_animations': True,
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/examples/classification/plot_early_classification.py
+++ b/docs/examples/classification/plot_early_classification.py
@@ -109,7 +109,29 @@ plt.show()
 ##############################################################################
 # Streaming inputs
 # ----------------
-# Analysing early classification of a time series over time.
+# Let's focus on analyzing early classification of a time series acquired sequentially over time.
+#
+# For each incoming timestamp :math:`t`, the following figure displays data-dependant computations of:
+#
+# * the clustering probabilities :math:`P(C_k | \mathbf{x}_{\rightarrow t})`
+# * the expected cost for all future times :math:`t + \tau`
+#   with :math:`\tau \geq 0`:
+#
+#   .. math::
+#
+#     f_\tau(\mathbf{x}_{\rightarrow t}, y) =
+#         \sum_k \left[ P(C_k | \mathbf{x}_{\rightarrow t})
+#         \sum_i \left( P(y=i | C_k)
+#         \left( \sum_{j \neq i} P_{t+\tau}(\hat{y} = j | y=i, C_k)
+#         \right) \right)
+#         \right]
+#         + \alpha t
+#
+# as described in :ref:`our User Guide section dedicated to early classification <early>`.
+#
+# The estimated optimal :math:`\tau` is derived at each timestamp from minimizing the expected costs.
+#
+# In this exemple, the `NonMyopicEarlyClassifier` recommends a classification decision as early as :math:`t=12`.
 
 ts_index = 1
 sz = X_test.shape[1]

--- a/docs/examples/classification/plot_early_classification.py
+++ b/docs/examples/classification/plot_early_classification.py
@@ -88,7 +88,7 @@ early_clf = NonMyopicEarlyClassifier(n_clusters=3,
                                      cost_time_parameter=1e-3,
                                      lamb=1e2,
                                      random_state=0)
-early_clf = early_clf.fit(X_train, y_train)
+early_clf.fit(X_train, y_train)
 
 preds, times = early_clf.predict_class_and_earliness(X_test)
 

--- a/docs/examples/classification/plot_early_classification.py
+++ b/docs/examples/classification/plot_early_classification.py
@@ -9,6 +9,8 @@ Early classifiers are implemented in the
 :mod:`tslearn.early_classification` module and in this example 
 we use the method from [1]_.
 
+References
+----------
 
 .. [1] A. Dachraoui, A. Bondu & A. Cornuejols. Early classification of time
   series as a non myopic sequential decision making problem. ECML/PKDD 2015
@@ -18,7 +20,12 @@ we use the method from [1]_.
 # License: BSD 3 clause
 # sphinx_gallery_thumbnail_number = 2
 
+from contextlib import suppress
+
 import numpy
+
+import matplotlib.animation as animation
+import matplotlib.gridspec as gridpsec
 import matplotlib.pyplot as plt
 
 from tslearn.preprocessing import TimeSeriesScalerMeanVariance
@@ -60,9 +67,10 @@ X_test = TimeSeriesScalerMeanVariance().fit_transform(X_test)
 size = X_train.shape[1]
 n_classes = len(set(y_train))
 
-plt.figure()
+plt.figure(layout="constrained")
 for i, cl in enumerate(set(y_train)):
-    plt.subplot(n_classes, 1, i + 1)
+    ax = plt.subplot(n_classes, 1, i + 1)
+    ax.set_title(f"Class {cl}")
     for ts in X_train[y_train == cl]:
         plt.plot(ts.ravel(), color="orange" if cl > 0 else "blue", alpha=.3)
     plt.xlim(0, size - 1)
@@ -80,7 +88,7 @@ early_clf = NonMyopicEarlyClassifier(n_clusters=3,
                                      cost_time_parameter=1e-3,
                                      lamb=1e2,
                                      random_state=0)
-early_clf.fit(X_train, y_train)
+early_clf = early_clf.fit(X_train, y_train)
 
 preds, times = early_clf.predict_class_and_earliness(X_test)
 
@@ -96,6 +104,72 @@ ts_idx = 9
 t = times[ts_idx]
 plot_partial(X_test[ts_idx], t, y_test[ts_idx], preds[ts_idx], color="blue")
 plt.tight_layout()
+plt.show()
+
+##############################################################################
+# Streaming inputs
+# ----------------
+# Analysing early classification of a time series over time.
+
+ts_index = 1
+sz = X_test.shape[1]
+
+fig = plt.figure(layout="constrained", figsize=(13, 4))
+fig.suptitle(r"Optimal prediction time $\tau$ evolution")
+
+gs = gridpsec.GridSpec(2, 3, figure=fig, width_ratios=[0.15, 0.70, 0.15])
+ax1 = fig.add_subplot(gs[:, 0], title='Cluster probas')
+ax2 = fig.add_subplot(
+    gs[0, 1],
+    xlim=[0, sz],
+    ylim=[numpy.min(X_test[ts_index]),
+          numpy.max(X_test[ts_index]) * 1.1],
+    title='Streamed TS'
+)
+ax3 = fig.add_subplot(gs[1, 1], xlim=[0, sz], ylim=[0, 1], title='Expected cost')
+ax4 = fig.add_subplot(gs[:, 2], title='Predicted probas')
+
+bar1 = ax1.barh(
+    ["cluster 1", "cluster 2", "cluster 3"],
+    [1.1, 0, 0],
+)
+line1 = ax2.plot([numpy.nan], marker='.')[0]
+line2 = ax3.plot(numpy.full((sz,), numpy.nan), linestyle="--",  marker='.')[0]
+bar2 = ax4.bar(
+    ["class -1", "class 1"],
+    [1.1, 0],
+)
+
+def update(frame):
+    incoming_ts_ =  X_test[ts_index, :frame+1]
+    cluster_probas = early_clf.get_cluster_probas(incoming_ts_)
+    expected_costs = early_clf._expected_costs(incoming_ts_).reshape(-1)
+    probas, delays = early_clf.early_predict_proba(
+        numpy.expand_dims(incoming_ts_, axis=0)
+    )
+    proba, delay = probas[0], delays[0]
+
+    for i, elem in enumerate(bar1):
+        elem.set_width(cluster_probas[i])
+
+    line1.set_xdata(numpy.arange(incoming_ts_.shape[0]))
+    line1.set_ydata(incoming_ts_)
+
+    for i, elem in enumerate(bar2):
+        elem.set_height(proba[i])
+
+    with suppress(IndexError):
+        ax2.lines[1].remove()
+        ax3.lines[1].remove()
+        ax2.texts[0].remove()
+    ax2.axvline(x=frame + delay, color="k", linewidth=1.5)
+    ax3.axvline(x=frame + delay, color="k", linewidth=1.5)
+    ax2.text(x=frame + delay, y= numpy.max(X_test[ts_index])/2, s=r"$\tau$")
+    line2.set_xdata(numpy.arange(expected_costs.shape[0]) + frame)
+    line2.set_ydata(expected_costs)
+    return bar1, line1, line2, bar2
+
+ani = animation.FuncAnimation(fig=fig, func=update, frames=sz, interval=100)
 plt.show()
 
 ##############################################################################

--- a/docs/examples/classification/plot_early_classification.py
+++ b/docs/examples/classification/plot_early_classification.py
@@ -131,7 +131,7 @@ plt.show()
 #
 # The estimated optimal :math:`\tau` is derived at each timestamp from minimizing the expected costs.
 #
-# In this exemple, the `NonMyopicEarlyClassifier` recommends a classification decision as early as :math:`t=12`.
+# In this example, the `NonMyopicEarlyClassifier` recommends a classification decision as early as :math:`t=12`.
 
 ts_index = 1
 sz = X_test.shape[1]

--- a/tests/test_early_classification.py
+++ b/tests/test_early_classification.py
@@ -1,0 +1,52 @@
+import numpy as np
+
+import pytest
+
+from tslearn.early_classification import NonMyopicEarlyClassifier
+from tslearn.neighbors import KNeighborsTimeSeriesClassifier
+from tslearn.utils import to_time_series_dataset
+
+
+def test_NonMyopicEarlyClassifier():
+
+    dataset = to_time_series_dataset(
+        [
+            [1, 2, 3, 4, 5, 6],
+            [1, 2, 3, 4, 5, 6],
+            [1, 2, 3, 4, 5, 6],
+            [1, 2, 3, 3, 2, 1],
+            [1, 2, 3, 3, 2, 1],
+            [1, 2, 3, 3, 2, 1],
+            [3, 2, 1, 1, 2, 3],
+            [3, 2, 1, 1, 2, 3],
+        ]
+    )
+
+    y = [0, 0, 0, 1, 1, 1, 0, 0]
+    model = NonMyopicEarlyClassifier(
+        n_clusters=3,
+        base_classifier=KNeighborsTimeSeriesClassifier(
+            n_neighbors=1, metric="euclidean"
+        ),
+        min_t=2,
+        lamb=1000.0,
+        cost_time_parameter=0.1,
+        random_state=0,
+    )
+    assert model.classes_ is None
+    model.fit(dataset, y)
+    np.testing.assert_almost_equal(model.early_classification_cost(dataset, y), 0.35)
+
+    # Fewer timestamps than min_ts
+    pred, delays = model.early_predict(dataset[:, :1])
+    np.testing.assert_array_equal(pred, np.array([np.nan] * 8))
+    np.testing.assert_array_equal(delays, np.array([np.nan] * 8))
+
+    pred, delays = model.early_predict(dataset[:, :3])
+    np.testing.assert_array_equal(pred, np.array([0, 0, 0, 0, 0, 0, 0, 0]))
+    np.testing.assert_array_equal(delays, np.array([1, 1, 1, 1, 1, 1, 0, 0]))
+
+    # More timestamps than trained dataset
+    data = to_time_series_dataset([[1, 2, 3, 3, 2, 1, 1, 2, 3]])
+    with pytest.raises(ValueError):
+        model.early_predict(data)

--- a/tests/test_early_classification.py
+++ b/tests/test_early_classification.py
@@ -49,6 +49,20 @@ def test_NonMyopicEarlyClassifier():
     np.testing.assert_array_equal(pred, np.array([0, 0, 0, 0, 0, 0, 0, 0]))
     np.testing.assert_array_equal(delays, np.array([1, 1, 1, 1, 1, 1, 0, 0]))
 
+    pred, delays = model.early_predict_proba(dataset[:, :3])
+    np.testing.assert_array_equal(
+        pred,
+        np.array([[1.0, 0.0],
+                  [1.0, 0.0],
+                  [1.0, 0.0],
+                  [1.0, 0.0],
+                  [1.0, 0.0],
+                  [1.0, 0.0],
+                  [1.0, 0.0],
+                  [1.0, 0.0]])
+    )
+    np.testing.assert_array_equal(delays, np.array([1, 1, 1, 1, 1, 1, 0, 0]))
+
     # More timestamps than trained dataset
     data = to_time_series_dataset([[1, 2, 3, 3, 2, 1, 1, 2, 3]])
     with pytest.raises(ValueError):
@@ -57,6 +71,22 @@ def test_NonMyopicEarlyClassifier():
     data = to_time_series_dataset([[1, 2, 3, 3, 2, 1]])
     gen = model.get_early_predict_generator()
     expected_preds = np.array([[np.nan], [0], [0], [1], [1], [1]])
+    expected_delays = np.array([[np.nan], [2], [1], [0], [0], [0], [0]])
+    for i in range(data.shape[1]):
+        pred, delay = gen.send(data[:, i:i+1, :])
+        np.testing.assert_array_equal(pred, expected_preds[i])
+        np.testing.assert_array_equal(delay, expected_delays[i])
+
+    data = to_time_series_dataset([[1, 2, 3, 3, 2, 1]])
+    gen = model.get_early_predict_proba_generator()
+    expected_preds = np.array([
+        [[np.nan, np.nan]],
+        [[1.0, 0.0]],
+        [[1.0, 0.0]],
+        [[0.0, 1.0]],
+        [[0.0, 1.0]],
+        [[0.0, 1.0]]
+    ])
     expected_delays = np.array([[np.nan], [2], [1], [0], [0], [0], [0]])
     for i in range(data.shape[1]):
         pred, delay = gen.send(data[:, i:i+1, :])

--- a/tests/test_early_classification.py
+++ b/tests/test_early_classification.py
@@ -1,3 +1,6 @@
+import warnings
+from warnings import catch_warnings
+
 import numpy as np
 
 import pytest
@@ -50,3 +53,20 @@ def test_NonMyopicEarlyClassifier():
     data = to_time_series_dataset([[1, 2, 3, 3, 2, 1, 1, 2, 3]])
     with pytest.raises(ValueError):
         model.early_predict(data)
+
+    data = to_time_series_dataset([[1, 2, 3, 3, 2, 1]])
+    gen = model.get_early_predict_generator()
+    expected_preds = np.array([[np.nan], [0], [0], [1], [1], [1]])
+    expected_delays = np.array([[np.nan], [2], [1], [0], [0], [0], [0]])
+    for i in range(data.shape[1]):
+        pred, delay = gen.send(data[:, i:i+1, :])
+        np.testing.assert_array_equal(pred, expected_preds[i])
+        np.testing.assert_array_equal(delay, expected_delays[i])
+
+    # Check unproperly formatted generator input
+    with pytest.warns(RuntimeWarning):
+        gen.send(1)
+
+    # Check iteration raises after n_samples + 1
+    with pytest.raises(ValueError):
+        gen.send([[[1]]])

--- a/tslearn/early_classification/early_classification.py
+++ b/tslearn/early_classification/early_classification.py
@@ -1,15 +1,18 @@
-from sklearn.metrics import confusion_matrix, accuracy_score
-from sklearn.base import ClassifierMixin, clone, BaseEstimator
-from sklearn.model_selection import train_test_split
+import warnings
+
 import numpy as np
+
 from scipy.sparse import coo_matrix
 
+from sklearn.base import ClassifierMixin, clone, BaseEstimator
+from sklearn.metrics import confusion_matrix, accuracy_score
+from sklearn.model_selection import train_test_split
 from sklearn.utils.validation import check_is_fitted
 
-from ..utils import to_time_series, to_time_series_dataset, check_array, check_dims
-from ..neighbors import KNeighborsTimeSeriesClassifier
-from ..clustering import TimeSeriesKMeans
 from ..bases import TimeSeriesMixin
+from ..clustering import TimeSeriesKMeans
+from ..neighbors import KNeighborsTimeSeriesClassifier
+from ..utils import to_time_series, to_time_series_dataset, check_array, check_dims
 
 
 class NonMyopicEarlyClassifier(TimeSeriesMixin, ClassifierMixin, BaseEstimator):
@@ -588,7 +591,10 @@ class NonMyopicEarlyClassifier(TimeSeriesMixin, ClassifierMixin, BaseEstimator):
         array-like, shape (n_series,)
             Estimated delays before prediction timestamps.
         """
-
+        check_is_fitted(self, '_X_fit_dims')
+        X = check_array(X, allow_nd=True)
+        X = check_dims(X, X_fit_dims=self._X_fit_dims, check_n_features_only=True)
+        X = to_time_series_dataset(X)
         return self._early_predict(X, predict_proba=False)
 
     def early_predict_proba(self, X):
@@ -612,14 +618,127 @@ class NonMyopicEarlyClassifier(TimeSeriesMixin, ClassifierMixin, BaseEstimator):
         array-like of shape (n_series,)
             Estimated delays before prediction timestamps.
         """
-        return self._early_predict(X, predict_proba=True)
-
-    def _early_predict(self, X, predict_proba):
         check_is_fitted(self, '_X_fit_dims')
-
         X = check_array(X, allow_nd=True)
         X = check_dims(X, X_fit_dims=self._X_fit_dims, check_n_features_only=True)
         X = to_time_series_dataset(X)
+        return self._early_predict(X, predict_proba=True)
+
+    def get_early_predict_generator(self, n_ts=1):
+        """
+        Allows streaming incoming timestamps of a time series and retrieving
+        current predicted class as well as estimated delay before prediction timestamps.
+
+        Prediction timestamps are timestamps at which a prediction is made in
+        early classification setting.
+
+        Parameters
+        ----------
+        n_ts: int (default 1)
+            The number of time series that will be predicted by the generator
+
+        Returns
+        -------
+        generator
+            Use the `send` method of the generator to stream timestamps and retrieve associated prediction and delays.
+            This method takes an array-like, shape (n_ts, n_features), as input and outputs the predicted classes
+            and estimated delays before prediction timestamps at the given timestamp (same output as
+            :func:`~early_predict`).
+
+        Examples
+        --------
+        >>> dataset = to_time_series_dataset([[1, 2, 3, 4, 5, 6],
+        ...                                   [1, 2, 3, 4, 5, 6],
+        ...                                   [1, 2, 3, 4, 5, 6],
+        ...                                   [1, 2, 3, 3, 2, 1],
+        ...                                   [1, 2, 3, 3, 2, 1],
+        ...                                   [1, 2, 3, 3, 2, 1],
+        ...                                   [3, 2, 1, 1, 2, 3],
+        ...                                   [3, 2, 1, 1, 2, 3]])
+        >>> y = [0, 0, 0, 1, 1, 1, 0, 0]
+        >>> model = NonMyopicEarlyClassifier(n_clusters=3, lamb=1000.,
+        ...                                  cost_time_parameter=.1,
+        ...                                  random_state=0).fit(dataset, y)
+        >>> incoming_timestamps = np.array([1, 2, 3, 3, 1, 2]).reshape(6, 1, 1, 1)
+        >>> gen = model.get_early_predict_generator()
+        >>> for x in incoming_timestamps:
+        ...     print(gen.send(x))
+        (array([0]), array([3]))
+        (array([0]), array([2]))
+        (array([0]), array([1]))
+        (array([1]), array([0]))
+        (array([1]), array([0]))
+        (array([1]), array([0]))
+        """
+        return self._get_early_predict_generator(n_ts, predict_proba=False)
+
+    def get_early_predict_proba_generator(self, n_ts=1):
+        """
+        Allows streaming incoming timestamps of a time series and retrieving
+        current probability estimates as well as estimated delay before prediction timestamps.
+
+        Prediction timestamps are timestamps at which a prediction is made in
+        early classification setting.
+
+        Parameters
+        ----------
+        n_ts: int (default 1)
+            The number of time series that will be predicted by the generator
+
+        Returns
+        -------
+        generator
+            Use the `send` method of the generator to stream timestamps and retrieve associated prediction and delays.
+            This method takes an array-like, shape (n_ts, n_timestamps, n_features), as input and outputs the predicted probability
+            estimates and estimated delays before prediction timestamps at the given timestamp (same output as
+            :func:`~early_predict_proba`).
+
+        Examples
+        --------
+        >>> dataset = to_time_series_dataset([[1, 2, 3, 4, 5, 6],
+        ...                                   [1, 2, 3, 4, 5, 6],
+        ...                                   [1, 2, 3, 4, 5, 6],
+        ...                                   [1, 2, 3, 3, 2, 1],
+        ...                                   [1, 2, 3, 3, 2, 1],
+        ...                                   [1, 2, 3, 3, 2, 1],
+        ...                                   [3, 2, 1, 1, 2, 3],
+        ...                                   [3, 2, 1, 1, 2, 3]])
+        >>> y = [0, 0, 0, 1, 1, 1, 0, 0]
+        >>> model = NonMyopicEarlyClassifier(n_clusters=3, lamb=1000.,
+        ...                                  cost_time_parameter=.1,
+        ...                                  random_state=0).fit(dataset, y)
+        >>> incoming_timestamps = np.array([1, 2, 3, 3, 1, 2]).reshape(6, 1, 1, 1)
+        >>> gen = model.get_early_predict_proba_generator()
+        >>> for x in incoming_timestamps:
+        ...     print(gen.send(x))
+        (array([[1., 0.]]), array([3]))
+        (array([[1., 0.]]), array([2]))
+        (array([[1., 0.]]), array([1]))
+        (array([[0., 1.]]), array([0]))
+        (array([[0., 1.]]), array([0]))
+        (array([[0., 1.]]), array([0]))
+        """
+        return self._get_early_predict_generator(n_ts, predict_proba=True)
+
+    def _get_early_predict_generator(self, n_ts, predict_proba):
+        check_is_fitted(self, '_X_fit_dims')
+
+        gen = self._generate_early_predictions(n_ts, predict_proba=predict_proba)
+        next(gen)
+        return gen
+
+    def _generate_early_predictions(self, n_ts, predict_proba=False):
+        data = np.empty((n_ts, 0, self._X_fit_dims[-1]))
+
+        while True:
+            incoming_timestamp = yield self._early_predict(data, predict_proba=predict_proba)
+            if incoming_timestamp is not None:
+                try:
+                    data = np.append(data, incoming_timestamp, axis = 1)
+                except ValueError as e:
+                    warnings.warn(f"Invalid incoming timestamps: {e}", RuntimeWarning)
+
+    def _early_predict(self, X, predict_proba):
 
         if X.shape[1] > self._X_fit_dims[1]:
             raise ValueError("Time series should not have more timestamps than those used for training.")

--- a/tslearn/early_classification/early_classification.py
+++ b/tslearn/early_classification/early_classification.py
@@ -6,7 +6,7 @@ from scipy.sparse import coo_matrix
 
 from sklearn.utils.validation import check_is_fitted
 
-from ..utils import to_time_series_dataset, check_array, check_dims
+from ..utils import to_time_series, to_time_series_dataset, check_array, check_dims
 from ..neighbors import KNeighborsTimeSeriesClassifier
 from ..clustering import TimeSeriesKMeans
 from ..bases import TimeSeriesMixin
@@ -244,7 +244,6 @@ class NonMyopicEarlyClassifier(TimeSeriesMixin, ClassifierMixin, BaseEstimator):
 
         Examples
         --------
-        >>> from tslearn.utils import to_time_series
         >>> dataset = to_time_series_dataset([[1, 2, 3, 4, 5, 6],
         ...                                   [1, 2, 3, 4, 5, 6],
         ...                                   [1, 2, 3, 4, 5, 6],
@@ -312,7 +311,6 @@ class NonMyopicEarlyClassifier(TimeSeriesMixin, ClassifierMixin, BaseEstimator):
 
         Examples
         --------
-        >>> from tslearn.utils import to_time_series
         >>> dataset = to_time_series_dataset([[1, 2, 3, 4, 5, 6],
         ...                                   [1, 2, 3, 4, 5, 6],
         ...                                   [1, 2, 3, 4, 5, 6],
@@ -359,27 +357,7 @@ class NonMyopicEarlyClassifier(TimeSeriesMixin, ClassifierMixin, BaseEstimator):
 
     def _predict_single_series(self, Xi):
         """
-        This function classifies a single time series xt
-
-        Parameters
-        ----------
-        xt: vector
-            a time series that is probably incomplete but that nonetheless we
-            want to classify
-        Returns
-        -------
-        int: the class which is predicted
-        int : the time of the prediction
-        float : the probability used for computing the cost
-        float : the loss when classifying
-        """
-        t = self._get_prediction_time(Xi)
-        pred = self.classifiers_[t].predict([Xi[:t]])[0]
-        return pred, t
-
-    def _predict_single_series_proba(self, Xi):
-        """
-        This function classifies a single time series xt
+        This function classifies a single time series
 
         Parameters
         ----------
@@ -390,8 +368,26 @@ class NonMyopicEarlyClassifier(TimeSeriesMixin, ClassifierMixin, BaseEstimator):
         -------
         int: the class which is predicted
         int : the time of the prediction
-        float : the probability used for computing the cost
-        float : the loss when classifying
+        """
+        t = self._get_prediction_time(Xi)
+        pred = self.classifiers_[t].predict([Xi[:t]])[0]
+        return pred, t
+
+    def _predict_single_series_proba(self, Xi):
+        """
+        This function computes the class probabilities for a single time series
+
+        Parameters
+        ----------
+        Xi: vector
+            a time series that is probably incomplete but that nonetheless we
+            want to compute the class probabilities for.
+        Returns
+        -------
+        array-like of shape (n_classes,)
+            Probability of the time series for each class in the model,
+            where classes are ordered as they are in ``self.classes_``.
+        int : the time of the prediction
         """
         t = self._get_prediction_time(Xi)
         pred = self.classifiers_[t].predict_proba([Xi[:t]])[0]
@@ -414,7 +410,7 @@ class NonMyopicEarlyClassifier(TimeSeriesMixin, ClassifierMixin, BaseEstimator):
 
         Returns
         -------
-        array, shape (n_samples,)
+        array, shape (n_series,)
             Predicted classes.
         array-like of shape (n_series, )
             Prediction timestamps.
@@ -446,7 +442,7 @@ class NonMyopicEarlyClassifier(TimeSeriesMixin, ClassifierMixin, BaseEstimator):
 
         Returns
         -------
-        array, shape (n_samples,)
+        array, shape (n_series,)
             Predicted classes.
         """
         return self.predict_class_and_earliness(X)[0]
@@ -571,6 +567,83 @@ class NonMyopicEarlyClassifier(TimeSeriesMixin, ClassifierMixin, BaseEstimator):
         y_pred, pred_times = self.predict_class_and_earliness(X)
         acc = accuracy_score(y, y_pred)
         return (1. - acc) + np.mean(self._cost_time(pred_times))
+
+    def early_predict(self, X):
+        """
+        Provides predicted classes as well as estimated delays before prediction timestamps
+        for a dataset of incomplete time series.
+
+        Prediction timestamps are timestamps at which a prediction is made in
+        early classification setting.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_series, t, n_features)
+            A dataset of incomplete time series observed up to time t
+
+        Returns
+        -------
+        array-like, shape (n_series,)
+            Predicted classes.
+        array-like, shape (n_series,)
+            Estimated delays before prediction timestamps.
+        """
+
+        return self._early_predict(X, predict_proba=False)
+
+    def early_predict_proba(self, X):
+        """
+        Provides probability estimates as well as estimated delays before prediction timestamps
+        for a dataset of incomplete time series.
+
+        Prediction timestamps are timestamps at which a prediction is made in
+        early classification setting.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_series, t, n_features)
+            A dataset of incomplete time series observed up to time t
+
+        Returns
+        -------
+        array-like, shape (n_series, n_classes)
+            Probabilities for each class in the model,
+            where classes are ordered as they are in ``self.classes_``.
+        array-like of shape (n_series,)
+            Estimated delays before prediction timestamps.
+        """
+        return self._early_predict(X, predict_proba=True)
+
+    def _early_predict(self, X, predict_proba):
+        check_is_fitted(self, '_X_fit_dims')
+
+        X = check_array(X, allow_nd=True)
+        X = check_dims(X, X_fit_dims=self._X_fit_dims, check_n_features_only=True)
+        X = to_time_series_dataset(X)
+
+        if X.shape[1] > self._X_fit_dims[1]:
+            raise ValueError("Time series should not have more timestamps than those used for training.")
+
+        pred = []
+        time_prediction = []
+        default_pred = [np.nan] * self.__n_classes_ if predict_proba else np.nan
+
+        for ts in X:
+            ts = to_time_series(ts, remove_nans=True)
+            sz = len(ts)
+            if len(ts) < self.min_t:
+                # Not enough timestamps
+                pred.append(default_pred)
+                time_prediction.append(np.nan)
+                continue
+
+            if predict_proba:
+                pred.append(self.classifiers_[sz].predict_proba([ts])[0])
+            else:
+                pred.append(self.classifiers_[sz].predict([ts])[0])
+            time_prediction.append(np.argmin(self._expected_costs(ts)))
+
+        return np.array(pred), np.array(time_prediction)
 
     def _more_tags(self):
         # Because some of the data validation checks rely on datasets that are

--- a/tslearn/early_classification/early_classification.py
+++ b/tslearn/early_classification/early_classification.py
@@ -640,10 +640,12 @@ class NonMyopicEarlyClassifier(TimeSeriesMixin, ClassifierMixin, BaseEstimator):
         Returns
         -------
         generator
-            Use the `send` method of the generator to stream timestamps and retrieve associated prediction and delays.
-            This method takes an array-like, shape (n_ts, n_timestamps, n_features), as input and outputs the predicted
-            classes and estimated delays before prediction timestamps at the given timestamp (same output as
-            :func:`~early_predict`).
+            Use the `send` method of the generator to stream timestamps as they become available and retrieve associated
+            predictions and delays. This method takes an array-like, shape (n_ts, n_timestamps, n_features),
+            representing freshly aquired data for all timeseries as input. This new data is concatenated with previously
+            sent data, if any, to output the predicted classes and estimated delays before optimal prediction
+            timestamps for all timeseries based all on available data (same output as :func:`~early_predict`).
+            Use n_timestamps = 1 for step by step feeding.
 
         Examples
         --------
@@ -688,10 +690,12 @@ class NonMyopicEarlyClassifier(TimeSeriesMixin, ClassifierMixin, BaseEstimator):
         Returns
         -------
         generator
-            Use the `send` method of the generator to stream timestamps and retrieve associated prediction and delays.
-            This method takes an array-like, shape (n_ts, n_timestamps, n_features), as input and outputs the predicted probability
-            estimates and estimated delays before prediction timestamps at the given timestamp (same output as
-            :func:`~early_predict_proba`).
+            Use the `send` method of the generator to stream timestamps as they become available and retrieve associated
+            prediction probalities and delays. This method takes an array-like, shape (n_ts, n_timestamps, n_features),
+            representing freshly aquired data for all timeseries as input. This new data is concatenated with previously
+            sent data, if any, to output the predicted probability estimates and estimated delays before optimal prediction
+            timestamps for all timeseries based all on available data (same output as :func:`~early_predict_proba`).
+            Use n_timestamps = 1 for step by step feeding.
 
         Examples
         --------

--- a/tslearn/early_classification/early_classification.py
+++ b/tslearn/early_classification/early_classification.py
@@ -641,8 +641,8 @@ class NonMyopicEarlyClassifier(TimeSeriesMixin, ClassifierMixin, BaseEstimator):
         -------
         generator
             Use the `send` method of the generator to stream timestamps and retrieve associated prediction and delays.
-            This method takes an array-like, shape (n_ts, n_features), as input and outputs the predicted classes
-            and estimated delays before prediction timestamps at the given timestamp (same output as
+            This method takes an array-like, shape (n_ts, n_timestamps, n_features), as input and outputs the predicted
+            classes and estimated delays before prediction timestamps at the given timestamp (same output as
             :func:`~early_predict`).
 
         Examples


### PR DESCRIPTION
`NonMyopicEarlyClassifier` can now be used with yet incomplete series or streamed inputs 
to retrieve optimal classification timing.

TODOs:
 - [x] check proba computation
 - [x] add tests for proba methods
 - [x] add streaming example