### PR TITLE
Fix LearningShapelets.shapelets_ attribute computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Changelogs for this project are recorded in this file since v0.2.0.
 * Fix imputer crash ([#659](https://github.com/tslearn-team/tslearn/issues/659))
 * `TimeSeriesScalerMinMax` and `TimeSeriesScalerMeanVariance` now scales based on fitted data characteristics
 when `per_timeseries` is False. ([#280](https://github.com/tslearn-team/tslearn/issues/280))
+* Fix `LearningShapelets.shapelets_` attribute computation.
 
 ## [v0.8.1]
 

--- a/tests/test_shapelets.py
+++ b/tests/test_shapelets.py
@@ -39,6 +39,12 @@ def test_shapelets():
                             model.shapelets_as_time_series_):
         np.testing.assert_allclose(shp,
                                    _to_time_series(shp_bis, remove_nans=True))
+    model = shapelets.LearningShapelets(n_shapelets_per_size={4: 1, 3: 2}, max_iter=1)
+    model.fit(time_series, y)
+    for shp, shp_bis in zip(model.shapelets_,
+                            model.shapelets_as_time_series_):
+        np.testing.assert_allclose(shp,
+                                   _to_time_series(shp_bis, remove_nans=True))
 
     # Test set_weights / get_weights
     clf = shapelets.LearningShapelets(n_shapelets_per_size={2: 5},

--- a/tslearn/shapelets/shapelets.py
+++ b/tslearn/shapelets/shapelets.py
@@ -440,19 +440,15 @@ class LearningShapelets(TimeSeriesMixin, ClassifierMixin, TransformerMixin, Base
     @property
     def shapelets_(self):
         check_is_fitted(self, '_X_fit_dims')
-        n_shapelets_per_size = self.n_shapelets_per_size_
 
-        total_nb_shapelets = sum(n_shapelets_per_size.values())
-        nb_shapelets_found = 0
+        total_nb_shapelets = sum(self.n_shapelets_per_size_.values())
         shapelets = numpy.empty((total_nb_shapelets,), dtype=object)
-        for i, shp_sz in enumerate(sorted(n_shapelets_per_size)):
+        nb_shapelets_found = 0
+        for i in range(self._n_shapelet_sizes):
             layer = self.model_.get_layer("shapelets_%d" % i)
-            weights = layer.get_weights()[0]
-            assert n_shapelets_per_size[shp_sz] == weights.shape[0]
-            for j in range(weights.shape[0]):
-                shapelets[nb_shapelets_found] = weights[j]
+            for weight in layer.get_weights()[0]:
+                shapelets[nb_shapelets_found] = weight
                 nb_shapelets_found += 1
-        assert nb_shapelets_found == total_nb_shapelets
         return shapelets
 
     @property


### PR DESCRIPTION
When n_shapelets_per_size is not sorted, the access to shapelets_ ( and therefore shapelets_as_time_series_) crashed. Do not rely on n_shapelets_per_size being sorted for layers weights to shapelets_ transform anymore.