### PR TITLE
[MRG] Fixes #441: expose PAA segment_indices()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelogs for this project are recorded in this file since v0.2.0.
 ### Added
 
 * Allow parallel computation of DTW barycenters and plug it in `TimeSeriesKMeans`.
+* `PiecewiseAggregateApproximation.segment_indices` exposes the start/end indices of each PAA segment in the original time series ([#441](https://github.com/tslearn-team/tslearn/issues/441)).
 
 ### Changed
 

--- a/tests/test_piecewise.py
+++ b/tests/test_piecewise.py
@@ -24,6 +24,37 @@ def test_paa():
                                paa_est.distance_paa(paa_repr[0], paa_repr[1]))
 
 
+def test_paa_segment_indices():
+    # Regression test for #441: expose PAA segment boundaries so callers can
+    # map paa_data[i] back to the original-series index range it summarises.
+    paa = PiecewiseAggregateApproximation(n_segments=3)
+    data = [[-1., 2., 0.1, -1., 1., -1.]]
+    # Before fitting, segment_indices must raise NotFittedError (consistent
+    # with distance / transform).
+    np.testing.assert_raises(NotFittedError, paa.segment_indices)
+
+    paa_data = paa.fit_transform(data)
+    seg_idx = paa.segment_indices()
+
+    # Shape and dtype contract.
+    assert seg_idx.shape == (3, 2)
+    assert np.issubdtype(seg_idx.dtype, np.integer)
+
+    # The boundaries must reproduce the means stored in paa_data — this is the
+    # property a user actually relies on when locating "where changes occur".
+    arr = np.asarray(data, dtype=float)
+    for i_seg, (start, end) in enumerate(seg_idx):
+        np.testing.assert_allclose(
+            paa_data[0, i_seg, 0], arr[0, start:end].mean()
+        )
+
+    # Non-divisible length: trailing samples are dropped, like transform does.
+    paa2 = PiecewiseAggregateApproximation(n_segments=3)
+    paa2.fit([[1., 2., 3., 4., 5., 6., 7.]])  # sz=7, n_segments=3 -> sz_seg=2
+    seg_idx2 = paa2.segment_indices()
+    np.testing.assert_array_equal(seg_idx2, [[0, 2], [2, 4], [4, 6]])
+
+
 def test_sax():
     unfitted_sax = SymbolicAggregateApproximation(n_segments=3,
                                                   alphabet_size_avg=2)

--- a/tslearn/piecewise/piecewise.py
+++ b/tslearn/piecewise/piecewise.py
@@ -258,6 +258,48 @@ class PiecewiseAggregateApproximation(TimeSeriesMixin,
         X = check_dims(X)
         return inv_transform_paa(X, original_size=self._X_fit_dims_[1])
 
+    def segment_indices(self):
+        """Return the start/end indices of each PAA segment in the original
+        time series.
+
+        These are the boundaries used when transforming a fitted-length time
+        series into its PAA representation: segment ``i`` of the PAA output
+        is the mean of ``ts[start_i:end_i]`` in the original series.
+
+        Returns
+        -------
+        numpy.ndarray of shape (n_segments, 2), dtype=int
+            ``[[start_0, end_0], [start_1, end_1], ...]`` segment ranges in the
+            original time-series index. ``end_i`` is exclusive and matches the
+            half-open convention used by :meth:`transform` (which slices
+            ``X[i_ts, start:end, :]``).
+
+        Examples
+        --------
+        >>> paa = PiecewiseAggregateApproximation(n_segments=3)
+        >>> _ = paa.fit([[-1., 2., 0.1, -1., 1., -1.]])
+        >>> paa.segment_indices()
+        array([[0, 2],
+               [2, 4],
+               [4, 6]])
+
+        Notes
+        -----
+        The segment width matches what :meth:`transform` uses internally:
+        ``sz_segment = sz_fit // n_segments``. Trailing samples beyond
+        ``n_segments * sz_segment`` are dropped, exactly as in
+        :meth:`transform` — this keeps the indices consistent with the values
+        in ``paa_data``.
+        """
+        self._is_fitted()
+        sz_fit = int(self._X_fit_dims_[1])
+        # Match _transform's segment-width convention so callers can map
+        # paa_data[i_seg] back to ts[start_i:end_i] without off-by-one.
+        sz_segment = sz_fit // self.n_segments
+        starts = numpy.arange(self.n_segments, dtype=int) * sz_segment
+        ends = starts + sz_segment
+        return numpy.stack([starts, ends], axis=1)
+
     def _more_tags(self):
         tags = super()._more_tags()
         tags.update({


### PR DESCRIPTION
## Summary

Adds `PiecewiseAggregateApproximation.segment_indices()`, a small accessor that returns the `(start, end)` indices each PAA segment summarises in the original-length time series. This lets users locate "where the PAA value changes" — the question raised in #441 — without re-deriving the segment-width logic from `_transform`.

Fixes #441 — *Index of changes in PAA and SAX*.

## Context

Issue #441 asks for a way to map a `paa_data[i]` value back to the original-series index range it averages. The information already exists implicitly inside `_transform` (`sz_segment = sz_fit // n_segments`; segment `i` covers `ts[i*sz_segment : (i+1)*sz_segment]`), but callers had to re-derive it. Exposing it as a method:
* keeps the source-of-truth in one place (we reuse the same `sz_fit // n_segments` formula),
* makes the `paa_data[i] == ts[start_i:end_i].mean()` invariant testable,
* requires no change to `transform` / `inverse_transform`.

## Changes

* `tslearn/piecewise/piecewise.py` — new `segment_indices()` method on `PiecewiseAggregateApproximation`. Returns `np.ndarray` of shape `(n_segments, 2)` with half-open intervals `[start, end)` matching `_transform`. Raises `NotFittedError` before `fit`. A short inline comment notes that the segment-width formula must stay in sync with `_transform` so that `paa_data[i_seg] == ts[start_i:end_i].mean()` holds.
* `tests/test_piecewise.py` — regression test `test_paa_segment_indices` that:
  * asserts `NotFittedError` before fitting,
  * checks shape / dtype,
  * verifies the means in `paa_data` match `ts[start:end].mean()` cell-by-cell,
  * exercises the non-divisible-length branch (sz=7, n_segments=3 → trailing sample dropped).
* `CHANGELOG.md` — entry under `[Towards v0.9.0] / Added`.

The new method is purely additive — no existing PAA / SAX behaviour changes.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/tslearn-team/tslearn.git /tmp/repro && cd /tmp/repro
python -m venv .venv && source .venv/bin/activate
pip install -e . pytest >/dev/null

# Save the regression test that demonstrates the fix
git fetch https://github.com/jbbqqf/tslearn.git feat/441-paa-segment-indices
git checkout FETCH_HEAD -- tests/test_piecewise.py

# --- BEFORE (origin/main) ---
git checkout origin/main -- tslearn/piecewise/piecewise.py
pytest tests/test_piecewise.py::test_paa_segment_indices -q
# Expected: FAILED — AttributeError: 'PiecewiseAggregateApproximation' object has no attribute 'segment_indices'

# --- AFTER (this PR) ---
git checkout FETCH_HEAD -- tslearn/piecewise/piecewise.py
pytest tests/test_piecewise.py::test_paa_segment_indices -q
# Expected: 1 passed
```

## What I ran locally

* `pytest tests/test_piecewise.py -v` → 5 passed (the existing 4 PAA/SAX tests + the new one).
* `pytest --doctest-modules tslearn/piecewise/piecewise.py` → 7 passed (covers the new docstring example).

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | Unfitted estimator | `PiecewiseAggregateApproximation(n_segments=3).segment_indices()` | `NotFittedError` | `test_paa_segment_indices` |
| 2 | Divisible length | `sz=6, n_segments=3` on `[-1, 2, 0.1, -1, 1, -1]` | `[[0,2],[2,4],[4,6]]` and `paa_data[i] == ts[start:end].mean()` | `test_paa_segment_indices` (loop assertion) |
| 3 | Non-divisible length | `sz=7, n_segments=3` | `[[0,2],[2,4],[4,6]]` (trailing sample dropped, matching `_transform`) | `test_paa_segment_indices` (non-divisible block) |

## Risk / blast radius

Additive only: a new method on an existing class. No changes to `fit`, `transform`, `inverse_transform`, `distance`, or `distance_paa`. Cannot break existing callers; cannot affect serialisation (no new attribute is stored on the estimator).

## Release note

```release-note
piecewise: PiecewiseAggregateApproximation now exposes segment_indices() to map PAA segments back to original-series index ranges (#441).
```

---

*PR drafted with assistance from Claude Code. The change was reviewed manually against tslearn-team/tslearn's source (`tslearn/piecewise/piecewise.py:147` `_transform`) and the reproducer block above was used during development; it is the same one a reviewer can paste verbatim.*
