### PR TITLE
[MRG] docs: Fixes #378 — restore 'Running tests locally' in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,46 @@ to create a pull request from your fork. This will send an email to the committe
 (If any of the above seems like magic to you, please look up the
 [Git documentation](https://git-scm.com/documentation) on the web, or ask a friend or another contributor for help.)
 
+### Running the test suite locally
+
+Before opening a pull request, please make sure the unit tests pass on your
+machine. `tslearn` uses [pytest](https://docs.pytest.org/) and the tests live
+under the top-level `tests/` directory.
+
+1. Set up a virtual environment and install `tslearn` in editable mode along
+   with `pytest`:
+
+   ```bash
+   $ python -m venv .venv
+   $ source .venv/bin/activate   # on Windows: .venv\Scripts\activate
+   $ pip install -e .
+   $ pip install pytest
+   ```
+
+2. Run the full test suite from the repository root:
+
+   ```bash
+   $ pytest tests/
+   ```
+
+3. To run a single file or a single test while iterating, use:
+
+   ```bash
+   $ pytest tests/test_metrics.py
+   $ pytest tests/test_metrics.py::test_dtw -v
+   ```
+
+4. Public methods come with doctests. To run the doctests for a single
+   module, use:
+
+   ```bash
+   $ pytest --doctest-modules tslearn/metrics/dtw_variants.py
+   ```
+
+If a test depends on optional extras (`h5py`, `tensorflow`, `torch`, …),
+install them on demand with `pip install <extra>`; the suite skips the
+corresponding tests when an optional dependency is missing.
+
 ### Pull Request Checklist
 
 We recommended that your contribution complies with the


### PR DESCRIPTION
## Summary

Restores a "Running the test suite locally" subsection to `CONTRIBUTING.md` so new contributors know how to verify their changes before opening a PR. Issue #378 reports that this guidance was lost during a previous CONTRIBUTING update.

Fixes #378 — *Contributing.MD no longer contains instructions to run tests locally*.

## Context

The current `CONTRIBUTING.md` walks new contributors through forking, branching and pushing, but never tells them which command runs the tests or where the tests live. New contributors hitting the file have to grep the repo (or guess `pytest`) before they can validate a fix locally — exactly the friction the original issue raised.

The added section sits right before the existing **Pull Request Checklist** (which already says "Bug-fixes or new features should be provided with non-regression tests" but doesn't say *how* to run them), so the two pieces of guidance now flow together.

## Changes

* `CONTRIBUTING.md` — added a `### Running the test suite locally` subsection covering:
  * creating a venv + editable install of `tslearn` + `pytest`,
  * running the full `pytest tests/` suite from the repo root,
  * running a single file / single test (`pytest tests/test_metrics.py::test_dtw -v`),
  * running doctests for a module (`pytest --doctest-modules tslearn/metrics/dtw_variants.py`),
  * a one-liner about optional extras (`h5py`, `tensorflow`, `torch`).

Documentation-only — no behavioural change.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/tslearn-team/tslearn.git /tmp/repro && cd /tmp/repro

# --- BEFORE (origin/main) ---
git checkout origin/main
grep -c "pytest" CONTRIBUTING.md
# Expected: 0  (no test instructions present)

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/tslearn.git feat/378-contributing-tests-section
git checkout FETCH_HEAD
grep -c "pytest" CONTRIBUTING.md
# Expected: >= 4  (full pytest section, single-test example, doctest example)
```

## What I ran locally

* `pytest tests/` against the new instructions to confirm the documented commands actually run on a clean editable install. Passing locally.
* Visual diff inspection of `CONTRIBUTING.md` — section sits before Pull Request Checklist; existing structure preserved.

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | Documentation-only diff | `git diff --stat` | only `CONTRIBUTING.md` modified | manual `git diff` |
| 2 | Existing content preserved | full `CONTRIBUTING.md` | every previous section still present, only the new subsection inserted | manual diff |

## Risk / blast radius

Documentation-only — zero runtime impact.

## Release note

```release-note
docs: CONTRIBUTING.md regained a "Running the test suite locally" section (#378).
```

---

*PR drafted with assistance from Claude Code. The reproducer block above was used during development; it is the same one a reviewer can paste verbatim.*
