### PR TITLE
[MRG] Fixes #343: document cycc functions in tslearn.metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ to retrieve optimal classification timing.
 * `TimeSeriesScalerMinMax` and `TimeSeriesScalerMeanVariance` now scales based on fitted data characteristics
 when `per_timeseries` is False. ([#280](https://github.com/tslearn-team/tslearn/issues/280))
 * Fix `LearningShapelets.shapelets_` attribute computation.
+* Document `cdist_normalized_cc` and `y_shifted_sbd_vec` in the `tslearn.metrics`
+API reference — they were already exported via `tslearn.metrics.__all__`, just
+missing from the Sphinx autosummary. ([#343](https://github.com/tslearn-team/tslearn/issues/343))
 
 ## [v0.8.1]
 

--- a/docs/gen_modules/tslearn.metrics.rst
+++ b/docs/gen_modules/tslearn.metrics.rst
@@ -45,3 +45,5 @@ tslearn.metrics
       frechet_path
       frechet_path_from_metric
       frechet_accumulated_matrix
+      cdist_normalized_cc
+      y_shifted_sbd_vec

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1111,3 +1111,30 @@ def test_sax():
         dataset2=[[-1, 0, 1], [1, 0, 1]],
     )
     np.testing.assert_equal(dists, expected)
+
+
+def test_cycc_functions_documented():
+    """Regression test for #343: cross-correlation helpers exported from
+    ``tslearn.metrics`` (sourced in ``cycc.py``) must appear in the
+    Sphinx autosummary so they show up in the generated reference docs.
+    """
+    import pathlib
+
+    # Symbols re-exported from cycc.py — these are part of the public API
+    # via ``tslearn.metrics.__all__`` but historically were absent from the
+    # autosummary block, leaving them undocumented on readthedocs.
+    cycc_public = ["cdist_normalized_cc", "y_shifted_sbd_vec"]
+    for name in cycc_public:
+        assert name in tslearn.metrics.__all__, (
+            f"{name} is expected to be re-exported from tslearn.metrics"
+        )
+
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    rst_path = repo_root / "docs" / "gen_modules" / "tslearn.metrics.rst"
+    assert rst_path.is_file(), f"missing {rst_path}"
+    rst_text = rst_path.read_text()
+    for name in cycc_public:
+        assert name in rst_text, (
+            f"{name} is exported by tslearn.metrics but missing from "
+            f"docs/gen_modules/tslearn.metrics.rst autosummary"
+        )


### PR DESCRIPTION
## Summary

`tslearn.metrics` re-exports `cdist_normalized_cc` and `y_shifted_sbd_vec` (sourced from `tslearn/metrics/cycc.py`) via `__all__`, but neither function appears in the Sphinx autosummary for `tslearn.metrics`, so they are absent from the rendered API reference on readthedocs. Add them so the docs match the public surface.

Fixes tslearn-team/tslearn#343 — *Cross-correlation functions are undocumented*

## Context

The original report (Feb 2021) noted that after `cycc` was moved under `tslearn.metrics` in v0.5, none of its functions showed up in the generated reference at https://tslearn.readthedocs.io/en/stable/gen_modules/tslearn.metrics.html. The exports themselves were kept (`tslearn/metrics/__init__.py:61`, and both names are listed in `__all__`), but they were never added to the autosummary block in `docs/gen_modules/tslearn.metrics.rst`. The `normalized_cc` helper in the same module is an internal njit function and is not re-exported, so it is intentionally left out of the doc list.

## Changes

- `docs/gen_modules/tslearn.metrics.rst` — add `cdist_normalized_cc` and `y_shifted_sbd_vec` to the autosummary list (the existing function docstrings already follow the project's NumPy-style convention).
- `tests/test_metrics.py` — add `test_cycc_functions_documented`, a small guard test that fails if either symbol is in `tslearn.metrics.__all__` but missing from the rst, so this won't drift back out silently.
- `CHANGELOG.md` — entry under `[Towards v0.9.0] / Changed` referencing #343.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/tslearn-team/tslearn.git /tmp/repro && cd /tmp/repro
uv venv .venv && . .venv/bin/activate
uv pip install -e . pytest

# --- BEFORE (origin/main) ---
git checkout origin/main
# Borrow the regression test from this PR so the reviewer can see the gap
git fetch https://github.com/jbbqqf/tslearn.git fix/343-document-cycc
git checkout FETCH_HEAD -- tests/test_metrics.py
pytest tests/test_metrics.py::test_cycc_functions_documented -v
# Expected: FAIL — "cdist_normalized_cc is exported by tslearn.metrics but
# missing from docs/gen_modules/tslearn.metrics.rst autosummary"

# --- AFTER (this PR) ---
git checkout FETCH_HEAD
pytest tests/test_metrics.py::test_cycc_functions_documented -v
# Expected: PASS — both names appear in the rst, no other tests affected
```

## What I ran locally

- `pytest tests/test_metrics.py::test_cycc_functions_documented -v` → **1 passed** on the branch, **1 failed** when the `.rst` change is stashed (assertion: `cdist_normalized_cc is exported by tslearn.metrics but missing from docs/gen_modules/tslearn.metrics.rst autosummary`).
- `pytest tests/test_utils.py` → **6 passed, 2 skipped** (sanity-check that the test infra is unaffected).
- Verified manually that `cdist_normalized_cc` and `y_shifted_sbd_vec` are both in `tslearn.metrics.__all__` on current `main` (commit `95bd2d3`).

I did not rebuild the Sphinx docs locally — the change is a single addition to an existing `autosummary` block with the same shape as the surrounding entries, so the html generation path is unchanged.

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | Both names present in `__all__` and in rst | current branch | passes | `test_cycc_functions_documented` |
| 2 | Name in `__all__` but missing from rst | `git stash` the rst patch | fails with the missing-name assertion | local run above |
| 3 | Internal `normalized_cc` (not in `__all__`) | absent from both | not asserted on — intentional, since it is private | manual inspection of `tslearn/metrics/__init__.py` |

## Risk / blast radius

Pure docs + test addition. No runtime code touched, no public API changed. The new test only reads files already present in the repo, so it is safe on CI (no network, no heavy compute).

## Release note

```release-note
docs: include `cdist_normalized_cc` and `y_shifted_sbd_vec` in the
`tslearn.metrics` API reference autosummary.
```

---

*PR drafted with assistance from Claude Code. The change was reviewed manually against tslearn-team/tslearn's source on commit `95bd2d3` and the BEFORE/AFTER block above was the one I ran during development; a reviewer can paste it verbatim.*
