### PR TITLE
ENH allow changing data root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Changelogs for this project are recorded in this file since v0.2.0.
 * Allow parallel computation of DTW barycenters and plug it in `TimeSeriesKMeans`.
 * `NonMyopicEarlyClassifier` can now be used with yet incomplete series or streamed inputs 
 to retrieve optimal classification timing.
+* Add `root_dir` parameter to `UCR_UEA_datasets` to allow users to specify 
+  where downloaded datasets should be cached. If None, a default directory is 
+  used, either in `$XDG_DATA_HOME/tslearn/UCR_UEA` if the environment variable 
+  is set or `~/.tslearn/datasets` otherwise.
 
 ### Changed
 

--- a/conftest.py
+++ b/conftest.py
@@ -17,6 +17,18 @@ def pytest_ignore_collect(collection_path, *args, **kwargs):
         return True
 
 
+@pytest.fixture(scope="session")
+def require_ucr_datasets():
+    "Check that UCR UEA datasets can be fetched, and skip tests if not."
+    try:
+        datasets = UCR_UEA_datasets()
+        if not datasets.list_datasets():
+            raise RuntimeError("No datasets found in cache")
+    except Exception as exc:
+        warnings.warn("Error fetching UCR UEA datasets: {}".format(exc))
+        pytest.skip("UCR UEA datasets not available")
+
+
 def pytest_collection_modifyitems(config, items):
     try:
         import pandas

--- a/docs/examples/classification/plot_early_classification.py
+++ b/docs/examples/classification/plot_early_classification.py
@@ -5,8 +5,8 @@ Early Classification
 
 This example presents the concept of early classification.
 
-Early classifiers are implemented in the 
-:mod:`tslearn.early_classification` module and in this example 
+Early classifiers are implemented in the
+:mod:`tslearn.early_classification` module and in this example
 we use the method from [1]_.
 
 References
@@ -53,10 +53,8 @@ loader = UCR_UEA_datasets()
 # sphinx_gallery_start_ignore
 if "__file__" not in locals():
     # runs by sphinx-gallery
-    import os
-    loader._data_dir = os.path.join(
-        os.path.dirname(os.path.realpath(os.getcwd())), '..', "datasets"
-    )
+    from pathlib import Path
+    loader._data_dir = Path.cwd().parents[1] / "datasets"
 # sphinx_gallery_end_ignore
 X_train, y_train, X_test, y_test = loader.load_dataset("ECG200")
 

--- a/docs/examples/neighbors/plot_sax_mindist_knn.py
+++ b/docs/examples/neighbors/plot_sax_mindist_knn.py
@@ -70,10 +70,8 @@ data_loader = UCR_UEA_datasets()
 # sphinx_gallery_start_ignore
 if "__file__" not in locals():
     # runs by sphinx-gallery
-    import os
-    data_loader._data_dir = os.path.join(
-        os.path.dirname(os.path.realpath(os.getcwd())), '..', "datasets"
-    )
+    from pathlib import Path
+    data_loader._data_dir = Path.cwd().parents[1] / "datasets"
 # sphinx_gallery_end_ignore
 datasets = [
     ('SyntheticControl', 16),

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -37,3 +37,18 @@ def test_root_dir(tmp_path):
 
     assert (Path(tmp_path) / "UCR_UEA" / "Trace").exists()
 
+
+def test_default_data_home(monkeypatch, tmp_path):
+    """Check that datasets are cached in the specified root directory."""
+    # Make sure the Trace dataset is cached in the default location
+    data_loader = UCR_UEA_datasets()
+    _ = data_loader.load_dataset("Trace")
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+
+    # Check that the cached directory of a new data loader is empty when
+    # using a custom location, and that loading Trace populates it
+    data_loader = UCR_UEA_datasets()
+    assert data_loader._data_dir == Path(tmp_path) / "tslearn" / "UCR_UEA"
+    cached_dir = data_loader.list_cached_datasets()
+    assert len(cached_dir) == 0

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+from tslearn.datasets.ucr_uea import UCR_UEA_datasets
+from tslearn.datasets.cached import CachedDatasets
+
+
+def test_ucr_uea_datasets():
+    data_loader = UCR_UEA_datasets()
+    X_train, y_train, X_test, y_test = data_loader.load_dataset("Trace")
+    assert X_train.shape == (100, 275, 1)
+    assert y_train.shape == (100,)
+    assert X_test.shape == (100, 275, 1)
+    assert y_test.shape == (100,)
+
+
+def test_cached_datasets():
+    data_loader = CachedDatasets()
+    cached = data_loader.list_datasets()
+    assert "Trace" in cached
+
+
+def test_root_dir(tmp_path):
+    """Check that datasets are cached in the specified root directory."""
+    # Make sure the Trace dataset is cached in the default location
+    data_loader = UCR_UEA_datasets()
+    _ = data_loader.load_dataset("Trace")
+
+    # Check that the cached directory of a new data loader is empty when
+    # using a custom location, and that loading Trace populates it
+    data_loader = UCR_UEA_datasets(root_dir=tmp_path)
+    cached_dir = data_loader.list_cached_datasets()
+    assert len(cached_dir) == 0
+
+    data_loader.load_dataset("Trace")
+    cached_dir = data_loader.list_cached_datasets()
+    assert "Trace" in cached_dir
+
+    assert (Path(tmp_path) / "UCR_UEA" / "Trace").exists()
+

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -4,7 +4,7 @@ from tslearn.datasets.ucr_uea import UCR_UEA_datasets
 from tslearn.datasets.cached import CachedDatasets
 
 
-def test_ucr_uea_datasets():
+def test_ucr_uea_datasets(require_ucr_datasets):
     data_loader = UCR_UEA_datasets()
     X_train, y_train, X_test, y_test = data_loader.load_dataset("Trace")
     assert X_train.shape == (100, 275, 1)
@@ -19,7 +19,7 @@ def test_cached_datasets():
     assert "Trace" in cached
 
 
-def test_root_dir(tmp_path):
+def test_root_dir(require_ucr_datasets, tmp_path):
     """Check that datasets are cached in the specified root directory."""
     # Make sure the Trace dataset is cached in the default location
     data_loader = UCR_UEA_datasets()
@@ -38,7 +38,7 @@ def test_root_dir(tmp_path):
     assert (Path(tmp_path) / "UCR_UEA" / "Trace").exists()
 
 
-def test_default_data_home(monkeypatch, tmp_path):
+def test_default_data_home(require_ucr_datasets, monkeypatch, tmp_path):
     """Check that datasets are cached in the specified root directory."""
     # Make sure the Trace dataset is cached in the default location
     data_loader = UCR_UEA_datasets()

--- a/tslearn/datasets/cached.py
+++ b/tslearn/datasets/cached.py
@@ -20,7 +20,7 @@ class CachedDatasets:
        Series Classification Repository, www.timeseriesclassification.com
     """
     def __init__(self):
-        # Local test datseta are stored in tslearn/.cached_datasets
+        # Local test datasets are stored in tslearn/.cached_datasets
         self.path = Path(__file__).parents[1] / ".cached_datasets"
 
     def list_datasets(self):

--- a/tslearn/datasets/cached.py
+++ b/tslearn/datasets/cached.py
@@ -1,5 +1,6 @@
 import numpy
-import os
+from pathlib import Path
+
 
 class CachedDatasets:
     """A convenience class to access cached time series datasets.
@@ -19,18 +20,16 @@ class CachedDatasets:
        Series Classification Repository, www.timeseriesclassification.com
     """
     def __init__(self):
-        self.path = os.path.join(os.path.dirname(__file__),
-                                 "..",
-                                 ".cached_datasets")
+        # Local test datseta are stored in tslearn/.cached_datasets
+        self.path = Path(__file__).parents[1] / ".cached_datasets"
 
     def list_datasets(self):
         """List cached datasets.
 
         Examples
         --------
-        >>> from tslearn.datasets import UCR_UEA_datasets
-        >>> _ = UCR_UEA_datasets().load_dataset("Trace")
-        >>> cached = UCR_UEA_datasets().list_cached_datasets()
+        >>> from tslearn.datasets import CachedDatasets
+        >>> cached = CachedDatasets().list_datasets()
         >>> "Trace" in cached
         True
 
@@ -38,11 +37,10 @@ class CachedDatasets:
         -------
         list of str:
             A list of names of all cached (univariate and multivariate) dataset
-            namas.
+            names.
         """
-        return [fname[:fname.rfind(".")]
-                for fname in os.listdir(self.path)
-                if fname.endswith(".npz")]
+        return [fname.with_suffix("").name for fname in self.path.iterdir()
+                if fname.suffix == ".npz"]
 
     def load_dataset(self, dataset_name):
         """Load a cached dataset from its name.
@@ -79,7 +77,7 @@ class CachedDatasets:
         IOError
             If the dataset does not exist or cannot be read.
         """
-        npzfile = numpy.load(os.path.join(self.path, dataset_name + ".npz"))
+        npzfile = numpy.load((self.path / dataset_name).with_suffix(".npz"))
         X_train = npzfile["X_train"]
         X_test = npzfile["X_test"]
         y_train = npzfile["y_train"]

--- a/tslearn/datasets/datasets.py
+++ b/tslearn/datasets/datasets.py
@@ -6,8 +6,8 @@ series datasets.
 import zipfile
 import tempfile
 import shutil
-import os
 import warnings
+from pathlib import Path
 from urllib.request import urlretrieve
 
 __author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
@@ -33,11 +33,12 @@ def extract_from_zip_url(url, target_dir=None, verbose=False):
         Directory in which the zip file has been extracted if the process was
         successful, None otherwise
     """
-    fname = os.path.basename(url)
+    fname = Path(url).name
     tmpdir = tempfile.mkdtemp()
-    local_zip_fname = os.path.join(tmpdir, fname)
+    local_zip_fname = Path(tmpdir) / fname
     urlretrieve(url, local_zip_fname)
-    os.makedirs(target_dir, exist_ok=True)
+    target_dir = Path(target_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
     try:
         with zipfile.ZipFile(local_zip_fname, "r") as f:
             f.extractall(path=target_dir)

--- a/tslearn/datasets/ucr_uea.py
+++ b/tslearn/datasets/ucr_uea.py
@@ -51,6 +51,13 @@ class UCR_UEA_datasets:
         Datasets are always cached upon loading, and this parameter only
         determines whether the cached version shall be refreshed upon loading.
 
+    root_dir : str or None (default: None)
+        Directory to be used to cache downloaded datasets.
+        If None, a default directory is used:
+           - If the environment variable `XDG_DATA_HOME` is set, the default
+             directory is `$XDG_DATA_HOME/tslearn/UCR_UEA`.
+           - Otherwise, the default directory is `~/.tslearn/datasets/UCR_UEA`.
+
     Notes
     -----
         Downloading dataset files can be time-consuming, it is recommended

--- a/tslearn/datasets/ucr_uea.py
+++ b/tslearn/datasets/ucr_uea.py
@@ -1,11 +1,15 @@
-import os
 import warnings
 import csv
 import shutil
+from pathlib import Path
 from urllib.request import urlretrieve
 
-from tslearn.utils import _load_arff_uea, _load_txt_uea
+from tslearn import utils
 from .datasets import in_file_string_replace, extract_from_zip_url
+
+BASE_URL = "https://www.timeseriesclassification.com/aeon-toolkit/"
+
+SUPPORTED_EXT = ["txt", "arff"]
 
 
 class UCR_UEA_datasets:
@@ -42,25 +46,25 @@ class UCR_UEA_datasets:
     .. [1] A. Bagnall, J. Lines, W. Vickers and E. Keogh, The UEA & UCR Time
        Series Classification Repository, www.timeseriesclassification.com
     """
-    def __init__(self, use_cache=True):
+    def __init__(self, use_cache=True, root_dir=None):
         self.use_cache = use_cache
-        self._data_dir = os.path.expanduser(os.path.join(
-            "~", ".tslearn", "datasets", "UCR_UEA"
-        ))
-        os.makedirs(self._data_dir, exist_ok=True)
+        if root_dir is None:
+            self._data_dir = Path.home() / ".tslearn" / "datasets" / "UCR_UEA"
+        else:
+            self._data_dir = Path(root_dir) / "UCR_UEA"
+        self._data_dir.mkdir(parents=True, exist_ok=True)
 
         try:
-            url_multivariate = ("https://www.timeseriesclassification.com/aeon-toolkit/Archives/"
-                                "summaryMultivariate.csv")
-            self._list_multivariate_filename = os.path.join(
-                self._data_dir, os.path.basename(url_multivariate)
+            url_multivariate = BASE_URL + "Archives/summaryMultivariate.csv"
+            self._list_multivariate_filename = (
+                self._data_dir / Path(url_multivariate).name
             )
             urlretrieve(url_multivariate, self._list_multivariate_filename)
 
-            url_univariate = ("https://www.timeseriesclassification.com/aeon-toolkit/Archives/"
-                            "summaryUnivariate.csv")
-            self._list_univariate_filename = os.path.join(
-                self._data_dir, os.path.basename(url_univariate))
+            url_univariate = BASE_URL + "Archives/summaryUnivariate.csv"
+            self._list_univariate_filename = (
+                self._data_dir / Path(url_univariate).name
+            )
             urlretrieve(url_univariate, self._list_univariate_filename)
 
             # fix typos in that CSV to match with the name in the download link
@@ -69,9 +73,10 @@ class UCR_UEA_datasets:
             in_file_string_replace(self._list_univariate_filename,
                                    "StarlightCurves", "StarLightCurves")
 
-            self._baseline_scores_filename = os.path.join(
-                os.path.dirname(__file__),
-                "../.cached_datasets/singleTrainTest.csv")
+            self._baseline_scores_filename = (
+                Path(__file__).parents[1] / ".cached_datasets" /
+                "singleTrainTest.csv"
+            )
 
         except Exception:
             self._baseline_scores_filename = None
@@ -182,7 +187,7 @@ class UCR_UEA_datasets:
             ]
 
     def list_datasets(self):
-        """List datasets (both univariate and multivariate) available in the 
+        """List datasets (both univariate and multivariate) available in the
         UCR/UEA archive.
 
         Examples
@@ -213,9 +218,8 @@ class UCR_UEA_datasets:
         >>> "BeetleFly" in l
         True
         """
-        return [path for path in os.listdir(self._data_dir)
-                if os.path.isdir(os.path.join(self._data_dir, path)) and
-                path not in self._ignore_list]
+        return [path.name for path in self._data_dir.iterdir()
+                if path.is_dir() and path.name not in self._ignore_list]
 
     def load_dataset(self, dataset_name):
         """Load a dataset from the UCR/UEA archive from its name.
@@ -259,16 +263,17 @@ class UCR_UEA_datasets:
         (7494, 8, 2)
         >>> assert (None, None, None, None) == data_loader.load_dataset(
         ...         "DatasetThatDoesNotExist")
+        >>>
         """
         dataset_name = self._filenames.get(dataset_name, dataset_name)
-        full_path = os.path.join(self._data_dir, dataset_name)
+        full_path = self._data_dir / dataset_name
 
         if not self._has_files(dataset_name) or not self.use_cache:
             # completely clear the target directory first, it will be created
             # by extract_from_zip_url if it does not exist
             try:
                 # maybe it is a normal file (not a directory) for some obscure reason
-                os.remove(full_path)
+                full_path.unlink()
             except FileNotFoundError:
                 pass  # nothing to do here, already deleted
             except IsADirectoryError:
@@ -276,8 +281,7 @@ class UCR_UEA_datasets:
                 shutil.rmtree(full_path, ignore_errors=True)
             # else, actually raise the error!
 
-            url = ("https://www.timeseriesclassification.com/aeon-toolkit/%s.zip"
-                   % dataset_name)
+            url = BASE_URL + Path(dataset_name).with_suffix(".zip").name
             success = extract_from_zip_url(url, target_dir=full_path)
             if not success:
                 warnings.warn("dataset \"%s\" could not be downloaded or "
@@ -289,25 +293,21 @@ class UCR_UEA_datasets:
             # if both TXT and ARFF files are provided, the TXT versions are
             # used
             # both training and test data must be available in the same format
-            if self._has_files(dataset_name, ext="txt"):
-                X_train, y_train = _load_txt_uea(
-                    os.path.join(full_path, dataset_name + "_TRAIN.txt")
-                )
-                X_test, y_test = _load_txt_uea(
-                    os.path.join(full_path, dataset_name + "_TEST.txt")
-                )
-            elif self._has_files(dataset_name, ext="arff"):
-                X_train, y_train = _load_arff_uea(
-                    os.path.join(full_path, dataset_name + "_TRAIN.arff")
-                )
-                X_test, y_test = _load_arff_uea(
-                    os.path.join(full_path, dataset_name + "_TEST.arff")
-                )
+            for ext in SUPPORTED_EXT:
+                if self._has_files(dataset_name, ext=ext):
+                    load_fn = getattr(utils, f"_load_{ext}_uea")
+                    X_train, y_train = load_fn(
+                        full_path / (dataset_name + f"_TRAIN.{ext}")
+                    )
+                    X_test, y_test = load_fn(
+                        full_path / (dataset_name + f"_TEST.{ext}")
+                    )
+                    break
             else:
-                warnings.warn("dataset \"%s\" is not provided in either TXT "
-                              "or ARFF format and thus could not be loaded"
-                              % dataset_name,
-                              category=RuntimeWarning, stacklevel=2)
+                warnings.warn(
+                    f'dataset "{dataset_name}" is not provided in supported '
+                    f'formats {SUPPORTED_EXT} and thus could not be loaded'
+                )
                 return None, None, None, None
 
             return X_train, y_train, X_test, y_test
@@ -338,14 +338,16 @@ class UCR_UEA_datasets:
             file extension
         """
         if ext is None:
-            return (self._has_files(dataset_name, ext="txt") or
-                    self._has_files(dataset_name, ext="arff"))
+            return any(
+                self._has_files(dataset_name, ext=ext) for ext in SUPPORTED_EXT
+            )
         else:
             dataset_name = self._filenames.get(dataset_name, dataset_name)
-            full_path = os.path.join(self._data_dir, dataset_name)
-            basename = os.path.join(full_path, dataset_name)
-            return (os.path.exists(basename + "_TRAIN.%s" % ext) and
-                    os.path.exists(basename + "_TEST.%s" % ext))
+            full_path = self._data_dir / dataset_name
+            return (
+                (full_path / (dataset_name + f"_TRAIN.{ext}")).exists() and
+                (full_path / (dataset_name + f"_TEST.{ext}")).exists()
+            )
 
     def cache_all(self):
         """Cache all datasets from the UCR/UEA archive for later use."""

--- a/tslearn/datasets/ucr_uea.py
+++ b/tslearn/datasets/ucr_uea.py
@@ -1,3 +1,4 @@
+import os
 import warnings
 import csv
 import shutil
@@ -10,6 +11,26 @@ from .datasets import in_file_string_replace, extract_from_zip_url
 BASE_URL = "https://www.timeseriesclassification.com/aeon-toolkit/"
 
 SUPPORTED_EXT = ["txt", "arff"]
+
+
+def _check_root_dir(root_dir=None):
+    """Get the default root directory for caching datasets, following the XDG Base
+    Directory Specification if possible.
+
+    Returns
+    -------
+    str
+        The path to the default root directory for caching datasets.
+    """
+    if root_dir is not None:
+        return Path(root_dir)
+    # Support for XDG Base Directory Specification for cache location,
+    # with fallback to ~/.tslearn/datasets/UCR_UEA
+    data_home = os.environ.get("XDG_DATA_HOME", None)
+    if data_home is not None:
+        return Path(data_home) / "tslearn"
+    else:
+        return Path.home() / ".tslearn" / "datasets"
 
 
 class UCR_UEA_datasets:
@@ -48,10 +69,7 @@ class UCR_UEA_datasets:
     """
     def __init__(self, use_cache=True, root_dir=None):
         self.use_cache = use_cache
-        if root_dir is None:
-            self._data_dir = Path.home() / ".tslearn" / "datasets" / "UCR_UEA"
-        else:
-            self._data_dir = Path(root_dir) / "UCR_UEA"
+        self._data_dir = _check_root_dir(root_dir) / "UCR_UEA"
         self._data_dir.mkdir(parents=True, exist_ok=True)
 
         try:

--- a/tslearn/datasets/ucr_uea.py
+++ b/tslearn/datasets/ucr_uea.py
@@ -288,7 +288,6 @@ class UCR_UEA_datasets:
         (7494, 8, 2)
         >>> assert (None, None, None, None) == data_loader.load_dataset(
         ...         "DatasetThatDoesNotExist")
-        >>>
         """
         dataset_name = self._filenames.get(dataset_name, dataset_name)
         full_path = self._data_dir / dataset_name


### PR DESCRIPTION
Proposal for dataset management:
- Allow changing the root_dir on `UCR_UEA_datasets`
- Move from `os.path` to `pathlib`
- Respect the `XDG_DATA_HOME` convention for cache directory (I could also remove this if you are not convinced by it but many projects follow it :)

Also add some dedicated dataset test (not only doctests).

Happy to change anything that you don't like, the most interesting change for me is the `root_dir` override to allow caching at different locations depending on the needs.