### PR TITLE
Revert "Bump pillow from 12.2.0 to 12.3.0 in /docs (#687)"

### DIFF
--- a/docs/requirements_rtd.txt
+++ b/docs/requirements_rtd.txt
@@ -62,7 +62,7 @@ packaging==26.1
     # via
     #   matplotlib
     #   sphinx
-pillow==12.3.0
+pillow==12.2.0
     # via
     #   matplotlib
     #   sphinx-gallery


### PR DESCRIPTION
This reverts commit b9673ffd11109abe81fb207a236a3b4333844ae5.