### PR TITLE
[MRG] Fix two docs build issues

### DIFF
--- a/docs/examples/classification/plot_shapelet_distances.py
+++ b/docs/examples/classification/plot_shapelet_distances.py
@@ -27,7 +27,6 @@ os.environ["KERAS_BACKEND"] = "torch"
 
 from keras.optimizers import Adam
 import numpy
-from matplotlib import cm
 import matplotlib.pyplot as plt
 
 from tslearn.datasets import CachedDatasets
@@ -62,7 +61,7 @@ distances = shp_clf.transform(X_train).reshape((-1, 2))
 weights, biases = shp_clf.get_weights('classification')
 
 # Create a grid for our two shapelets on the left and distances on the right
-viridis = cm.get_cmap('viridis', 4)
+viridis = plt.get_cmap('viridis', 4)
 fig = plt.figure(constrained_layout=True)
 gs = fig.add_gridspec(3, 9)
 fig_ax1 = fig.add_subplot(gs[0, :2])

--- a/tslearn/datasets/ucr_uea.py
+++ b/tslearn/datasets/ucr_uea.py
@@ -54,9 +54,10 @@ class UCR_UEA_datasets:
     root_dir : str or None (default: None)
         Directory to be used to cache downloaded datasets.
         If None, a default directory is used:
-           - If the environment variable `XDG_DATA_HOME` is set, the default
-             directory is `$XDG_DATA_HOME/tslearn/UCR_UEA`.
-           - Otherwise, the default directory is `~/.tslearn/datasets/UCR_UEA`.
+
+        - If the environment variable `XDG_DATA_HOME` is set, the default
+          directory is `$XDG_DATA_HOME/tslearn/UCR_UEA`.
+        - Otherwise, the default directory is `~/.tslearn/datasets/UCR_UEA`.
 
     Notes
     -----


### PR DESCRIPTION
- Replace deprecated matplotlib.cm.get_cmap with plt.get_cmap in the shapelet distances example.
- Fix RST bullet list formatting in UCR_UEA_datasets docstring (missing blank line before list caused a docutils "Unexpected indentation" error).