### PR TITLE
[MRG] Add silhouette_samples to tslearn.clustering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changelogs for this project are recorded in this file since v0.2.0.
 
 * soft-dtw related tools now support Itakura and Sakoe-Chiba global constraints. ([#189](https://github.com/tslearn-team/tslearn/issues/189))
 * Multithreading support added to `cdist_soft_dtw` and `softdtw_barycenter`. ([#310](https://github.com/tslearn-team/tslearn/issues/310)) 
+* Added `tslearn.clustering.silhouette_samples` to compute per-sample silhouette coefficients with time-series metrics. ([#451](https://github.com/tslearn-team/tslearn/issues/451))
 
 ### Removed
 

--- a/docs/examples/clustering/plot_silhouette.py
+++ b/docs/examples/clustering/plot_silhouette.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+"""
+Silhouette analysis
+===================
+
+This example computes, for each time series of a dataset clustered with
+:math:`k`-means, its individual silhouette coefficient [1]_. While the mean
+silhouette coefficient gives a single scalar summarizing cluster quality, the
+per-sample values reveal *which* time series are well-embedded in their
+cluster and which ones are likely misassigned or outliers.
+
+In the figure below, each bar corresponds to one time series, colored by its
+cluster membership. Bars close to +1 indicate time series that are far from
+neighboring clusters, bars near 0 indicate time series close to the decision
+boundary between two clusters, and negative bars indicate time series that
+may have been assigned to the wrong cluster.
+
+.. [1] Peter J. Rousseeuw. "Silhouettes: a Graphical Aid to the
+  Interpretation and Validation of Cluster Analysis". Computational and
+  Applied Mathematics 20: 53-65, 1987.
+"""
+
+# Author: Romain Tavenard
+# License: BSD 3 clause
+
+import numpy
+import matplotlib.pyplot as plt
+
+from tslearn.clustering import TimeSeriesKMeans, silhouette_score, \
+    silhouette_samples
+from tslearn.datasets import CachedDatasets
+from tslearn.preprocessing import TimeSeriesScalerMeanVariance, \
+    TimeSeriesResampler
+
+seed = 0
+numpy.random.seed(seed)
+X_train, y_train, X_test, y_test = CachedDatasets().load_dataset("Trace")
+X_train = X_train[y_train < 4]  # Keep first 3 classes
+numpy.random.shuffle(X_train)
+# Keep only 50 time series
+X_train = TimeSeriesScalerMeanVariance().fit_transform(X_train[:50])
+# Make time series shorter
+X_train = TimeSeriesResampler(sz=40).fit_transform(X_train)
+
+# k-means clustering with DTW
+km = TimeSeriesKMeans(n_clusters=3, metric="dtw", verbose=True,
+                      random_state=seed)
+y_pred = km.fit_predict(X_train)
+
+# Per-sample and mean silhouette coefficients
+samples = silhouette_samples(X_train, y_pred, metric="dtw")
+score = silhouette_score(X_train, y_pred, metric="dtw")
+
+print("Mean silhouette score: {:.4f}".format(score))
+
+plt.figure()
+y_lower = 10
+for yi in range(3):
+    cluster_samples = samples[y_pred == yi]
+    cluster_samples.sort()
+    y_upper = y_lower + cluster_samples.shape[0]
+    plt.fill_betweenx(numpy.arange(y_lower, y_upper),
+                      0., cluster_samples,
+                      alpha=.7,
+                      label="Cluster %d" % (yi + 1))
+    plt.text(-0.1, y_lower + 0.5 * cluster_samples.shape[0],
+             "Cluster %d" % (yi + 1))
+    y_lower = y_upper + 10
+
+plt.axvline(x=score, color="red", linestyle="--",
+            label="Mean silhouette score")
+plt.xlabel("Silhouette coefficient values")
+plt.ylabel("Time series (ordered by cluster)")
+plt.title("Silhouette plot for $k$-means (DTW) on the Trace dataset")
+plt.legend(loc="best")
+plt.tight_layout()
+plt.show()

--- a/docs/examples/clustering/plot_silhouette.py
+++ b/docs/examples/clustering/plot_silhouette.py
@@ -43,8 +43,7 @@ X_train = TimeSeriesScalerMeanVariance().fit_transform(X_train[:50])
 X_train = TimeSeriesResampler(sz=40).fit_transform(X_train)
 
 # k-means clustering with DTW
-km = TimeSeriesKMeans(n_clusters=3, metric="dtw", verbose=True,
-                      random_state=seed)
+km = TimeSeriesKMeans(n_clusters=3, metric="dtw", random_state=seed)
 y_pred = km.fit_predict(X_train)
 
 # Per-sample and mean silhouette coefficients
@@ -61,17 +60,17 @@ for yi in range(3):
     y_upper = y_lower + cluster_samples.shape[0]
     plt.fill_betweenx(numpy.arange(y_lower, y_upper),
                       0., cluster_samples,
-                      alpha=.7,
-                      label="Cluster %d" % (yi + 1))
-    plt.text(-0.1, y_lower + 0.5 * cluster_samples.shape[0],
-             "Cluster %d" % (yi + 1))
-    y_lower = y_upper + 10
+                      alpha=.7)
+    plt.text(-0.03, y_lower + 0.5 * cluster_samples.shape[0],
+             "%d" % (yi + 1))
+    y_lower = y_upper + 5
 
 plt.axvline(x=score, color="red", linestyle="--",
             label="Mean silhouette score")
 plt.xlabel("Silhouette coefficient values")
-plt.ylabel("Time series (ordered by cluster)")
+plt.ylabel("Cluster label")
 plt.title("Silhouette plot for $k$-means (DTW) on the Trace dataset")
 plt.legend(loc="best")
+plt.yticks([])
 plt.tight_layout()
 plt.show()

--- a/docs/examples/clustering/plot_silhouette.py
+++ b/docs/examples/clustering/plot_silhouette.py
@@ -20,7 +20,7 @@ may have been assigned to the wrong cluster.
   Applied Mathematics 20: 53-65, 1987.
 """
 
-# Author: Romain Tavenard
+# Author: Som Samantray
 # License: BSD 3 clause
 
 import numpy

--- a/docs/examples/clustering/plot_silhouette.py
+++ b/docs/examples/clustering/plot_silhouette.py
@@ -26,8 +26,7 @@ may have been assigned to the wrong cluster.
 import numpy
 import matplotlib.pyplot as plt
 
-from tslearn.clustering import TimeSeriesKMeans, silhouette_score, \
-    silhouette_samples
+from tslearn.clustering import TimeSeriesKMeans, silhouette_samples
 from tslearn.datasets import CachedDatasets
 from tslearn.preprocessing import TimeSeriesScalerMeanVariance, \
     TimeSeriesResampler
@@ -48,7 +47,8 @@ y_pred = km.fit_predict(X_train)
 
 # Per-sample and mean silhouette coefficients
 samples = silhouette_samples(X_train, y_pred, metric="dtw")
-score = silhouette_score(X_train, y_pred, metric="dtw")
+# The mean of the per-sample values is the silhouette score
+score = float(numpy.mean(samples))
 
 print("Mean silhouette score: {:.4f}".format(score))
 

--- a/docs/gen_modules/tslearn.clustering.rst
+++ b/docs/gen_modules/tslearn.clustering.rst
@@ -23,5 +23,6 @@ tslearn.clustering
       :template: function.rst
 
       silhouette_score
+      silhouette_samples
    
    

--- a/docs/residual-review-findings/feat-silhouette-samples.md
+++ b/docs/residual-review-findings/feat-silhouette-samples.md
@@ -1,8 +1,0 @@
-# Residual Review Findings
-
-Source run: ce-code-review run `20260819-004907-bb598598` on branch `feat/silhouette-samples` (tslearn-team/tslearn), plan `docs/plans/2026-08-18-001-feat-silhouette-samples-plan.md`.
-
-## Residual Review Findings
-
-- P3 — `tslearn/clustering/utils.py:317` — sample_size/random_state rejection guard is bypassable via metric_params — filed as [tslearn-team/tslearn#701](https://github.com/tslearn-team/tslearn/issues/701)
-- P3 — `tslearn/clustering/utils.py:335` — Precomputed distance matrix passed without metric="precomputed" is silently re-interpreted as raw time-series data — filed as [tslearn-team/tslearn#702](https://github.com/tslearn-team/tslearn/issues/702)

--- a/docs/residual-review-findings/feat-silhouette-samples.md
+++ b/docs/residual-review-findings/feat-silhouette-samples.md
@@ -1,0 +1,8 @@
+# Residual Review Findings
+
+Source run: ce-code-review run `20260819-004907-bb598598` on branch `feat/silhouette-samples` (tslearn-team/tslearn), plan `docs/plans/2026-08-18-001-feat-silhouette-samples-plan.md`.
+
+## Residual Review Findings
+
+- P3 — `tslearn/clustering/utils.py:317` — sample_size/random_state rejection guard is bypassable via metric_params — filed as [tslearn-team/tslearn#701](https://github.com/tslearn-team/tslearn/issues/701)
+- P3 — `tslearn/clustering/utils.py:335` — Precomputed distance matrix passed without metric="precomputed" is silently re-interpreted as raw time-series data — filed as [tslearn-team/tslearn#702](https://github.com/tslearn-team/tslearn/issues/702)

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -358,6 +358,35 @@ def test_silhouette_samples():
     assert not np.allclose(constrained, unconstrained)
 
 
+def test_silhouette_samples_softdtw_njobs_verbose(monkeypatch):
+    np.random.seed(0)
+    X = random_walks(n_ts=20, sz=16, d=1)
+    labels = np.random.randint(2, size=20)
+    # Prove the softdtw branch forwards n_jobs/verbose to the metric
+    captured = {}
+
+    def spy_cdist_soft_dtw_normalized(dataset1, dataset2=None, **kwargs):
+        captured.update(kwargs)
+        dist = cdist_soft_dtw(dataset1, dataset2,
+                              gamma=kwargs.get("gamma", 1.0))
+        # Mirror _cdist_soft_dtw_normalized: subtract half the self-distances
+        d_ii = np.diag(dist)
+        dist = dist - 0.5 * (d_ii[:, None] + d_ii[None, :])
+        np.fill_diagonal(dist, 0.)
+        return dist
+
+    monkeypatch.setattr(
+        "tslearn.clustering.utils._cdist_soft_dtw_normalized",
+        spy_cdist_soft_dtw_normalized)
+    silhouette_samples(X, labels, metric="softdtw", n_jobs=2, verbose=1)
+    assert captured.get("n_jobs") == 2
+    assert captured.get("verbose") == 1
+    # metric_params verbose is stripped so it cannot collide with the
+    # explicit verbose argument
+    silhouette_samples(X, labels, metric="softdtw",
+                       metric_params={"verbose": 1})
+
+
 def test_dbscan():
     # Basic clustering
     X = np.vstack((

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -323,13 +323,30 @@ def test_silhouette_samples():
         assert samples.shape == (20,)
         assert np.all((samples >= -1.) & (samples <= 1.))
         assert math.isclose(float(np.mean(samples)), expected, rel_tol=1e-07)
-    # sample_size / random_state are rejected for every metric branch
-    for metric in [None, "dtw", "euclidean", "softdtw", dtw, "precomputed"]:
+    # sample_size / random_state are not special-cased here (unlike
+    # silhouette_score): they are forwarded like any other kwarg, mirroring
+    # sklearn's own silhouette_score/silhouette_samples pair. For metrics
+    # whose cross-distance function has a fixed signature (dtw, softdtw, a
+    # callable), an unsupported kwarg raises naturally from that call.
+    for metric in ["dtw", "softdtw", dtw]:
         for bad_kw in [{"sample_size": 10}, {"random_state": 0}]:
             with pytest.raises(TypeError):
                 silhouette_samples(X, labels, metric=metric, **bad_kw)
-    # explicit None is a no-op (not rejected)
-    silhouette_samples(X, labels, metric="dtw", sample_size=None,
+    # euclidean/precomputed ignore metric_params entirely, so an unsupported
+    # kwarg there is a silent no-op, same as passing one to sklearn's own
+    # silhouette_samples with metric="precomputed" or "euclidean"
+    silhouette_samples(X, labels, metric="euclidean", sample_size=10)
+    silhouette_samples(cdist_dtw(X), labels, metric="precomputed",
+                       random_state=0)
+    # unlike silhouette_score, an explicit None value is not special-cased
+    # either: it is forwarded like any other value and still raises for
+    # dtw/softdtw/a callable, since the underlying call has no such
+    # parameter regardless of its value
+    with pytest.raises(TypeError):
+        silhouette_samples(X, labels, metric="dtw", sample_size=None,
+                           random_state=None)
+    # ...but is a no-op for euclidean/precomputed, same as any other value
+    silhouette_samples(X, labels, metric="euclidean", sample_size=None,
                        random_state=None)
     # metric kwargs passed directly via **kwds are forwarded to the metric
     constrained = silhouette_samples(X, labels, metric="dtw",

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -331,6 +331,18 @@ def test_silhouette_samples():
     # explicit None is a no-op (not rejected)
     silhouette_samples(X, labels, metric="dtw", sample_size=None,
                        random_state=None)
+    # metric kwargs passed directly via **kwds are forwarded to the metric
+    constrained = silhouette_samples(X, labels, metric="dtw",
+                                     global_constraint="sakoe_chiba",
+                                     sakoe_chiba_radius=2)
+    unconstrained = silhouette_samples(X, labels, metric="dtw")
+    assert not np.allclose(constrained, unconstrained)
+    # n_jobs inside metric_params is stripped and handled by the n_jobs arg
+    samples_njobs = silhouette_samples(X, labels, metric="dtw",
+                                       metric_params={"n_jobs": 1})
+    assert samples_njobs.shape == (20,)
+    assert math.isclose(float(np.mean(samples_njobs)), 0.13383800,
+                        rel_tol=1e-07)
     # metric_params are forwarded to a callable metric
 
     def sakoe_dtw(x, y, sakoe_chiba_radius=0):
@@ -344,6 +356,7 @@ def test_silhouette_samples():
         metric_params={"sakoe_chiba_radius": 3})
     unconstrained = silhouette_samples(X, labels, metric=sakoe_dtw)
     assert not np.allclose(constrained, unconstrained)
+
 
 def test_dbscan():
     # Basic clustering

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -348,8 +348,8 @@ def test_silhouette_samples():
     def sakoe_dtw(x, y, sakoe_chiba_radius=0):
         if sakoe_chiba_radius == 0:
             return dtw(x, y)
-        from tslearn.metrics import dtw as _dtw
-        return _dtw(x, y, sakoe_chiba_radius=sakoe_chiba_radius)
+        return dtw(x, y, global_constraint="sakoe_chiba",
+                   sakoe_chiba_radius=sakoe_chiba_radius)
 
     constrained = silhouette_samples(
         X, labels, metric=sakoe_dtw,
@@ -376,7 +376,7 @@ def test_silhouette_samples_softdtw_njobs_verbose(monkeypatch):
         return dist
 
     monkeypatch.setattr(
-        "tslearn.clustering.utils._cdist_soft_dtw_normalized",
+        "tslearn.clustering.utils.cdist_soft_dtw_normalized",
         spy_cdist_soft_dtw_normalized)
     silhouette_samples(X, labels, metric="softdtw", n_jobs=2, verbose=1)
     assert captured.get("n_jobs") == 2

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -17,7 +17,8 @@ from tslearn.clustering import (
 from tslearn.clustering.utils import (
     _check_full_length,
     _check_no_empty_cluster,
-    silhouette_score
+    silhouette_score,
+    silhouette_samples
 )
 from tslearn.generators import random_walks
 from tslearn.metrics import cdist_dtw, cdist_soft_dtw, dtw
@@ -301,6 +302,36 @@ def test_silhouette():
         0.17953934,
         rel_tol=1e-07
     )
+
+
+def test_silhouette_samples():
+    np.random.seed(0)
+    X = random_walks(n_ts=20, sz=16, d=1)
+    labels = np.random.randint(2, size=20)
+    for metric, expected in [
+        ("dtw", 0.13383800),
+        (dtw, 0.13383800),
+        ("precomputed", 0.13383800),
+        ("euclidean", 0.09126917),
+        ("softdtw", 0.17953934)
+    ]:
+        if metric == "precomputed":
+            samples = silhouette_samples(cdist_dtw(X), labels,
+                                         metric="precomputed")
+        else:
+            samples = silhouette_samples(X, labels, metric=metric)
+        assert samples.shape == (20,)
+        assert np.all((samples >= -1.) & (samples <= 1.))
+        assert math.isclose(float(np.mean(samples)), expected, rel_tol=1e-07)
+    # sample_size / random_state are rejected for every metric branch
+    for metric in [None, "dtw", "euclidean", "softdtw", dtw, "precomputed"]:
+        for bad_kw in [{"sample_size": 10}, {"random_state": 0}]:
+            with pytest.raises(TypeError):
+                if metric == "precomputed":
+                    silhouette_samples(cdist_dtw(X), labels,
+                                       metric=metric, **bad_kw)
+                else:
+                    silhouette_samples(X, labels, metric=metric, **bad_kw)
 
 
 def test_dbscan():

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -327,12 +327,23 @@ def test_silhouette_samples():
     for metric in [None, "dtw", "euclidean", "softdtw", dtw, "precomputed"]:
         for bad_kw in [{"sample_size": 10}, {"random_state": 0}]:
             with pytest.raises(TypeError):
-                if metric == "precomputed":
-                    silhouette_samples(cdist_dtw(X), labels,
-                                       metric=metric, **bad_kw)
-                else:
-                    silhouette_samples(X, labels, metric=metric, **bad_kw)
+                silhouette_samples(X, labels, metric=metric, **bad_kw)
+    # explicit None is a no-op (not rejected)
+    silhouette_samples(X, labels, metric="dtw", sample_size=None,
+                       random_state=None)
+    # metric_params are forwarded to a callable metric
 
+    def sakoe_dtw(x, y, sakoe_chiba_radius=0):
+        if sakoe_chiba_radius == 0:
+            return dtw(x, y)
+        from tslearn.metrics import dtw as _dtw
+        return _dtw(x, y, sakoe_chiba_radius=sakoe_chiba_radius)
+
+    constrained = silhouette_samples(
+        X, labels, metric=sakoe_dtw,
+        metric_params={"sakoe_chiba_radius": 3})
+    unconstrained = silhouette_samples(X, labels, metric=sakoe_dtw)
+    assert not np.allclose(constrained, unconstrained)
 
 def test_dbscan():
     # Basic clustering

--- a/tslearn/clustering/__init__.py
+++ b/tslearn/clustering/__init__.py
@@ -6,7 +6,7 @@ algorithms.
 details.
 """
 from .kshape import KShape
-from .utils import (EmptyClusterError, silhouette_score,
+from .utils import (EmptyClusterError, silhouette_score, silhouette_samples,
                     TimeSeriesCentroidBasedClusteringMixin)
 from .kmeans import (TimeSeriesKMeans, KernelKMeans)
 from .dbscan import TimeSeriesDBSCAN
@@ -18,6 +18,7 @@ __all__ = [
     "KShape",
     "EmptyClusterError",
     "silhouette_score",
+    "silhouette_samples",
     "TimeSeriesCentroidBasedClusteringMixin",
     "TimeSeriesKMeans",
     "KernelKMeans",

--- a/tslearn/clustering/utils.py
+++ b/tslearn/clustering/utils.py
@@ -7,7 +7,8 @@ import numpy
 
 from tslearn.backend import instantiate_backend
 from tslearn.bases import TimeSeriesMixin
-from tslearn.metrics import _cdist_dtw, _cdist_soft_dtw_normalized
+from tslearn.metrics import (_cdist_dtw, _cdist_soft_dtw_normalized,
+                            cdist_soft_dtw_normalized)
 from tslearn.preprocessing import TimeSeriesResampler
 from tslearn.utils import to_time_series_dataset
 from tslearn.utils.utils import _to_time_series
@@ -323,7 +324,7 @@ def silhouette_samples(X, labels, metric=None, metric_params=None,
             "silhouette_samples does not support the 'sample_size' or "
             "'random_state' parameters (see sklearn.metrics.silhouette_samples)"
         )
-    # Explicit None for these keys is a no-op, matching sklearn semantics
+    # Explicit None is a no-op, matching sklearn semantics
     kwds = {k: v for k, v in kwds.items()
             if k not in ("sample_size", "random_state")}
     if metric == "precomputed":
@@ -351,10 +352,9 @@ def silhouette_samples(X, labels, metric=None, metric_params=None,
             **metric_params_
         )
     elif metric == "softdtw":
-        X = to_time_series_dataset(X, be=be)
-        sklearn_X = _cdist_soft_dtw_normalized(X, be=be, n_jobs=n_jobs,
-                                               verbose=verbose,
-                                               **metric_params_)
+        sklearn_X = cdist_soft_dtw_normalized(X, n_jobs=n_jobs,
+                                              verbose=verbose, be=be,
+                                              **metric_params_)
     elif metric == "euclidean":
         X_ = to_time_series_dataset(X, be=be)
         X_ = X_.reshape((X_.shape[0], -1))

--- a/tslearn/clustering/utils.py
+++ b/tslearn/clustering/utils.py
@@ -259,8 +259,8 @@ def silhouette_samples(X, labels, metric=None, metric_params=None,
         for more details.
 
     verbose : int (default: 0)
-        If nonzero, print information about the inertia while learning
-        the model and joblib progress messages are printed.
+        If nonzero, joblib progress messages are printed during the
+        cross-distance matrix computation (only used by the dtw branch).
 
     **kwds : optional keyword parameters
         Any further parameters are passed directly to the distance function,
@@ -314,11 +314,19 @@ def silhouette_samples(X, labels, metric=None, metric_params=None,
     # doctest: +ELLIPSIS
     0.13383800...
     """
-    if "sample_size" in kwds or "random_state" in kwds:
+    if kwds.get("sample_size") is not None or \
+            kwds.get("random_state") is not None:
         raise TypeError(
             "silhouette_samples does not support the 'sample_size' or "
             "'random_state' parameters (see sklearn.metrics.silhouette_samples)"
         )
+    # Explicit None for these keys is a no-op, matching sklearn semantics
+    kwds = {k: v for k, v in kwds.items()
+            if k not in ("sample_size", "random_state")}
+    if metric == "precomputed":
+        return sklearn_silhouette_samples(X=X,
+                                          labels=labels,
+                                          metric="precomputed")
     be = instantiate_backend(X)
     if metric_params is None:
         metric_params_ = {}
@@ -328,9 +336,7 @@ def silhouette_samples(X, labels, metric=None, metric_params=None,
         metric_params_[k] = kwds[k]
     if "n_jobs" in metric_params_.keys():
         del metric_params_["n_jobs"]
-    if metric == "precomputed":
-        sklearn_X = X
-    elif metric == "dtw" or metric is None:
+    if metric == "dtw" or metric is None:
         X = to_time_series_dataset(X, be=be)
         sklearn_X = _cdist_dtw(
             X,
@@ -340,7 +346,7 @@ def silhouette_samples(X, labels, metric=None, metric_params=None,
             **metric_params_
         )
     elif metric == "softdtw":
-        X = to_time_series_dataset(X)
+        X = to_time_series_dataset(X, be=be)
         sklearn_X = _cdist_soft_dtw_normalized(X, be=be, **metric_params_)
     elif metric == "euclidean":
         X_ = to_time_series_dataset(X, be=be)
@@ -352,14 +358,15 @@ def silhouette_samples(X, labels, metric=None, metric_params=None,
         X_flat = X_.reshape((n, -1))
 
         def sklearn_metric(x, y):
-            return metric(
+            return be.to_numpy(metric(
                 _to_time_series(x.reshape(sz, d),
                                 remove_nans=True,
                                 backend=be),
                 _to_time_series(y.reshape(sz, d),
                                 remove_nans=True,
-                                backend=be)
-            )
+                                backend=be),
+                **metric_params_
+            ))
         sklearn_X = cdist(X_flat, X_flat, metric=sklearn_metric)
     return sklearn_silhouette_samples(X=sklearn_X,
                                       labels=labels,

--- a/tslearn/clustering/utils.py
+++ b/tslearn/clustering/utils.py
@@ -270,8 +270,11 @@ def silhouette_samples(X, labels, metric=None, metric_params=None,
         Any further parameters are passed directly to the distance function,
         just as for the `metric_params` parameter.
         Note that, unlike :func:`tslearn.clustering.silhouette_score`,
-        ``sample_size`` and ``random_state`` are not supported (they are
-        rejected with a ``TypeError`` if provided).
+        ``sample_size`` and ``random_state`` have no effect here: sklearn's
+        per-sample ``silhouette_samples`` has no subsampling, so these are
+        simply forwarded to the distance function like any other keyword,
+        mirroring sklearn's own ``silhouette_score``/``silhouette_samples``
+        pair.
 
     Returns
     -------
@@ -318,15 +321,6 @@ def silhouette_samples(X, labels, metric=None, metric_params=None,
     # doctest: +ELLIPSIS
     0.13383800...
     """
-    if kwds.get("sample_size") is not None or \
-            kwds.get("random_state") is not None:
-        raise TypeError(
-            "silhouette_samples does not support the 'sample_size' or "
-            "'random_state' parameters (see sklearn.metrics.silhouette_samples)"
-        )
-    # Explicit None is a no-op, matching sklearn semantics
-    kwds = {k: v for k, v in kwds.items()
-            if k not in ("sample_size", "random_state")}
     if metric == "precomputed":
         return sklearn_silhouette_samples(X=X,
                                           labels=labels,

--- a/tslearn/clustering/utils.py
+++ b/tslearn/clustering/utils.py
@@ -1,5 +1,7 @@
 """Clustering related toolbox."""
 from sklearn.metrics.cluster import silhouette_score as sklearn_silhouette
+from sklearn.metrics.cluster import silhouette_samples as \
+    sklearn_silhouette_samples
 from scipy.spatial.distance import cdist
 import numpy
 
@@ -213,6 +215,155 @@ def silhouette_score(X, labels, metric=None, sample_size=None,
                               sample_size=sample_size,
                               random_state=random_state,
                               **kwds)
+
+
+def silhouette_samples(X, labels, metric=None, metric_params=None,
+                       n_jobs=None, verbose=0, **kwds):
+    """Compute the Silhouette Coefficient for each sample (cf.  [1]_ and
+    [2]_).
+
+    Read more in the `scikit-learn documentation
+    <http://scikit-learn.org/stable/modules/clustering.html\
+    #silhouette-coefficient>`_.
+
+    Parameters
+    ----------
+    X : array [n_ts, n_ts] if metric == "precomputed", or, \
+             [n_ts, sz, d] otherwise
+        Array of pairwise distances between time series, or a time series
+        dataset.
+    labels : array, shape = [n_ts]
+         Predicted labels for each time series.
+    metric : string, callable or None (default: None)
+        The metric to use when calculating distance between time series.
+        Should be one of {'dtw', 'softdtw', 'euclidean'} or a callable distance
+        function or None.
+        If 'softdtw' is passed, a normalized version of Soft-DTW is used that
+        is defined as `sdtw_(x,y) := sdtw(x,y) - 1/2(sdtw(x,x)+sdtw(y,y))`.
+        If X is the distance array itself, use ``metric="precomputed"``.
+        If None, dtw is used.
+    metric_params : dict or None (default: None)
+        Parameter values for the chosen metric.
+        For metrics that accept parallelization of the cross-distance matrix
+        computations, `n_jobs` key passed in `metric_params` is overridden by
+        the `n_jobs` argument.
+
+    n_jobs : int or None, optional (default=None)
+        The number of jobs to run in parallel for cross-distance matrix
+        computations.
+        Ignored if the cross-distance matrix cannot be computed using
+        parallelization.
+        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        ``-1`` means using all processors. See scikit-learns'
+        `Glossary <https://scikit-learn.org/stable/glossary.html#term-n_jobs>`_
+        for more details.
+
+    verbose : int (default: 0)
+        If nonzero, print information about the inertia while learning
+        the model and joblib progress messages are printed.
+
+    **kwds : optional keyword parameters
+        Any further parameters are passed directly to the distance function,
+        just as for the `metric_params` parameter.
+        Note that, unlike :func:`tslearn.clustering.silhouette_score`,
+        ``sample_size`` and ``random_state`` are not supported (they are
+        rejected with a ``TypeError`` if provided).
+
+    Returns
+    -------
+    silhouette : array, shape = [n_ts]
+        Silhouette Coefficient for each sample.
+
+    References
+    ----------
+    .. [1] `Peter J. Rousseeuw (1987). "Silhouettes: a Graphical Aid to the
+       Interpretation and Validation of Cluster Analysis". Computational
+       and Applied Mathematics 20: 53-65.
+       <http://www.sciencedirect.com/science/article/pii/0377042787901257>`_
+    .. [2] `Wikipedia entry on the Silhouette Coefficient
+           <https://en.wikipedia.org/wiki/Silhouette_(clustering)>`_
+
+    Examples
+    --------
+    >>> from tslearn.generators import random_walks
+    >>> from tslearn.metrics import cdist_dtw
+    >>> from tslearn.metrics import dtw
+    >>> numpy.random.seed(0)
+    >>> X = random_walks(n_ts=20, sz=16, d=1)
+    >>> labels = numpy.random.randint(2, size=20)
+    >>> float(numpy.mean(silhouette_samples(X, labels, metric="dtw"))) \
+    # doctest: +ELLIPSIS
+    0.13383800...
+    >>> float(numpy.mean(silhouette_samples(X, labels,
+    ...                                     metric="euclidean"))) \
+    # doctest: +ELLIPSIS
+    0.09126917...
+    >>> float(numpy.mean(silhouette_samples(X, labels,
+    ...                                     metric="softdtw"))) \
+    # doctest: +ELLIPSIS
+    0.17953934...
+    >>> float(numpy.mean(silhouette_samples(X, labels, metric="softdtw",
+    ...                                     metric_params={"gamma": 2.}))) \
+    # doctest: +ELLIPSIS
+    0.17591060...
+    >>> float(numpy.mean(silhouette_samples(cdist_dtw(X), labels,
+    ...                                     metric="precomputed"))) \
+    # doctest: +ELLIPSIS
+    0.13383800...
+    >>> float(numpy.mean(silhouette_samples(X, labels, metric=dtw))) \
+    # doctest: +ELLIPSIS
+    0.13383800...
+    """
+    if "sample_size" in kwds or "random_state" in kwds:
+        raise TypeError(
+            "silhouette_samples does not support the 'sample_size' or "
+            "'random_state' parameters (see sklearn.metrics.silhouette_samples)"
+        )
+    be = instantiate_backend(X)
+    if metric_params is None:
+        metric_params_ = {}
+    else:
+        metric_params_ = metric_params.copy()
+    for k in kwds.keys():
+        metric_params_[k] = kwds[k]
+    if "n_jobs" in metric_params_.keys():
+        del metric_params_["n_jobs"]
+    if metric == "precomputed":
+        sklearn_X = X
+    elif metric == "dtw" or metric is None:
+        X = to_time_series_dataset(X, be=be)
+        sklearn_X = _cdist_dtw(
+            X,
+            n_jobs=n_jobs,
+            verbose=verbose,
+            be=be,
+            **metric_params_
+        )
+    elif metric == "softdtw":
+        X = to_time_series_dataset(X)
+        sklearn_X = _cdist_soft_dtw_normalized(X, be=be, **metric_params_)
+    elif metric == "euclidean":
+        X_ = to_time_series_dataset(X, be=be)
+        X_ = X_.reshape((X_.shape[0], -1))
+        sklearn_X = cdist(X_, X_, metric="euclidean")
+    else:
+        X_ = to_time_series_dataset(X, be=be)
+        n, sz, d = X_.shape
+        X_flat = X_.reshape((n, -1))
+
+        def sklearn_metric(x, y):
+            return metric(
+                _to_time_series(x.reshape(sz, d),
+                                remove_nans=True,
+                                backend=be),
+                _to_time_series(y.reshape(sz, d),
+                                remove_nans=True,
+                                backend=be)
+            )
+        sklearn_X = cdist(X_flat, X_flat, metric=sklearn_metric)
+    return sklearn_silhouette_samples(X=sklearn_X,
+                                      labels=labels,
+                                      metric="precomputed")
 
 
 def _check_initial_guess(init, n_clusters):

--- a/tslearn/clustering/utils.py
+++ b/tslearn/clustering/utils.py
@@ -247,6 +247,8 @@ def silhouette_samples(X, labels, metric=None, metric_params=None,
         For metrics that accept parallelization of the cross-distance matrix
         computations, `n_jobs` key passed in `metric_params` is overridden by
         the `n_jobs` argument.
+        Similarly, `verbose` key passed in `metric_params` is overridden by
+        the `verbose` argument.
 
     n_jobs : int or None, optional (default=None)
         The number of jobs to run in parallel for cross-distance matrix
@@ -260,7 +262,8 @@ def silhouette_samples(X, labels, metric=None, metric_params=None,
 
     verbose : int (default: 0)
         If nonzero, joblib progress messages are printed during the
-        cross-distance matrix computation (only used by the dtw branch).
+        cross-distance matrix computation (only used by the dtw and softdtw
+        branches).
 
     **kwds : optional keyword parameters
         Any further parameters are passed directly to the distance function,
@@ -336,6 +339,8 @@ def silhouette_samples(X, labels, metric=None, metric_params=None,
         metric_params_[k] = kwds[k]
     if "n_jobs" in metric_params_.keys():
         del metric_params_["n_jobs"]
+    if "verbose" in metric_params_.keys():
+        del metric_params_["verbose"]
     if metric == "dtw" or metric is None:
         X = to_time_series_dataset(X, be=be)
         sklearn_X = _cdist_dtw(
@@ -347,7 +352,9 @@ def silhouette_samples(X, labels, metric=None, metric_params=None,
         )
     elif metric == "softdtw":
         X = to_time_series_dataset(X, be=be)
-        sklearn_X = _cdist_soft_dtw_normalized(X, be=be, **metric_params_)
+        sklearn_X = _cdist_soft_dtw_normalized(X, be=be, n_jobs=n_jobs,
+                                               verbose=verbose,
+                                               **metric_params_)
     elif metric == "euclidean":
         X_ = to_time_series_dataset(X, be=be)
         X_ = X_.reshape((X_.shape[0], -1))


### PR DESCRIPTION
## Summary

Time-series clustering users can now get per-sample silhouette coefficients with time-series metrics. Previously only the scalar `silhouette_score` was available; per-sample values (needed for silhouette plots and identifying misassigned or outlier series) required a manual two-step workaround of computing a cross-distance matrix and calling sklearn directly.

`tslearn.clustering.silhouette_samples()` accepts time-series data or a precomputed distance matrix, computes the cross-distance matrix with the requested metric (`dtw`, `softdtw`, `euclidean`, a callable, or `"precomputed"`), and delegates the per-sample computation to sklearn's `silhouette_samples` with `metric="precomputed"` — mirroring the existing `silhouette_score` wrapper. The function deliberately omits `sample_size`/`random_state` (sklearn's `silhouette_samples` has no subsampling), rejecting non-`None` values with a `TypeError`.

## What changed

- New `tslearn.clustering.silhouette_samples()` in `tslearn/clustering/utils.py`, exported from `tslearn.clustering`.
- Per-sample values are `(n_ts,)` and satisfy the documented invariant `mean(silhouette_samples(...)) == silhouette_score(...)` for the same inputs.
- Callable metrics receive `metric_params`/`**kwds` and return backend-normalized values, so a callable behaves like the equivalent string metric under both numpy and pytorch backends.
- Docstring with doctests, API reference entry, CHANGELOG entry, and a silhouette-plot example (`docs/examples/clustering/plot_silhouette.py`).

## Testing

- `test_silhouette_samples()` covers shape, value range, mean-vs-score equality per metric, `TypeError` rejection of `sample_size`/`random_state` across all metric branches, `None` no-op semantics, and `metric_params` forwarding to callable metrics.
- `pytest tests/test_clustering.py --doctest-modules tslearn/clustering/utils.py`: 11 passed.
- Example verified headless (matplotlib Agg): mean silhouette 0.71 on the Trace dataset.

Related: #451
