### PR TITLE
[MRG] Document DBA initialization differences

### DIFF
--- a/tslearn/barycenters/dba.py
+++ b/tslearn/barycenters/dba.py
@@ -500,6 +500,9 @@ def dtw_barycenter_averaging(
     DBA was originally presented in [1]_.
     This implementation is based on an idea from [2]_ (Majorize-Minimize Mean
     Algorithm).
+    By default, the initial barycenter is the pointwise mean of ``X``.
+    Petitjean's standalone ``DBA.py`` instead starts from an approximate
+    medoid, so set ``init_barycenter`` explicitly when comparing results.
 
     Parameters
     ----------


### PR DESCRIPTION
Title: [MRG] Document DBA initialization differences

## Summary

- Document that `dtw_barycenter_averaging` starts from the pointwise mean by
  default.
- Clarify that Petitjean's standalone `DBA.py` starts from an approximate
  medoid and that comparisons should provide the same `init_barycenter`.

The issue snapshot is unassigned and shows no related PR or duplicate label.

## Test evidence

- `python3 -c 'import ast, pathlib; tree = ast.parse(pathlib.Path("tslearn/barycenters/dba.py").read_text()); doc = next(ast.get_docstring(node) for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "dtw_barycenter_averaging"); doc = " ".join(doc.split()); assert "starts from an approximate medoid" in doc and "set ``init_barycenter`` explicitly" in doc'`
- `git diff --check`

Both commands passed. Runtime doctests were not available in the Builder
environment because pytest and joblib are not installed.

## Risks or notes for maintainers

The reporter did not provide the requested reproduction data, so this patch
does not claim that initialization is the only source of the plotted
difference. It changes documentation only and intentionally leaves #445 open
for a concrete reproduction.

Refs #445
