### PR TITLE
Fix LCSS ignoring the global_constraint / Sakoe-Chiba band

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Changelogs for this project are recorded in this file since v0.2.0.
 
 * soft-dtw API is now consistent with other metrics regarding parameters names and backend management.
 
+### Fixed
+
+* `lcss` and `lcss_path_from_metric` now respect the `global_constraint` / Sakoe-Chiba / Itakura band, which was previously ignored. ([#526](https://github.com/tslearn-team/tslearn/issues/526))
+
 ## [v0.9.0]
 
 ### Added

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -231,6 +231,22 @@ def test_lcss():
             np.testing.assert_equal(sim, 1.0)
 
 
+def test_lcss_sakoe_chiba_constraint():
+    # A Sakoe-Chiba band must actually restrict the matched pairs. The two
+    # matches giving 0.5 sit two steps off the diagonal, so a radius-1 band
+    # forbids one of them and the similarity drops to 0.25.
+    s1 = [2.0, 0.0, 2.0, 0.0]
+    s2 = [0.0, 0.0, 1.0, 1.0]
+    for be in backends:
+        sim = tslearn.metrics.lcss(s1, s2, eps=0, be=be)
+        np.testing.assert_equal(sim, 0.5)
+
+        sim = tslearn.metrics.lcss(
+            s1, s2, eps=0, global_constraint="sakoe_chiba", sakoe_chiba_radius=1, be=be
+        )
+        np.testing.assert_equal(sim, 0.25)
+
+
 def test_lcss_path():
     for be in backends:
         for array_type in array_types:

--- a/tslearn/metrics/dtw_variants.py
+++ b/tslearn/metrics/dtw_variants.py
@@ -971,7 +971,7 @@ def njit_lcss_accumulated_matrix(s1, s2, eps, mask):
 
     for i in range(1, l1 + 1):
         for j in range(1, l2 + 1):
-            if numpy.isfinite(mask[i - 1, j - 1]):
+            if mask[i - 1, j - 1]:
                 if numpy.sqrt(_njit_local_squared_dist(s1[i - 1], s2[j - 1])) <= eps:
                     acc_cost_mat[i][j] = 1 + acc_cost_mat[i - 1][j - 1]
                 else:
@@ -1566,7 +1566,7 @@ def njit_lcss_accumulated_matrix_from_dist_matrix(dist_matrix, eps, mask):
 
     for i in range(1, l1 + 1):
         for j in range(1, l2 + 1):
-            if numpy.isfinite(mask[i - 1, j - 1]):
+            if mask[i - 1, j - 1]:
                 if dist_matrix[i - 1, j - 1] <= eps:
                     acc_cost_mat[i][j] = 1 + acc_cost_mat[i - 1][j - 1]
                 else:


### PR DESCRIPTION
`lcss` and `lcss_path_from_metric` accept `global_constraint` / `sakoe_chiba_radius` / `itakura_max_slope`, but the constraint is silently ignored: the numba LCSS score functions test the band with `numpy.isfinite(mask[i - 1, j - 1])`. The mask returned by `compute_mask` is a boolean array, and `numpy.isfinite` is `True` for both `True` and `False`, so the test is always true and no pairing is ever excluded.

Repro:

```python
import tslearn.metrics as M
s1 = [2.0, 0.0, 2.0, 0.0]
s2 = [0.0, 0.0, 1.0, 1.0]
print(M.lcss(s1, s2, eps=0))  # 0.5
print(M.lcss(s1, s2, eps=0, global_constraint="sakoe_chiba", sakoe_chiba_radius=1))  # 0.5, should be 0.25
```

The two matches that give `0.5` sit two steps off the diagonal, so a radius-1 Sakoe-Chiba band forbids one of them and the similarity should drop to `0.25` (confirmed with a brute-force LCSS restricted to the band).

The fix tests the boolean mask directly (`if mask[i - 1, j - 1]:`), which is the same convention already used by `_dtw.py` and the non-numba LCSS backend. Only the two score functions are changed. The two path-backtracking functions keep `isfinite` on purpose: their `while i > 0 and j > 0` loop only decrements inside the `if` block, so honoring the mask there could loop forever on a masked cell; constrained `lcss_path` is left as a separate follow-up.

Added a regression test that checks the unconstrained result is unchanged (`0.5`) and the radius-1 result is now `0.25`. Relates to #526.
