### PR TITLE
[MRG] Document KShape normalization requirement

### DIFF
--- a/tslearn/clustering/kshape.py
+++ b/tslearn/clustering/kshape.py
@@ -77,6 +77,8 @@ class KShape(TimeSeriesCentroidBasedClusteringMixin,
     Notes
     -----
         This method requires a dataset of equal-sized time series.
+        The time series must be z-normalized, for example with
+        :class:`~tslearn.preprocessing.TimeSeriesScalerMeanVariance`.
 
     Examples
     --------


### PR DESCRIPTION
Title: [MRG] Document KShape normalization requirement

## Summary

- Document that KShape expects z-normalized time series.
- Point users to the existing `TimeSeriesScalerMeanVariance` preprocessing utility already used in the example.
- Keep this as a non-closing clarification because the issue does not include the dataset needed to verify the reported empty-cluster behavior, and related initialization and multivariate fixes are already present in the base.

## Test evidence

- `python3 -c "import ast, pathlib; doc=ast.get_docstring(next(n for n in ast.parse(pathlib.Path('tslearn/clustering/kshape.py').read_text()).body if isinstance(n, ast.ClassDef) and n.name == 'KShape')); assert 'must be z-normalized' in doc and 'TimeSeriesScalerMeanVariance' in doc"`
- `git diff --check`

Both commands pass.

## Risks or notes for maintainers

This documents required preprocessing but does not claim to solve every source of empty clusters, including duplicate or indistinguishable series. No runtime behavior changes.

Refs #439
