### PR TITLE
Fix TypeError when be is passed to silhouette_score/silhouette_samples

### DIFF
--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -393,6 +393,10 @@ def test_silhouette_pinned_kwargs_not_forwarded():
                         rel_tol=1e-07)
     assert samples.shape == (12,)
     assert silhouette_score(X, labels, metric="dtw", be="numpy") is not None
+    # verbose is pinned by silhouette_score's call sites too; passing it
+    # through metric_params must be stripped, not forwarded
+    assert silhouette_score(X, labels, metric="dtw",
+                            metric_params={"verbose": 1}) is not None
 
 
 def test_silhouette_samples_softdtw_njobs_verbose(monkeypatch):

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -375,6 +375,26 @@ def test_silhouette_samples():
     assert not np.allclose(constrained, unconstrained)
 
 
+def test_silhouette_pinned_kwargs_not_forwarded():
+    # Regression test: `be` (and `verbose` in silhouette_score) are pinned by
+    # the call sites, so forwarding them through metric_params/**kwds used to
+    # raise "got multiple values for keyword argument 'be'". They must be
+    # stripped like n_jobs, since the backend is fixed by instantiate_backend.
+    np.random.seed(0)
+    X = random_walks(n_ts=12, sz=16, d=1)
+    labels = np.random.randint(2, size=12)
+
+    score = silhouette_score(X, labels, metric="dtw",
+                             metric_params={"be": "numpy"})
+    samples = silhouette_samples(X, labels, metric="dtw",
+                                 metric_params={"be": "numpy"})
+    assert math.isclose(float(score),
+                        float(np.mean(samples)),
+                        rel_tol=1e-07)
+    assert samples.shape == (12,)
+    assert silhouette_score(X, labels, metric="dtw", be="numpy") is not None
+
+
 def test_silhouette_samples_softdtw_njobs_verbose(monkeypatch):
     np.random.seed(0)
     X = random_walks(n_ts=20, sz=16, d=1)

--- a/tslearn/clustering/utils.py
+++ b/tslearn/clustering/utils.py
@@ -178,6 +178,10 @@ def silhouette_score(X, labels, metric=None, sample_size=None,
         metric_params_[k] = kwds[k]
     if "n_jobs" in metric_params_.keys():
         del metric_params_["n_jobs"]
+    if "verbose" in metric_params_.keys():
+        del metric_params_["verbose"]
+    if "be" in metric_params_.keys():
+        del metric_params_["be"]
     if metric == "precomputed":
         sklearn_X = X
     elif metric == "dtw" or metric is None:
@@ -342,6 +346,8 @@ def silhouette_samples(X, labels, metric=None, metric_params=None,
         del metric_params_["n_jobs"]
     if "verbose" in metric_params_.keys():
         del metric_params_["verbose"]
+    if "be" in metric_params_.keys():
+        del metric_params_["be"]
     if metric == "dtw" or metric is None:
         X = to_time_series_dataset(X, be=be)
         sklearn_X = _cdist_dtw(


### PR DESCRIPTION
Closes #713.

## Problem
`silhouette_score` / `silhouette_samples` pin `be=be` (backend fixed via `instantiate_backend(X)`) in their internal cross-distance calls, but kwargs merged from `metric_params`/`**kwds` were still forwarded — so `metric_params={"be": "numpy"}` raised:

```
TypeError: _cdist_dtw() got multiple values for keyword argument 'be'
```

## Fix
Treat `be` exactly like the already-handled `n_jobs`/`verbose`: strip it from `metric_params_` before the splat, in **both** functions. Also added `verbose` stripping to `silhouette_score`, which pins `verbose=verbose` in its calls but only stripped `n_jobs` — same collision class (`samples()` already stripped both).

## Verification
- Reproduced the exact `TypeError` on master for both functions before touching anything.
- After fix: both calls succeed; `silhouette_score(X, labels, metric="dtw", metric_params={"be": "numpy"})` equals `np.mean(silhouette_samples(...))` as expected.
- Added regression test `test_silhouette_pinned_kwargs_not_forwarded` covering: `be` via `metric_params`, and `be` via `**kwds`.
- Full `tests/test_clustering.py`: **10 passed** (includes all pre-existing silhouette tests unchanged).
