### PR TITLE
[MRG] Fix silhouette metric parameter collisions

### DIFF
--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -404,6 +404,46 @@ def test_silhouette_samples_softdtw_njobs_verbose(monkeypatch):
                        metric_params={"verbose": 1})
 
 
+@pytest.mark.parametrize("silhouette_func",
+                         [silhouette_score, silhouette_samples])
+@pytest.mark.parametrize(
+    "metric_params, extra_kwds",
+    [
+        ({"be": "ignored", "n_jobs": -1, "verbose": 99}, {}),
+        (None, {"be": "ignored"}),
+    ],
+    ids=["metric-params", "direct-keyword"]
+)
+def test_silhouette_controlled_metric_params_are_not_forwarded(
+        monkeypatch, silhouette_func, metric_params, extra_kwds):
+    X = np.arange(8, dtype=float).reshape(4, 2, 1)
+    labels = np.array([0, 0, 1, 1])
+    distances = np.array([
+        [0., 1., 5., 6.],
+        [1., 0., 4., 5.],
+        [5., 4., 0., 1.],
+        [6., 5., 1., 0.],
+    ])
+    captured = {}
+
+    def fake_cdist_dtw(dataset1, dataset2=None, *, n_jobs=None, verbose=0,
+                       be=None, **forwarded_params):
+        captured.update(n_jobs=n_jobs, verbose=verbose, be=be,
+                        forwarded_params=forwarded_params)
+        return distances
+
+    monkeypatch.setattr("tslearn.clustering.utils._cdist_dtw",
+                        fake_cdist_dtw)
+
+    silhouette_func(X, labels, metric="dtw", metric_params=metric_params,
+                    n_jobs=2, verbose=3, **extra_kwds)
+
+    assert captured["n_jobs"] == 2
+    assert captured["verbose"] == 3
+    assert captured["be"] != "ignored"
+    assert captured["forwarded_params"] == {}
+
+
 def test_dbscan():
     # Basic clustering
     X = np.vstack((

--- a/tslearn/clustering/utils.py
+++ b/tslearn/clustering/utils.py
@@ -103,8 +103,9 @@ def silhouette_score(X, labels, metric=None, sample_size=None,
     metric_params : dict or None (default: None)
         Parameter values for the chosen metric.
         For metrics that accept parallelization of the cross-distance matrix
-        computations, `n_jobs` key passed in `metric_params` is overridden by
-        the `n_jobs` argument.
+        computations, `n_jobs` and `verbose` keys passed in `metric_params`
+        are overridden by the corresponding function arguments. The `be` key
+        is ignored because the backend is inferred from `X`.
 
     n_jobs : int or None, optional (default=None)
         The number of jobs to run in parallel for cross-distance matrix
@@ -129,6 +130,7 @@ def silhouette_score(X, labels, metric=None, sample_size=None,
     **kwds : optional keyword parameters
         Any further parameters are passed directly to the distance function,
         just as for the `metric_params` parameter.
+        The `be` keyword is ignored because the backend is inferred from `X`.
 
     Returns
     -------
@@ -174,10 +176,10 @@ def silhouette_score(X, labels, metric=None, sample_size=None,
         metric_params_ = {}
     else:
         metric_params_ = metric_params.copy()
-    for k in kwds.keys():
-        metric_params_[k] = kwds[k]
-    if "n_jobs" in metric_params_.keys():
-        del metric_params_["n_jobs"]
+    kwds.pop("be", None)
+    metric_params_.update(kwds)
+    for k in ("be", "n_jobs", "verbose"):
+        metric_params_.pop(k, None)
     if metric == "precomputed":
         sklearn_X = X
     elif metric == "dtw" or metric is None:
@@ -252,10 +254,9 @@ def silhouette_samples(X, labels, metric=None, metric_params=None,
     metric_params : dict or None (default: None)
         Parameter values for the chosen metric.
         For metrics that accept parallelization of the cross-distance matrix
-        computations, `n_jobs` key passed in `metric_params` is overridden by
-        the `n_jobs` argument.
-        Similarly, `verbose` key passed in `metric_params` is overridden by
-        the `verbose` argument.
+        computations, `n_jobs` and `verbose` keys passed in `metric_params`
+        are overridden by the corresponding function arguments. The `be` key
+        is ignored because the backend is inferred from `X`.
 
     n_jobs : int or None, optional (default=None)
         The number of jobs to run in parallel for cross-distance matrix
@@ -275,6 +276,7 @@ def silhouette_samples(X, labels, metric=None, metric_params=None,
     **kwds : optional keyword parameters
         Any further parameters are passed directly to the distance function,
         just as for the `metric_params` parameter.
+        The `be` keyword is ignored because the backend is inferred from `X`.
         Note that, unlike :func:`tslearn.clustering.silhouette_score`,
         ``sample_size`` and ``random_state`` have no effect here: sklearn's
         per-sample ``silhouette_samples`` has no subsampling, so these are
@@ -336,12 +338,10 @@ def silhouette_samples(X, labels, metric=None, metric_params=None,
         metric_params_ = {}
     else:
         metric_params_ = metric_params.copy()
-    for k in kwds.keys():
-        metric_params_[k] = kwds[k]
-    if "n_jobs" in metric_params_.keys():
-        del metric_params_["n_jobs"]
-    if "verbose" in metric_params_.keys():
-        del metric_params_["verbose"]
+    kwds.pop("be", None)
+    metric_params_.update(kwds)
+    for k in ("be", "n_jobs", "verbose"):
+        metric_params_.pop(k, None)
     if metric == "dtw" or metric is None:
         X = to_time_series_dataset(X, be=be)
         sklearn_X = _cdist_dtw(


### PR DESCRIPTION
## Summary

- prevent `be`, `n_jobs`, and `verbose` from colliding with arguments already controlled by `silhouette_score` and `silhouette_samples`
- handle `be` consistently whether it arrives through `metric_params` or direct keyword input
- document which metric parameters are overridden or inferred
- add regression coverage for both public functions and both input paths

The precomputed-metric behavior discussed in #714 is intentionally unchanged.

Closes #713

## Validation

- `pytest tests/test_clustering.py -q` — 13 passed
- `pytest --doctest-modules tslearn/clustering/utils.py -q` — 3 passed
- `pytest -q --doctest-modules` — 1,168 passed, 44 skipped, 11 xfailed
- `git diff --check`