### PR TITLE
Document that silhouette_samples ignores kwargs for metric="precomputed"

### DIFF
--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -338,6 +338,13 @@ def test_silhouette_samples():
     silhouette_samples(X, labels, metric="euclidean", sample_size=10)
     silhouette_samples(cdist_dtw(X), labels, metric="precomputed",
                        random_state=0)
+    # metric_params/n_jobs/verbose are likewise a no-op for precomputed, and
+    # do not change the result (now documented on the function's docstring)
+    baseline = silhouette_samples(cdist_dtw(X), labels, metric="precomputed")
+    ignored = silhouette_samples(cdist_dtw(X), labels, metric="precomputed",
+                                 metric_params={"gamma": 2.}, n_jobs=2,
+                                 verbose=1)
+    np.testing.assert_array_equal(baseline, ignored)
     # unlike silhouette_score, an explicit None value is not special-cased
     # either: it is forwarded like any other value and still raises for
     # dtw/softdtw/a callable, since the underlying call has no such

--- a/tslearn/clustering/utils.py
+++ b/tslearn/clustering/utils.py
@@ -256,12 +256,16 @@ def silhouette_samples(X, labels, metric=None, metric_params=None,
         the `n_jobs` argument.
         Similarly, `verbose` key passed in `metric_params` is overridden by
         the `verbose` argument.
+        Ignored when ``metric="precomputed"``, since no distance function is
+        called in that case: this mirrors scikit-learn's own
+        ``silhouette_samples``, which likewise ignores extra keyword
+        parameters for a precomputed distance matrix.
 
     n_jobs : int or None, optional (default=None)
         The number of jobs to run in parallel for cross-distance matrix
         computations.
         Ignored if the cross-distance matrix cannot be computed using
-        parallelization.
+        parallelization, and when ``metric="precomputed"``.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See scikit-learns'
         `Glossary <https://scikit-learn.org/stable/glossary.html#term-n_jobs>`_
@@ -270,11 +274,12 @@ def silhouette_samples(X, labels, metric=None, metric_params=None,
     verbose : int (default: 0)
         If nonzero, joblib progress messages are printed during the
         cross-distance matrix computation (only used by the dtw and softdtw
-        branches).
+        branches). Ignored when ``metric="precomputed"``.
 
     **kwds : optional keyword parameters
         Any further parameters are passed directly to the distance function,
-        just as for the `metric_params` parameter.
+        just as for the `metric_params` parameter. Ignored when
+        ``metric="precomputed"``, for the same reason as `metric_params`.
         Note that, unlike :func:`tslearn.clustering.silhouette_score`,
         ``sample_size`` and ``random_state`` have no effect here: sklearn's
         per-sample ``silhouette_samples`` has no subsampling, so these are
@@ -328,6 +333,9 @@ def silhouette_samples(X, labels, metric=None, metric_params=None,
     0.13383800...
     """
     if metric == "precomputed":
+        # metric_params/n_jobs/verbose/**kwds are intentionally ignored here:
+        # no distance function is called on a precomputed matrix, matching
+        # sklearn's own silhouette_samples(metric="precomputed") behavior.
         return sklearn_silhouette_samples(X=X,
                                           labels=labels,
                                           metric="precomputed")


### PR DESCRIPTION
## Summary

`silhouette_samples(..., metric="precomputed")` returns before `metric_params`, `n_jobs`, `verbose`, or `**kwds` are ever consulted, so they're silently ignored — no distance function is called on a precomputed matrix, matching sklearn's own `silhouette_samples`. That behavior wasn't documented anywhere on the function itself.

This PR documents it rather than raising, for parity with sklearn and with `silhouette_score`'s existing precomputed handling (see discussion on #713).

- Docstring notes on `metric_params`, `n_jobs`, `verbose`, and `**kwds` stating they're ignored when `metric="precomputed"`.
- Inline comment at the early-return explaining why.
- Regression test asserting `metric_params`/`n_jobs`/`verbose` passed alongside `metric="precomputed"` don't change the result.

Closes #714.

## Test plan

- [x] Manually traced the precomputed branch against the docstring changes and the existing test comments at `tests/test_clustering.py:335-337`, which already assumed this behavior.
- [x] Added `test_silhouette_samples` assertion comparing a baseline precomputed call against one with `metric_params`/`n_jobs`/`verbose` set, asserting equal output.
- [ ] Couldn't run the suite locally due to an unrelated broken Python/libexpat install in my environment — would appreciate CI running it.