### PR TITLE
[MRG] Reject complex input in soft-DTW barycenters

### DIFF
--- a/tests/test_barycenters.py
+++ b/tests/test_barycenters.py
@@ -215,3 +215,52 @@ def test_softdtw_barycenter_preserves_real_ragged_input():
         time_series, max_iter=0
     )
     np.testing.assert_allclose(barycenter, [[0.], [0.75], [1.5]])
+
+
+def test_softdtw_barycenter_rejects_complex_object_array():
+    time_series = np.empty(2, dtype=object)
+    time_series[:] = [
+        np.array([[1 + 2j], [3 + 4j]]),
+        np.array([[2 + 5j], [4 + 7j]]),
+    ]
+
+    with pytest.raises(ValueError, match="Complex-valued"):
+        tslearn.barycenters.softdtw_barycenter(time_series, max_iter=0)
+
+
+def test_softdtw_barycenter_accepts_real_ragged_object_array():
+    time_series = np.empty(2, dtype=object)
+    time_series[:] = [np.array([0., 1.]), np.array([0., 1., 2.])]
+
+    barycenter = tslearn.barycenters.softdtw_barycenter(
+        time_series, max_iter=0
+    )
+    np.testing.assert_allclose(barycenter, [[0.], [0.75], [1.5]])
+
+
+def test_softdtw_barycenter_rejects_complex_torch_input_and_init():
+    torch = pytest.importorskip("torch")
+    time_series = torch.tensor([[[1.], [3.]], [[2.], [4.]]])
+
+    with pytest.raises(ValueError, match="Complex-valued"):
+        tslearn.barycenters.softdtw_barycenter(
+            time_series.to(torch.complex64), max_iter=0
+        )
+
+    with pytest.raises(ValueError, match="Complex-valued"):
+        tslearn.barycenters.softdtw_barycenter(
+            time_series,
+            init=torch.tensor([[1 + 0j], [3 + 0j]]),
+            max_iter=0,
+        )
+
+
+def test_softdtw_barycenter_accepts_real_torch_input_and_init():
+    torch = pytest.importorskip("torch")
+    time_series = torch.tensor([[[1.], [3.]], [[2.], [4.]]])
+    init = torch.tensor([[1.], [3.]])
+
+    barycenter = tslearn.barycenters.softdtw_barycenter(
+        time_series, init=init, max_iter=0
+    )
+    torch.testing.assert_close(barycenter, init)

--- a/tests/test_barycenters.py
+++ b/tests/test_barycenters.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import tslearn.barycenters
 from tslearn.utils import to_time_series
@@ -173,3 +174,44 @@ def test_softdtw_barycenter():
     time_series[-1, -2:, :] = np.nan
     sdtw_bar = tslearn.barycenters.softdtw_barycenter(time_series, max_iter=5)
     assert sdtw_bar.shape == (sz, d)
+
+
+@pytest.mark.parametrize(
+    "time_series",
+    [
+        np.array([[[1 + 2j], [3 + 4j]], [[2 + 5j], [4 + 7j]]]),
+        np.array([[[1 + 0j], [3 + 0j]], [[2 + 0j], [4 + 0j]]]),
+        [[[1 + 2j], [3 + 4j]], [[2 + 5j], [4 + 7j]]],
+    ],
+    ids=["array", "zero-imag-array", "list"],
+)
+@pytest.mark.parametrize("max_iter", [0, 1])
+def test_softdtw_barycenter_rejects_complex_input(time_series, max_iter):
+    with pytest.raises(ValueError, match="Complex-valued"):
+        tslearn.barycenters.softdtw_barycenter(time_series, max_iter=max_iter)
+
+
+@pytest.mark.parametrize(
+    "init",
+    [
+        np.array([[1 + 2j], [3 + 4j]]),
+        np.array([[1 + 0j], [3 + 0j]]),
+        [[1 + 2j], [3 + 4j]],
+    ],
+    ids=["array", "zero-imag-array", "list"],
+)
+@pytest.mark.parametrize("max_iter", [0, 1])
+def test_softdtw_barycenter_rejects_complex_init(init, max_iter):
+    time_series = np.array([[[1.], [3.]], [[2.], [4.]]])
+    with pytest.raises(ValueError, match="Complex-valued"):
+        tslearn.barycenters.softdtw_barycenter(
+            time_series, init=init, max_iter=max_iter
+        )
+
+
+def test_softdtw_barycenter_preserves_real_ragged_input():
+    time_series = [[0., 1.], [0., 1., 2.]]
+    barycenter = tslearn.barycenters.softdtw_barycenter(
+        time_series, max_iter=0
+    )
+    np.testing.assert_allclose(barycenter, [[0.], [0.75], [1.5]])

--- a/tslearn/barycenters/softdtw.py
+++ b/tslearn/barycenters/softdtw.py
@@ -21,6 +21,33 @@ from .utils import _set_weights
 __author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
 
 
+def _contains_complex_values(data, backend):
+    """Check for complex values without converting ragged inputs."""
+    if data is None:
+        return False
+    if isinstance(data, (list, tuple)):
+        return any(_contains_complex_values(value, backend) for value in data)
+
+    is_complex = getattr(data, "is_complex", None)
+    if callable(is_complex):
+        return bool(is_complex())
+
+    dtype = getattr(data, "dtype", None)
+    kind = getattr(dtype, "kind", None)
+    if kind == "c" or getattr(dtype, "is_complex", False):
+        return True
+    if kind == "O":
+        return any(
+            _contains_complex_values(value, backend) for value in data.flat
+        )
+    if kind is not None:
+        return False
+    if dtype is None:
+        return isinstance(data, complex)
+
+    return bool(backend.any(backend.iscomplex(data)))
+
+
 def _acc_softdtw_func(
     Z,
     X,
@@ -165,6 +192,11 @@ def softdtw_barycenter(
             if provided or `sz` otherwise
         Soft-DTW barycenter of the provided time series dataset.
 
+    Raises
+    ------
+    ValueError
+        If `X` or `init` contains complex-valued time series.
+
     Examples
     --------
     >>> time_series = [[1, 2, 3, 4], [1, 2, 4, 5]]
@@ -187,6 +219,14 @@ def softdtw_barycenter(
        Time-Series," ICML 2017.
     """
     backend = instantiate_backend(X)
+    if (
+        _contains_complex_values(X, backend)
+        or _contains_complex_values(init, backend)
+    ):
+        raise ValueError(
+            "Complex-valued time series are not supported by "
+            "softdtw_barycenter."
+        )
     X_ = to_time_series_dataset(X, be=backend)
 
     weights = _set_weights(weights, X_.shape[0])


### PR DESCRIPTION
Fixes #167.

`softdtw_barycenter` can discard imaginary values during conversion and return a real-only result. Reject unsupported complex datasets and initial barycenters before conversion or optimization, including complex dtypes whose imaginary part is zero. Real-valued ragged inputs remain supported.

Validation: 21 barycenter tests pass, including NumPy object/ragged arrays and Torch complex and real inputs. The complex object-array regression fails on the base revision. `git diff --check` passes.