### PR TITLE
Scale the input once in OneD_SymbolicAggregateApproximation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Changelogs for this project are recorded in this file since v0.2.0.
 ### Fixed
 
 * `lcss` and `lcss_path_from_metric` now respect the `global_constraint` / Sakoe-Chiba / Itakura band, which was previously ignored. ([#526](https://github.com/tslearn-team/tslearn/issues/526))
+* Fixed double scaling in `OneD_SymbolicAggregateApproximation`. ([#722](https://github.com/tslearn-team/tslearn/issues/722))
 
 ## [v0.9.0]
 

--- a/tests/test_piecewise.py
+++ b/tests/test_piecewise.py
@@ -93,3 +93,20 @@ def test_sax_scale():
     np.testing.assert_array_almost_equal(X, X_scale_unscale)
 
     knn_sax.predict(X)
+
+
+def test_1dsax_scale_matches_sax_average():
+    # With scale=True the average symbols of 1d-SAX must match those of SAX:
+    # both scale the series once, using the same fitted mean and std.
+    n, sz, d = 4, 12, 1
+    rng = np.random.RandomState(0)
+    X = rng.randn(n, sz, d) * 5 + 10
+
+    sax = SymbolicAggregateApproximation(n_segments=4, alphabet_size_avg=5,
+                                         scale=True)
+    one_d_sax = OneD_SymbolicAggregateApproximation(n_segments=4,
+                                                    alphabet_size_avg=5,
+                                                    alphabet_size_slope=5,
+                                                    scale=True)
+    np.testing.assert_array_equal(sax.fit_transform(X),
+                                  one_d_sax.fit_transform(X)[:, :, :d])

--- a/tslearn/piecewise/piecewise.py
+++ b/tslearn/piecewise/piecewise.py
@@ -687,15 +687,15 @@ class OneD_SymbolicAggregateApproximation(SymbolicAggregateApproximation):
         return X_slopes
 
     def _transform(self, X, y=None):
-        X = self._scale(X)
         n_ts, sz_raw, d = X.shape
         X_1d_sax = numpy.empty((n_ts, self.n_segments, 2 * d), dtype=int)
 
         # Average
+        # `SymbolicAggregateApproximation._transform` scales `X` itself.
         X_1d_sax_avg = SymbolicAggregateApproximation._transform(self, X)
 
         # Slope
-        X_slopes = self._get_slopes(X)
+        X_slopes = self._get_slopes(self._scale(X))
         X_1d_sax_slope = _paa_to_symbols(X_slopes, self.breakpoints_slope_)
 
         X_1d_sax[:, :, :d] = X_1d_sax_avg


### PR DESCRIPTION
`OneD_SymbolicAggregateApproximation._transform` scales `X` and then passes it to `SymbolicAggregateApproximation._transform`, which scales it again:

```python
def _transform(self, X, y=None):
    X = self._scale(X)
    ...
    X_1d_sax_avg = SymbolicAggregateApproximation._transform(self, X)   # scales again
```

`_scale` uses the fitted `mu_` and `std_`, so it is not idempotent — the average symbols end up computed from `((X - mu) / std - mu) / std`. The slopes are fine, since they are derived separately.

With `scale=True` on data that is not already standardised, the average symbols collapse. For a series with mean 10 and standard deviation 5:

```python
X = np.random.RandomState(0).randn(4, 12, 1) * 5 + 10
SymbolicAggregateApproximation(n_segments=4, alphabet_size_avg=5, scale=True).fit_transform(X)
OneD_SymbolicAggregateApproximation(n_segments=4, alphabet_size_avg=5,
                                    alphabet_size_slope=5, scale=True).fit_transform(X)[:, :, :1]
```

```
SAX     [3 3 2 3 2 3 0 2 2 3 1 1 3 0 2 1]     4 of 5 symbols used
1d-SAX  [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]     1 of 5 symbols used
```

Every segment lands in the same symbol, so the average half of the representation carries no information. `inverse_transform` also unscales only once, so the round-trip does not return to the input scale.

This lets the parent do the scaling for the average, and scales explicitly for the slopes, which need the scaled series as well.

Scope:

- `scale=False`, the default, is unchanged — average and slope symbols are identical before and after.
- With `scale=True` the **slope** symbols are also unchanged; only the average symbols move, and they now match `SymbolicAggregateApproximation` exactly.
- It does change the average symbols for anyone currently using `scale=True`. That output is degenerate today rather than merely different, which is why it seemed worth correcting rather than leaving.

The existing `test_1dsax` exercises `scale=True` but only asserts that `distance` and `distance_1d_sax` agree with each other, so it passes either way. The added test compares the average symbols against `SymbolicAggregateApproximation`; it fails on `main` and passes here. `tests/test_piecewise.py` goes 4 -> 5 passing, and `tests/test_estimators.py` for the SAX/piecewise estimators is 127 passed, 3 skipped.
