### PR TITLE
Convert global_constraint to its code in _cdist_frechet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Changelogs for this project are recorded in this file since v0.2.0.
 * `lcss` and `lcss_path_from_metric` now respect the `global_constraint` / Sakoe-Chiba / Itakura band, which was previously ignored. ([#526](https://github.com/tslearn-team/tslearn/issues/526))
 * `gak` and `cdist_gak` no longer return `NaN` for time series longer than about 405 samples. They are now normalized in log space, and the Global Alignment Kernel recursion falls back to a log-space accumulation when its value leaves the range of a 64-bit float. This also fixes `TimeSeriesSVC` / `TimeSeriesSVR` and `KernelKMeans` with `kernel="gak"` on long time series. ([#450](https://github.com/tslearn-team/tslearn/issues/450))
 * Fixed double scaling in `OneD_SymbolicAggregateApproximation`. ([#722](https://github.com/tslearn-team/tslearn/issues/722))
+* `cdist_frechet` now respects `global_constraint`, which was previously ignored. ([#726](https://github.com/tslearn-team/tslearn/issues/726))
 
 ## [v0.9.0]
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1306,3 +1306,21 @@ def test_softdtw_migration():
             old_cdist_normalized,
             rtol=1e-06
         )
+
+
+def test_cdist_frechet_honours_global_constraint():
+    # `cdist_frechet` must apply the constraint the same way scalar `frechet` does.
+    rng = np.random.RandomState(0)
+    dataset1 = rng.randn(3, 10, 1)
+    dataset2 = rng.randn(2, 10, 1)
+
+    expected = np.array([[
+        tslearn.metrics.frechet(ts1, ts2, global_constraint="sakoe_chiba",
+                                sakoe_chiba_radius=1)
+        for ts2 in dataset2
+    ] for ts1 in dataset1])
+    actual = tslearn.metrics.cdist_frechet(dataset1, dataset2,
+                                           global_constraint="sakoe_chiba",
+                                           sakoe_chiba_radius=1)
+
+    np.testing.assert_allclose(actual, expected)

--- a/tslearn/metrics/_frechet.py
+++ b/tslearn/metrics/_frechet.py
@@ -798,7 +798,7 @@ def _cdist_frechet(
         verbose=verbose,
         be=be,
         compute_diagonal=False,
-        global_constraint=global_constraint,
+        global_constraint=GLOBAL_CONSTRAINT_CODE[global_constraint],
         sakoe_chiba_radius=sakoe_chiba_radius,
         itakura_max_slope=itakura_max_slope,
     )


### PR DESCRIPTION
`_cdist_frechet` forwards the user-facing `global_constraint` string straight to the kernel, which compares it against the integer codes in `GLOBAL_CONSTRAINT_CODE`:

```python
return _cdist_generic(
    ...
    global_constraint=global_constraint,      # "sakoe_chiba", not GLOBAL_CONSTRAINT_CODE[...]
```

`"sakoe_chiba" == 2` is `False`, so `_compute_mask_generic` falls through to an all-`True` mask and the constraint is silently dropped — no error, just unconstrained distances.

```python
d1, d2 = rng.randn(3, 10, 1), rng.randn(2, 10, 1)
cdist_frechet(d1, d2)
cdist_frechet(d1, d2, global_constraint="sakoe_chiba", sakoe_chiba_radius=1)
[[frechet(a, b, global_constraint="sakoe_chiba", sakoe_chiba_radius=1) for b in d2] for a in d1]
```

On `main`:

```
no constraint            [1.862731 2.812605 1.775638 1.850314 2.707937 1.745519]
sakoe_chiba radius=1     [1.862731 2.812605 1.775638 1.850314 2.707937 1.745519]   <- identical
scalar frechet reference [2.959534 2.812605 2.102471 2.502826 2.707937 2.284454]
```

With this PR the constrained call returns the reference values exactly.

Both siblings already do the lookup — `_dtw.py` and `_soft_dtw.py` pass `GLOBAL_CONSTRAINT_CODE[global_constraint]` — and this file imports and uses that mapping in four other places.

Scope:

- `global_constraint=None` is unchanged, since `GLOBAL_CONSTRAINT_CODE[None]` is `0`.
- Values only change where a constraint was requested, and the current output there ignores it entirely.
- The public `cdist_frechet` wrapper a few lines above passes the string deliberately — it is `_cdist_frechet` that needs the code — so only that one call site changes.
- This also reaches `KNeighborsTimeSeries` and `TimeSeriesKMeans` with `metric="frechet"`, which dispatch through `_cdist_frechet`.

Added a test comparing `cdist_frechet` against the scalar `frechet` under a Sakoe-Chiba band; it fails on `main` and passes here. `tests/test_metrics.py` is 27 passed.
