### PR TITLE
Pass epsilon through to the underlying SVR in TimeSeriesSVR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Changelogs for this project are recorded in this file since v0.2.0.
 * `gak` and `cdist_gak` no longer return `NaN` for time series longer than about 405 samples. They are now normalized in log space, and the Global Alignment Kernel recursion falls back to a log-space accumulation when its value leaves the range of a 64-bit float. This also fixes `TimeSeriesSVC` / `TimeSeriesSVR` and `KernelKMeans` with `kernel="gak"` on long time series. ([#450](https://github.com/tslearn-team/tslearn/issues/450))
 * Fixed double scaling in `OneD_SymbolicAggregateApproximation`. ([#722](https://github.com/tslearn-team/tslearn/issues/722))
 * `cdist_frechet` now respects `global_constraint`, which was previously ignored. ([#726](https://github.com/tslearn-team/tslearn/issues/726))
+* `TimeSeriesSVR` now passes `epsilon` on to the underlying `sklearn.svm.SVR`, which was previously ignored so the epsilon-tube width was always the sklearn default. ([#727](https://github.com/tslearn-team/tslearn/issues/727))
 
 ## [v0.9.0]
 

--- a/tests/test_svm.py
+++ b/tests/test_svm.py
@@ -81,3 +81,24 @@ def test_attributes():
         for attr in ['coef_', 'support_', 'support_vectors_',
                      'dual_coef_', 'coef_', 'intercept_']:
             assert hasattr(linear_model, attr)
+
+
+def test_svr_epsilon_is_used():
+    # TimeSeriesSVR accepted and documented `epsilon` but never passed it on
+    # to the underlying sklearn SVR, so the epsilon-tube width was stuck at
+    # the sklearn default whatever the user asked for.
+    n, sz, d = 40, 20, 1
+    rng = np.random.RandomState(0)
+    time_series = rng.randn(n, sz, d)
+    targets = time_series[:, :, 0].mean(axis=1) * 5.
+
+    # `linear` keeps the fit deterministic (gak's gamma="auto" subsamples).
+    small = TimeSeriesSVR(kernel="linear", epsilon=0.1).fit(time_series, targets)
+    large = TimeSeriesSVR(kernel="linear", epsilon=5.).fit(time_series, targets)
+
+    assert small.svm_estimator_.epsilon == 0.1
+    assert large.svm_estimator_.epsilon == 5.
+
+    # A tube that wide leaves no point outside it, hence no support vector.
+    assert len(small.svm_estimator_.support_) > 0
+    assert len(large.svm_estimator_.support_) == 0

--- a/tslearn/svm/svm.py
+++ b/tslearn/svm/svm.py
@@ -585,7 +585,7 @@ class TimeSeriesSVR(TimeSeriesSVMMixin, RegressorMixin, BaseEstimator):
         self.svm_estimator_ = SVR(
             C=self.C, kernel=self.estimator_kernel_, degree=self.degree,
             gamma=self.gamma_, coef0=self.coef0, shrinking=self.shrinking,
-            tol=self.tol, cache_size=self.cache_size,
+            tol=self.tol, epsilon=self.epsilon, cache_size=self.cache_size,
             verbose=self.verbose, max_iter=self.max_iter
         )
         self.svm_estimator_.fit(sklearn_X, y, sample_weight=sample_weight)


### PR DESCRIPTION
### What this fixes

`TimeSeriesSVR.__init__` accepts `epsilon`, documents it in the class docstring —

> `epsilon : float, optional (default=0.1)` — Epsilon in the epsilon-SVR model. It specifies the epsilon-tube within which no penalty is associated in the training loss function with points predicted within a distance epsilon from the actual value.

— and stores it as `self.epsilon`. But `fit()` never reads it. The inner estimator is built with ten hyperparameters and `epsilon` is not among them:

```python
self.svm_estimator_ = SVR(
    C=self.C, kernel=self.estimator_kernel_, degree=self.degree,
    gamma=self.gamma_, coef0=self.coef0, shrinking=self.shrinking,
    tol=self.tol, cache_size=self.cache_size,
    verbose=self.verbose, max_iter=self.max_iter
)
```

So the tube width is always sklearn's default, whatever was requested.

### Evidence

Fitting the same data twice with a deterministic kernel (`linear`, since `gak`'s `gamma="auto"` subsamples and adds run-to-run noise):

| requested `epsilon` | inner `SVR.epsilon` | n support vectors |
|---|---|---|
| 0.1 | 0.1 | 19 |
| 5.0 | **0.1** | 19 |

Predictions were byte-identical between the two. The parameter is inert, so a `GridSearchCV` over `epsilon` silently searches nothing.

After the fix the requested value arrives, and a tube that wide leaves no point outside it:

| requested `epsilon` | inner `SVR.epsilon` | n support vectors |
|---|---|---|
| 0.1 | 0.1 | 19 |
| 5.0 | 5.0 | 0 |

### Compatibility

tslearn's default for `epsilon` is `0.1`, which is also sklearn's default, so anything fitted at default settings gives exactly the same result as before. Only users who explicitly passed `epsilon` see a change — and that change is the documented behaviour they were already asking for.

`TimeSeriesSVC` is unaffected: `epsilon` is regression-only and `SVC` has no such parameter.

### Testing

Added `test_svr_epsilon_is_used` in `tests/test_svm.py`, asserting the value reaches `svm_estimator_` and that a wide tube collapses the support set.

- without the fix: `assert 0.1 == 5.0` — fails
- with the fix: passes
- `tests/test_svm.py`, `tests/test_variablelength.py`, `tests/test_serialize_models.py`: 18 passed, 1 skipped
- `tests/test_estimators.py -k SVR` (sklearn estimator checks): 55 passed, 1 skipped, 1 xfailed, 2 xpassed
