### PR TITLE
Fix ctw_path never iterating because the path was compared with itself (#728)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ to reverse the normalization. ([#697](https://github.com/tslearn-team/tslearn/is
 * Fixed double scaling in `OneD_SymbolicAggregateApproximation`. ([#722](https://github.com/tslearn-team/tslearn/issues/722))
 * `cdist_frechet` now respects `global_constraint`, which was previously ignored. ([#726](https://github.com/tslearn-team/tslearn/issues/726))
 * `TimeSeriesSVR` now passes `epsilon` on to the underlying `sklearn.svm.SVR`, which was previously ignored so the epsilon-tube width was always the sklearn default. ([#727](https://github.com/tslearn-team/tslearn/issues/727))
+* `ctw` / `ctw_path` now iterate until the alignment path is stable. The loop used to compare the current path with itself and always stop after the first DTW, so the returned score was the identity-projection DTW and disagreed with the returned path. Canonical projections are rescaled to unit covariance before DTW, matching the CTW paper, which also stops period-2 path cycles. ([#728](https://github.com/tslearn-team/tslearn/issues/728))
 
 ## [v0.9.0]
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -127,9 +127,14 @@ def test_ctw():
                 assert backend.belongs_to_backend(dist)
 
             path, cca, dist = tslearn.metrics.ctw_path(
-                cast([1, 2, 3], array_type), cast([1.0, 2.0, 2.0, 3.0, 4.0], array_type), be=be
+                cast([1, 2, 3], array_type), cast([1.0, 2.0, 2.0, 3.0, 4.0], array_type),
+                max_iter=1, be=be
             )
             np.testing.assert_allclose(dist, 1.0)
+            path, cca, dist = tslearn.metrics.ctw_path(
+                cast([1, 2, 3], array_type), cast([1.0, 2.0, 2.0, 3.0, 4.0], array_type), be=be
+            )
+            np.testing.assert_allclose(dist, 0.751955, atol=1e-5)
             if not backend.is_numpy:
                 assert backend.belongs_to_backend(dist)
 
@@ -147,7 +152,7 @@ def test_ctw():
 
             # cdist_dtw
             dists = tslearn.metrics.cdist_ctw(cast([[1, 2, 2, 3], [1.0, 2.0, 3.0, 4.0]], array_type), be=be)
-            np.testing.assert_allclose(dists, [[0.0, 1.0], [1.0, 0.0]])
+            np.testing.assert_allclose(dists, [[0.0, 0.751955], [0.751955, 0.0]], atol=1e-5)
             assert backend.belongs_to_backend(dists)
 
             dists = tslearn.metrics.cdist_ctw(
@@ -155,9 +160,52 @@ def test_ctw():
                 [[1, 2, 3], [2, 3, 4, 5]], be=be  # The second dataset can not be cast to array because of its shape
             )
             np.testing.assert_allclose(
-                dists, [[0.0, 2.44949], [1.0, 1.414214]], atol=1e-5
+                dists, [[0.0, 0.751955], [0.670046, 0.939336]], atol=1e-5
             )
             assert backend.belongs_to_backend(dists)
+
+
+def test_ctw_path_iterates_until_alignment_stabilizes():
+    """Non-regression test for
+    https://github.com/tslearn-team/tslearn/issues/728
+
+    The loop compared the current path with itself, so it always broke
+    after the first DTW. The score stayed at the identity-projection DTW
+    and disagreed with the path / CCA actually returned.
+    """
+    rng = np.random.RandomState(0)
+    s1 = rng.randn(20, 3)
+    s2 = rng.randn(24, 3) @ np.linalg.qr(rng.randn(3, 3))[0]
+    dtw_score = tslearn.metrics.dtw(s1, s2)
+
+    np.testing.assert_allclose(
+        tslearn.metrics.ctw(s1, s2, max_iter=1), dtw_score
+    )
+
+    path, cca, score = tslearn.metrics.ctw_path(s1, s2)
+    seq1_tr, seq2_tr = cca.transform(s1, s2)
+    path_from_cca, score_from_cca = tslearn.metrics.dtw_path(seq1_tr, seq2_tr)
+    np.testing.assert_allclose(score, score_from_cca)
+    np.testing.assert_equal(path, path_from_cca)
+
+    assert not np.isclose(score, dtw_score)
+    np.testing.assert_allclose(
+        tslearn.metrics.ctw(s1, s2, max_iter=5),
+        tslearn.metrics.ctw(s1, s2, max_iter=100),
+    )
+
+    # The counter-example from PR 579 used to cycle with period 2 once
+    # the self-comparison was fixed, because sklearn.CCA leaves the two
+    # views on different scales. After rescaling to unit covariance the
+    # path is stable and the score no longer depends on the parity of
+    # max_iter.
+    x = [[1, 1], [3, 4], [126, 126]]
+    y = [[1, 1.0], [3.0, 3], [4.0, 4], [2.0, 2], [0, 0], [127, 127]]
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        dist_2 = tslearn.metrics.ctw(x, y, max_iter=2)
+        dist_3 = tslearn.metrics.ctw(x, y, max_iter=3)
+    np.testing.assert_allclose(dist_2, dist_3)
 
 
 def test_ldtw():

--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -18,10 +18,11 @@ def test_k_neighbors_timeseries():
         [0, 13, 7, 12, 3]
     )
 
+    # Distinct from DTW now that CTW actually runs CCA (#728).
     model = KNeighborsTimeSeries(metric='ctw')
     np.testing.assert_equal(
         model.fit(X).kneighbors(X, return_distance=False)[0],
-        [0, 13, 7, 12, 3]
+        [0, 6, 12, 7, 2]
     )
 
     model = KNeighborsTimeSeries(metric='softdtw')

--- a/tslearn/metrics/ctw.py
+++ b/tslearn/metrics/ctw.py
@@ -175,9 +175,20 @@ def ctw_path(
         Wx, Wy = _get_warp_matrices(current_path, be=be)
 
         cca.fit(Wx @ s1, Wy @ s2)
+        # CTW constrains each projected warped view to unit covariance
+        # (Zhou & de la Torre, NIPS 2009). sklearn.CCA does not, so rescale
+        # the canonical axes before DTW.
+        warped1, warped2 = cca.transform(Wx @ s1, Wy @ s2)
+        x_std = np.std(warped1, axis=0)
+        y_std = np.std(warped2, axis=0)
+        x_std = np.where(x_std == 0.0, 1.0, x_std)
+        y_std = np.where(y_std == 0.0, 1.0, y_std)
+        cca.x_rotations_ = cca.x_rotations_ / x_std
+        cca.y_rotations_ = cca.y_rotations_ / y_std
         seq1_tr, seq2_tr = cca.transform(s1, s2)
 
-        current_path, score_match = dtw_path(
+        prev_path = current_path
+        current_path, current_score = dtw_path(
             seq1_tr,
             seq2_tr,
             global_constraint=global_constraint,
@@ -186,13 +197,11 @@ def ctw_path(
             be=be,
         )
 
-        if np.array_equal(current_path, current_path):
-            break
-
-        current_score = score_match
-
         if verbose:
             print("Iteration {}, score={}".format(it + 1, current_score))
+
+        if np.array_equal(prev_path, current_path):
+            break
 
     return current_path, cca, current_score
 
@@ -389,12 +398,12 @@ def cdist_ctw(
     Examples
     --------
     >>> cdist_ctw([[1, 2, 2, 3], [1., 2., 3., 4.]])
-    array([[0., 1.],
-           [1., 0.]])
+    array([[0.       , 0.7519551],
+           [0.7519551, 0.       ]])
     >>> cdist_ctw([[1, 2, 2, 3], [1., 2., 3., 4.]],
     ...           [[[1, 1], [2, 2], [3, 3]], [[2, 2], [3, 3], [4, 4], [5, 5]]])
-    array([[0.        , 2.44948974],
-           [1.        , 1.41421356]])
+    array([[0.        , 0.7519551 ],
+           [0.67004592, 0.93933644]])
 
     See Also
     --------


### PR DESCRIPTION
Fixes #728.

## Summary

* `ctw_path` compared the current alignment path with itself, so the loop always stopped after the first DTW. The returned score was the identity-projection DTW; `max_iter` was a no-op; the path and the score disagreed; `verbose` only printed iteration 0.
* The loop now compares against the previous path and always keeps the path and score from the same `dtw_path` call.
* sklearn's CCA does not enforce the paper's unit-covariance constraint on the two views. After each `fit` the canonical axes are rescaled so each warped view has unit standard deviation before DTW. That is also what stops the period-2 path cycle on the series from #579 (the paper's alternation is monotonically decreasing; Zhou's MATLAB code stops on path stability, not cycle detection).

**What I chose, and the alternative.** Path-stability stop plus unit-covariance rescaling of the existing sklearn object. Alternative: typo-only, as in #579, that iterates and fixes the four bullets above, but on PR 579's series the path cycles and `ctw(..., max_iter=2) != ctw(..., max_iter=3)`. Happy to drop the rescaling if you want the smaller diff, or to replace sklearn CCA with the paper's generalized eigenproblem if you want a stricter match.

This comparison has been in `ctw.py` since CTW landed. Callers that treated `metric="ctw"` as DTW (including the k-neighbors unit test) will see different rankings; that is the bugfix.

## Test plan

- [x] `ctw(..., max_iter=1)` still equals DTW; default `ctw` does not, on the issue's rotated 3-D series
- [x] returned path and score match `dtw_path(*cca.transform(s1, s2))`
- [x] `max_iter=5` equals `max_iter=100` on that series (path has stabilized)
- [x] PR 579 series: `max_iter=2` equals `max_iter=3` (no parity-dependent score)
- [x] existing 1-D doctests: linearly related series still have distance 0; imperfect 1-D pair is the canonical-space DTW, not identity DTW
- [x] `KNeighborsTimeSeries(metric="ctw")` neighbor order is no longer identical to DTW
