### PR TITLE
Fix shapelets error with keras nightly 3.16.0.dev2026091104

### DIFF
--- a/tslearn/shapelets/shapelets.py
+++ b/tslearn/shapelets/shapelets.py
@@ -748,12 +748,21 @@ class LearningShapelets(TimeSeriesMixin, ClassifierMixin, TransformerMixin, Base
         self.transformer_model_.compile(loss="mean_squared_error",
                                         optimizer=self.optimizer)
 
-        min_pool_inputs = [self.model_.get_layer("min_pooling_%d" % i).input[0]
+        min_pool_inputs = [self.model_.get_layer("min_pooling_%d" % i).input
                            for i in range(self._n_shapelet_sizes)]
-        pool_layers_locations = [
-            GlobalArgminPooling1D(name="argmin_pooling_%d" % i)(pool_input)
-            for i, pool_input in enumerate(min_pool_inputs)
-        ]
+
+        try:
+            # With Keras 3.16, mask not considered a layer's input
+            pool_layers_locations = [
+                GlobalArgminPooling1D(name="argmin_pooling_%d" % i)(pool_input)
+                for i, pool_input in enumerate(min_pool_inputs)
+            ]
+        except ValueError:
+            # Before Keras 3.16, mask is considered a layer's input, pool_input is a list
+            pool_layers_locations = [
+                GlobalArgminPooling1D(name="argmin_pooling_%d" % i)(pool_input[0])
+                for i, pool_input in enumerate(min_pool_inputs)
+            ]
         if self._n_shapelet_sizes > 1:
             concatenated_locations = concatenate(pool_layers_locations)
         else:


### PR DESCRIPTION
Keras nightly ([see commit](https://github.com/keras-team/keras/commit/b54a80058a9e337a172897ed42432e098e307db3)) now do not include masks in layer's input.

Fixes shapelets tests in [nightly dep build](https://github.com/tslearn-team/tslearn/actions/runs/34574192267/job/103182832080)